### PR TITLE
feat(ui): Column management — US-02

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,6 +1,6 @@
 # COOKBOOK — ToDo List con Web Components
 
-> **Versión:** 0.7.0  
+> **Versión:** 0.8.0  
 > **Última actualización:** 2026-03-25  
 > **Mantenido por:** Agente `documentalista`
 
@@ -19,6 +19,7 @@
    - [Paso 5 — Implementación del Skeleton del Proyecto (US-00 / Issue #1)](#paso-5--implementación-del-skeleton-del-proyecto-us-00--issue-1)
    - [Paso 6 — Apertura del Pull Request #18](#paso-6--apertura-del-pull-request-18)
    - [Paso 7 — Implementación de la Visualización del Tablero Kanban (US-01 / Issue #2)](#paso-7--implementación-de-la-visualización-del-tablero-kanban-us-01--issue-2)
+   - [Paso 8 — Implementación de la Gestión de Columnas del Tablero (US-02 / Issue #3)](#paso-8--implementación-de-la-gestión-de-columnas-del-tablero-us-02--issue-3)
 
 ---
 
@@ -765,3 +766,105 @@ $ npm run build
 `dojo-kanban-board` carga las tareas de **todas** las columnas en el `connectedCallback` para tener disponible el total de tareas por columna y poder mostrar el formato `X / Y` cuando se activa un filtro. Esto es aceptable para el tamaño de datos de un tablero Kanban personal (decenas o cientos de tareas), donde la consulta a IndexedDB es sub-milisegundo. Si el dataset crece, se puede memoizar por columna y recargar solo la columna afectada.
 
 *Este PR fue creado como [PR #19](https://github.com/Code-Dojo-Labs/agent-app/pull/19) y revisado por el agente Reviewer.*
+
+---
+
+### Paso 8 — Implementación de la Gestión de Columnas del Tablero (US-02 / Issue #3)
+
+**Fecha:** 2026-03-25  
+**Agente ejecutor:** `builder`  
+**Issue asociado:** [#3 — US-02 Gestión de columnas del tablero](https://github.com/Code-Dojo-Labs/agent-app/issues/3)  
+**Rama:** `feat/3-gestion-columnas-tablero`  
+**Estado:** ✅ Implementado — pendiente de PR y revisión
+
+#### Descripción
+
+El agente Builder implementó la gestión completa de columnas del tablero Kanban (US-02), añadiendo 3 nuevos Web Components y modificando los 2 componentes existentes del tablero. La solución cubre todos los escenarios Gherkin: crear, renombrar, eliminar (con mover o borrar tareas) y reordenar columnas mediante drag & drop.
+
+#### Criterios de aceptación cubiertos (US-02)
+
+| Escenario Gherkin | Estado |
+|---|---|
+| Crear nueva columna (nombre + icóno + UUID) | ✅ `DojoColumnDialog.openCreate()` → `createColumn()` en IndexedDB |
+| Renombrar columna existente | ✅ `DojoColumnDialog.openRename()` → `updateColumn()` + atributo DOM |
+| Eliminar columna sin tareas | ✅ `DojoColumnDialog.openDelete()` → `deleteColumn()` |
+| Eliminar columna con tareas — mover | ✅ `updateTask({ statusId, order })` en paralelo + `deleteColumn()` |
+| Eliminar columna con tareas — eliminar | ✅ `deleteTask()` en paralelo + `deleteColumn()` |
+| Reordenar columnas mediante arrastre | ✅ DnD nativo `dragstart/dragover/drop` → `updateColumn({ order })` |
+
+#### Componentes creados
+
+| Nivel | Componente | Tag HTML | Archivo |
+|---|---|---|---|
+| Átomo | Column Menu | `<dojo-column-menu>` | `src/components/atoms/dojo-column-menu/dojo-column-menu.ts` |
+| Átomo | Add Column Button | `<dojo-add-column-button>` | `src/components/atoms/dojo-add-column-button/dojo-add-column-button.ts` |
+| Organismo | Column Dialog | `<dojo-column-dialog>` | `src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts` |
+
+#### Componentes modificados
+
+| Componente | Cambios |
+|---|---|
+| `dojo-kanban-column` | Añadido `<dojo-column-menu>` en fila de cabecera; DnD de columna (`dragstart/dragover/drop`) con atributo `[dragging]` y `[drag-column-over]`; eventos `dojo:column-rename`, `dojo:column-delete`, `dojo:column-reorder` |
+| `dojo-kanban-board` | Gestiona el ciclo completo de columnas (crear / renombrar / eliminar / reordenar); mantiene `_columns: Column[]` en memoria; monta un solo `<dojo-column-dialog>` compartido; añade `<dojo-add-column-button>` al final del track |
+
+#### Detalles de implementación
+
+**`dojo-column-menu` (Átomo)**
+- Botón trigger `⋮` con `aria-haspopup="menu"` y `aria-expanded` dinámico
+- Menú flotante con posicionamiento absoluto (`right: 0`)
+- Cierre automático al hacer clic fuera (`document.click`) con limpieza en `disconnectedCallback`
+- Opciones: ✏️ Renombrar y 🗑️ Eliminar (coloreada con `--dojo-danger`)
+- Guarda de idempotencia en `connectedCallback`
+
+**`dojo-add-column-button` (Átomo)**
+- Botón de 200 × 56 px con borde discontinuo `dashed` que se colorea al hover
+- Emite `dojo:add-column` con `bubbles + composed`
+- Guarda de idempotencia en `connectedCallback`
+
+**`dojo-column-dialog` (Organismo)**
+- API pública: `openCreate()`, `openRename(columnId, currentName)`, `openDelete(columnId, columnName, otherColumns[])`
+- Backdrop semitransparente con `role="dialog" aria-modal="true"`
+- Cierre con clic en backdrop o tecla `Escape`
+- Modo *crear*: campo de nombre + grid de 12 íconos preseleccionables (`role="option"` + `aria-pressed`)
+- Modo *renombrar*: campo de nombre prerelleno + focus + select al abrir
+- Modo *eliminar*: alerta `role="alert"` + radiogroup (mover tareas a columna destino | eliminar tareas)
+- Eventos: `dojo:dialog-create-column { name, icon }`, `dojo:dialog-rename-column { columnId, name }`, `dojo:dialog-delete-column { columnId, action, targetColumnId? }`
+- Animación de entrada `dlg-in` (scale + translateY) via `@keyframes`
+
+**Gestión de reorder en `dojo-kanban-board`**
+- Al recibir `dojo:column-reorder { sourceId, targetId }`, reordena `_columns[]` en memoria usando `splice`
+- Persiste con `Promise.all(columns.map((col, idx) => updateColumn(col.id, { order: idx })))`
+- Si la persistencia falla, recarga el tablero desde IndexedDB para garantizar consistencia
+
+**Gestión de eliminación en `dojo-kanban-board`**
+- Acción `move`: `updateTask({ statusId: targetColumnId, order: ... })` en paralelo + `deleteColumn()`
+- Acción `delete`: `deleteTask()` en paralelo + `deleteColumn()`
+- Actualiza `_tasksByColumn` en memoria tras la operación
+
+#### Estructura `src/components/` actualizada
+
+```
+src/components/
+├── atoms/
+│   ├── dojo-column-header/
+│   ├── dojo-column-menu/          # Átomo NEW — menú contextual ⋮
+│   └── dojo-add-column-button/    # Átomo NEW — botón "Añadir columna"
+├── molecules/
+│   └── dojo-kanban-column/        # MOD — menú + DnD columna
+└── organisms/
+    ├── dojo-kanban-board/         # MOD — gestión completa columnas
+    ├── dojo-column-dialog/        # Organismo NEW — modal de gestión
+    └── dojo-app/
+```
+
+#### Resultado del build
+
+```
+$ npm run build
+→ tsc && cp public/index.html dist/index.html
+→ 0 errores TypeScript · build limpio
+```
+
+#### Decisión de diseño: Un solo `<dojo-column-dialog>` por tablero
+
+El `dojo-kanban-board` monta un único `<dojo-column-dialog>` en su shadow DOM y lo reutiliza para los tres modos (crear / renombrar / eliminar). Esto evita inflar el DOM con múltiples dialogs y centraliza la gestión de eventos, simplificando la limpieza de listeners.

--- a/src/components/atoms/dojo-add-column-button/dojo-add-column-button.ts
+++ b/src/components/atoms/dojo-add-column-button/dojo-add-column-button.ts
@@ -1,0 +1,92 @@
+/**
+ * dojo-add-column-button — Átomo
+ *
+ * Botón "Añadir columna" que aparece al final del tablero.
+ *
+ * ## Eventos despachados
+ * | Nombre              | Detalle | Descripción                      |
+ * |---------------------|---------|----------------------------------|
+ * | dojo:add-column     | —       | El usuario solicita agregar col. |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-border, --dojo-text-secondary, --dojo-surface, --dojo-radius,
+ * --dojo-primary, --dojo-text-primary
+ */
+
+export class DojoAddColumnButton extends HTMLElement {
+  static readonly TAG = 'dojo-add-column-button';
+
+  private _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: flex;
+        flex-shrink: 0;
+        align-self: flex-start;
+      }
+
+      .add-btn {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.625rem 1rem;
+        background: var(--dojo-surface);
+        border: 2px dashed var(--dojo-border);
+        border-radius: var(--dojo-radius);
+        cursor: pointer;
+        color: var(--dojo-text-secondary);
+        font-size: 0.875rem;
+        white-space: nowrap;
+        transition: border-color 0.15s, color 0.15s, background 0.15s;
+        width: 200px;
+        min-height: 56px;
+        justify-content: center;
+      }
+      .add-btn:hover,
+      .add-btn:focus-visible {
+        border-color: var(--dojo-primary, #1D4ED8);
+        color: var(--dojo-primary, #1D4ED8);
+        background: var(--dojo-bg);
+        outline: none;
+      }
+      .plus {
+        font-size: 1.25rem;
+        line-height: 1;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    const btn = document.createElement('button');
+    btn.className = 'add-btn';
+    btn.setAttribute('aria-label', 'Añadir nueva columna');
+
+    const plus = document.createElement('span');
+    plus.className = 'plus';
+    plus.setAttribute('aria-hidden', 'true');
+    plus.textContent = '+';
+
+    const label = document.createElement('span');
+    label.textContent = 'Añadir columna';
+
+    btn.appendChild(plus);
+    btn.appendChild(label);
+    btn.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:add-column', { bubbles: true, composed: true }));
+    });
+
+    this._shadow.appendChild(btn);
+  }
+}
+
+customElements.define(DojoAddColumnButton.TAG, DojoAddColumnButton);

--- a/src/components/atoms/dojo-column-menu/dojo-column-menu.ts
+++ b/src/components/atoms/dojo-column-menu/dojo-column-menu.ts
@@ -1,0 +1,194 @@
+/**
+ * dojo-column-menu — Átomo
+ *
+ * Botón ⋮ con menú contextual flotante para acciones de columna.
+ * Admite las acciones "Renombrar" y "Eliminar".
+ *
+ * ## Atributos observados
+ * Ninguno — es un componente puramente interactivo.
+ *
+ * ## Eventos despachados
+ * | Nombre                    | Detalle | Descripción                        |
+ * |---------------------------|---------|------------------------------------|
+ * | dojo:column-rename        | —       | El usuario elige "Renombrar"       |
+ * | dojo:column-delete        | —       | El usuario elige "Eliminar"        |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-surface, --dojo-border, --dojo-text-primary, --dojo-text-secondary,
+ * --dojo-radius, --dojo-shadow, --dojo-danger (fallback: #DC2626)
+ */
+
+export class DojoColumnMenu extends HTMLElement {
+  static readonly TAG = 'dojo-column-menu';
+
+  private _shadow: ShadowRoot;
+  private _open = false;
+  private _onDocClick = (e: MouseEvent): void => {
+    if (!this.contains(e.target as Node)) this._close();
+  };
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('click', this._onDocClick);
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        position: relative;
+        display: inline-flex;
+      }
+
+      .trigger {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        border: none;
+        background: transparent;
+        border-radius: var(--dojo-radius-sm, 4px);
+        cursor: pointer;
+        color: var(--dojo-text-secondary);
+        font-size: 1rem;
+        line-height: 1;
+        padding: 0;
+        transition: background 0.15s;
+      }
+      .trigger:hover,
+      .trigger:focus-visible {
+        background: var(--dojo-border);
+        color: var(--dojo-text-primary);
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 1px;
+      }
+
+      .menu {
+        position: absolute;
+        top: calc(100% + 4px);
+        right: 0;
+        min-width: 140px;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius);
+        box-shadow: var(--dojo-shadow);
+        z-index: 100;
+        overflow: hidden;
+        display: none;
+      }
+      .menu[aria-hidden="false"] { display: block; }
+
+      .menu-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        text-align: left;
+        transition: background 0.1s;
+      }
+      .menu-item:hover,
+      .menu-item:focus-visible {
+        background: var(--dojo-bg);
+        outline: none;
+      }
+      .menu-item.danger { color: var(--dojo-danger, #DC2626); }
+      .menu-item .icon  { font-size: 0.875rem; }
+    `;
+    this._shadow.appendChild(style);
+
+    // Botón trigger ⋮
+    const trigger = document.createElement('button');
+    trigger.className = 'trigger';
+    trigger.setAttribute('aria-label', 'Opciones de columna');
+    trigger.setAttribute('aria-haspopup', 'menu');
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.textContent = '⋮';
+    trigger.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._toggle();
+    });
+    this._shadow.appendChild(trigger);
+
+    // Menú desplegable
+    const menu = document.createElement('div');
+    menu.className = 'menu';
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('aria-hidden', 'true');
+
+    const renameBtn = this._createMenuItem('✏️', 'Renombrar', false, () => {
+      this._close();
+      this.dispatchEvent(new CustomEvent('dojo:column-rename', { bubbles: true, composed: true }));
+    });
+
+    const deleteBtn = this._createMenuItem('🗑️', 'Eliminar', true, () => {
+      this._close();
+      this.dispatchEvent(new CustomEvent('dojo:column-delete', { bubbles: true, composed: true }));
+    });
+
+    menu.appendChild(renameBtn);
+    menu.appendChild(deleteBtn);
+    this._shadow.appendChild(menu);
+  }
+
+  private _createMenuItem(icon: string, label: string, isDanger: boolean, onClick: () => void): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.className = `menu-item${isDanger ? ' danger' : ''}`;
+    btn.setAttribute('role', 'menuitem');
+
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'icon';
+    iconSpan.setAttribute('aria-hidden', 'true');
+    iconSpan.textContent = icon;
+
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = label;
+
+    btn.appendChild(iconSpan);
+    btn.appendChild(labelSpan);
+    btn.addEventListener('click', (e) => { e.stopPropagation(); onClick(); });
+    return btn;
+  }
+
+  // ── Toggle / Open / Close ─────────────────────────────────────────────────
+
+  private _toggle(): void {
+    this._open ? this._close() : this._openMenu();
+  }
+
+  private _openMenu(): void {
+    this._open = true;
+    const trigger = this._shadow.querySelector<HTMLButtonElement>('.trigger');
+    const menu    = this._shadow.querySelector<HTMLElement>('.menu');
+    if (trigger) trigger.setAttribute('aria-expanded', 'true');
+    if (menu)    menu.setAttribute('aria-hidden', 'false');
+    document.addEventListener('click', this._onDocClick);
+  }
+
+  private _close(): void {
+    this._open = false;
+    const trigger = this._shadow.querySelector<HTMLButtonElement>('.trigger');
+    const menu    = this._shadow.querySelector<HTMLElement>('.menu');
+    if (trigger) trigger.setAttribute('aria-expanded', 'false');
+    if (menu)    menu.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('click', this._onDocClick);
+  }
+}
+
+customElements.define(DojoColumnMenu.TAG, DojoColumnMenu);

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -50,13 +50,12 @@ export class DojoKanbanColumn extends HTMLElement {
   }
 
   connectedCallback(): void {
-    // Guarda de idempotencia: evita re-render (y re-registro del listener slotchange)
-    // si el elemento se mueve en el DOM. Los listeners DnD sí se re-registran
-    // porque disconnectedCallback los limpia antes de cada desconexión.
     if (this._shadow.childElementCount === 0) {
       this._render();
     }
     this._attachDragListeners();
+    // I-1: registrar aquí (no en _render) para que funcione también al reconectar
+    this._attachColumnDragListeners();
   }
 
   disconnectedCallback(): void {
@@ -191,7 +190,7 @@ export class DojoKanbanColumn extends HTMLElement {
 
     // Habilitar drag de columna
     this.setAttribute('draggable', 'true');
-    this._attachColumnDragListeners();
+    // (los listeners de DnD de columna se registran en connectedCallback)
 
     // ── Zona de contenido ──────────────────────────────────────────────────
     const content = document.createElement('div');

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -2,8 +2,8 @@
  * dojo-kanban-column — Molécula
  *
  * Columna del tablero Kanban con scroll vertical independiente.
- * Contiene un `<dojo-column-header>` y una zona de contenido (slot)
- * donde se colocarán las tarjetas de tareas (`<dojo-task-card>`).
+ * Contiene un `<dojo-column-header>`, un botón de menú contextual ⋮
+ * y una zona de contenido (slot) donde se colocarán las tarjetas de tareas.
  *
  * ## Atributos observados
  * | Atributo      | Tipo   | Descripción                                         |
@@ -21,15 +21,19 @@
  * (default) | Tarjetas de tarea (`<dojo-task-card>`) proyectadas aquí      |
  *
  * ## Eventos despachados
- * | Nombre            | Detalle                      | Descripción              |
- * |-------------------|------------------------------|--------------------------|
- * | dojo:column-drop  | { columnId, taskId, order }  | Tarea dropeada en columna|
+ * | Nombre               | Detalle                       | Descripción                    |
+ * |----------------------|-------------------------------|--------------------------------|
+ * | dojo:column-drop     | { columnId, taskId }          | Tarea dropeada en la columna   |
+ * | dojo:column-rename   | { columnId }                  | Usuario eligió "Renombrar"     |
+ * | dojo:column-delete   | { columnId }                  | Usuario eligió "Eliminar"      |
+ * | dojo:column-reorder  | { sourceId, targetId }        | Columna arrastrada a posición  |
  *
  * ## CSS Custom Properties heredadas
  * --dojo-surface, --dojo-border, --dojo-radius, --dojo-bg, --dojo-shadow
  */
 
 import '../../atoms/dojo-column-header/dojo-column-header.js';
+import '../../atoms/dojo-column-menu/dojo-column-menu.js';
 
 export class DojoKanbanColumn extends HTMLElement {
   static readonly TAG = 'dojo-kanban-column';
@@ -90,6 +94,31 @@ export class DojoKanbanColumn extends HTMLElement {
         border-radius: var(--dojo-radius);
         box-shadow: var(--dojo-shadow);
         overflow: hidden;
+        /* Permite que el usuario arrastre la columna */
+        cursor: grab;
+      }
+      :host([dragging]) {
+        opacity: 0.5;
+        cursor: grabbing;
+      }
+      :host([drag-column-over]) {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Fila superior: header + menú */
+      .col-header-row {
+        display: flex;
+        align-items: stretch;
+      }
+      .col-header-row dojo-column-header {
+        flex: 1;
+        min-width: 0;
+      }
+      .col-header-row dojo-column-menu {
+        padding-right: 0.5rem;
+        display: flex;
+        align-items: center;
       }
 
       /* Zona de contenido con scroll vertical independiente */
@@ -132,14 +161,37 @@ export class DojoKanbanColumn extends HTMLElement {
     `;
     this._shadow.appendChild(style);
 
-    // ── Header ─────────────────────────────────────────────────────────────
+    // ── Fila: Header + Menú ────────────────────────────────────────────────
+    const headerRow = document.createElement('div');
+    headerRow.className = 'col-header-row';
+
     const header = document.createElement('dojo-column-header') as HTMLElement;
     header.setAttribute('icon', this._icon);
     header.setAttribute('column-name', this._name);
     header.setAttribute('count', this._count);
     header.setAttribute('total-count', this._totalCount);
     if (this._accentColor) header.setAttribute('accent-color', this._accentColor);
-    this._shadow.appendChild(header);
+    headerRow.appendChild(header);
+
+    const menu = document.createElement('dojo-column-menu');
+    menu.addEventListener('dojo:column-rename', () => {
+      this.dispatchEvent(new CustomEvent('dojo:column-rename', {
+        bubbles: true, composed: true,
+        detail: { columnId: this.columnId },
+      }));
+    });
+    menu.addEventListener('dojo:column-delete', () => {
+      this.dispatchEvent(new CustomEvent('dojo:column-delete', {
+        bubbles: true, composed: true,
+        detail: { columnId: this.columnId },
+      }));
+    });
+    headerRow.appendChild(menu);
+    this._shadow.appendChild(headerRow);
+
+    // Habilitar drag de columna
+    this.setAttribute('draggable', 'true');
+    this._attachColumnDragListeners();
 
     // ── Zona de contenido ──────────────────────────────────────────────────
     const content = document.createElement('div');
@@ -177,6 +229,55 @@ export class DojoKanbanColumn extends HTMLElement {
     header.setAttribute('total-count', this._totalCount);
     if (this._accentColor) header.setAttribute('accent-color', this._accentColor);
     else header.removeAttribute('accent-color');
+  }
+
+  // ── Drag & Drop de columnas (reorder) ────────────────────────────────────
+
+  private _onColumnDragStart = (e: DragEvent): void => {
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/dojo-column-id', this.columnId);
+    }
+    this.setAttribute('dragging', '');
+  };
+
+  private _onColumnDragEnd = (): void => {
+    this.removeAttribute('dragging');
+    this.removeAttribute('drag-column-over');
+  };
+
+  private _onColumnDragOver = (e: DragEvent): void => {
+    // Solo reaccionar si hay una columna siendo arrastrada (no una tarea)
+    if (e.dataTransfer?.types.includes('text/dojo-column-id')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      this.setAttribute('drag-column-over', '');
+    }
+  };
+
+  private _onColumnDragLeave = (e: DragEvent): void => {
+    if (!this.contains(e.relatedTarget as Node)) {
+      this.removeAttribute('drag-column-over');
+    }
+  };
+
+  private _onColumnDrop = (e: DragEvent): void => {
+    e.preventDefault();
+    this.removeAttribute('drag-column-over');
+    const sourceId = e.dataTransfer?.getData('text/dojo-column-id');
+    if (!sourceId || sourceId === this.columnId) return;
+    this.dispatchEvent(new CustomEvent('dojo:column-reorder', {
+      bubbles: true, composed: true,
+      detail: { sourceId, targetId: this.columnId },
+    }));
+  };
+
+  private _attachColumnDragListeners(): void {
+    this.addEventListener('dragstart',  this._onColumnDragStart);
+    this.addEventListener('dragend',    this._onColumnDragEnd);
+    this.addEventListener('dragover',   this._onColumnDragOver);
+    this.addEventListener('dragleave',  this._onColumnDragLeave);
+    this.addEventListener('drop',       this._onColumnDrop);
   }
 
   // ── Drag & Drop (drop target) ─────────────────────────────────────────────
@@ -218,9 +319,15 @@ export class DojoKanbanColumn extends HTMLElement {
   }
 
   private _detachDragListeners(): void {
-    this.removeEventListener('dragover',  this._onDragOver);
-    this.removeEventListener('dragleave', this._onDragLeave);
-    this.removeEventListener('drop',      this._onDrop);
+    this.removeEventListener('dragover',   this._onDragOver);
+    this.removeEventListener('dragleave',  this._onDragLeave);
+    this.removeEventListener('drop',       this._onDrop);
+    // También limpiar los listeners de drag de columna
+    this.removeEventListener('dragstart',  this._onColumnDragStart);
+    this.removeEventListener('dragend',    this._onColumnDragEnd);
+    this.removeEventListener('dragover',   this._onColumnDragOver);
+    this.removeEventListener('dragleave',  this._onColumnDragLeave);
+    this.removeEventListener('drop',       this._onColumnDrop);
   }
 }
 

--- a/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
+++ b/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
@@ -1,0 +1,539 @@
+/**
+ * dojo-column-dialog — Organismo
+ *
+ * Diálogo modal para gestión de columnas: crear, renombrar y eliminar.
+ *
+ * ## Modos
+ * | Modo     | Descripción                                             |
+ * |----------|---------------------------------------------------------|
+ * | create   | Formulario para nombre + ícono de nueva columna        |
+ * | rename   | Formulario para cambiar el nombre de una columna       |
+ * | delete   | Confirmación: mover tareas a otra columna o eliminarlas|
+ *
+ * ## API Pública
+ * | Método                                              | Descripción              |
+ * |-----------------------------------------------------|--------------------------|
+ * | openCreate()                                        | Abre en modo "crear"     |
+ * | openRename(columnId, currentName)                   | Abre en modo "renombrar" |
+ * | openDelete(columnId, columnName, otherColumns)      | Abre en modo "eliminar"  |
+ *
+ * ## Eventos despachados
+ * | Nombre                     | Detalle                                     |
+ * |----------------------------|---------------------------------------------|
+ * | dojo:dialog-create-column  | { name, icon }                              |
+ * | dojo:dialog-rename-column  | { columnId, name }                          |
+ * | dojo:dialog-delete-column  | { columnId, action: 'move'|'delete', targetColumnId? } |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*, --dojo-primary,
+ * --dojo-danger, --dojo-radius, --dojo-shadow
+ */
+
+import type { Column } from '../../../types/models.js';
+
+// Íconos predefinidos seleccionables al crear una columna
+const PRESET_ICONS = ['📋', '🔲', '🔄', '🔍', '✅', '🚫', '⭐', '🎯', '🔥', '💡', '🛠️', '📌'];
+
+type DialogMode = 'create' | 'rename' | 'delete';
+
+export class DojoColumnDialog extends HTMLElement {
+  static readonly TAG = 'dojo-column-dialog';
+
+  private _shadow: ShadowRoot;
+  private _mode: DialogMode = 'create';
+  private _columnId = '';
+  private _currentName = '';
+  private _otherColumns: Column[] = [];
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  // ── API pública ───────────────────────────────────────────────────────────
+
+  openCreate(): void {
+    this._mode = 'create';
+    this._columnId = '';
+    this._currentName = '';
+    this._otherColumns = [];
+    this._buildContent();
+    this._open();
+  }
+
+  openRename(columnId: string, currentName: string): void {
+    this._mode = 'rename';
+    this._columnId = columnId;
+    this._currentName = currentName;
+    this._otherColumns = [];
+    this._buildContent();
+    this._open();
+  }
+
+  openDelete(columnId: string, columnName: string, otherColumns: Column[]): void {
+    this._mode = 'delete';
+    this._columnId = columnId;
+    this._currentName = columnName;
+    this._otherColumns = otherColumns;
+    this._buildContent();
+    this._open();
+  }
+
+  // ── Render base (solo backdrop + contenedor) ──────────────────────────────
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: contents;
+      }
+
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.45);
+        z-index: 200;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+      }
+      .backdrop[aria-hidden="false"] { display: flex; }
+
+      .dialog {
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius);
+        box-shadow: var(--dojo-shadow);
+        width: 100%;
+        max-width: 420px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        animation: dlg-in 0.18s ease;
+      }
+      @keyframes dlg-in {
+        from { opacity: 0; transform: scale(0.96) translateY(-8px); }
+        to   { opacity: 1; transform: none; }
+      }
+
+      .dialog-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0;
+      }
+
+      /* Formulario */
+      .field { display: flex; flex-direction: column; gap: 0.375rem; }
+      .field label {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--dojo-text-secondary);
+      }
+      .field input,
+      .field select {
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.9375rem;
+        color: var(--dojo-text-primary);
+        background: var(--dojo-bg);
+        width: 100%;
+        box-sizing: border-box;
+        transition: border-color 0.15s;
+      }
+      .field input:focus,
+      .field select:focus {
+        outline: none;
+        border-color: var(--dojo-primary, #1D4ED8);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--dojo-primary, #1D4ED8) 20%, transparent);
+      }
+
+      /* Íconos */
+      .icon-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.375rem;
+      }
+      .icon-opt {
+        width: 36px;
+        height: 36px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.125rem;
+        border: 2px solid transparent;
+        border-radius: var(--dojo-radius-sm, 4px);
+        cursor: pointer;
+        background: var(--dojo-bg);
+        transition: border-color 0.1s;
+      }
+      .icon-opt:hover { border-color: var(--dojo-border); }
+      .icon-opt[aria-pressed="true"] {
+        border-color: var(--dojo-primary, #1D4ED8);
+        background: color-mix(in srgb, var(--dojo-primary, #1D4ED8) 10%, transparent);
+      }
+
+      /* Delete options */
+      .delete-warning {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+        padding: 0.75rem;
+        background: color-mix(in srgb, var(--dojo-danger, #DC2626) 8%, transparent);
+        border: 1px solid color-mix(in srgb, var(--dojo-danger, #DC2626) 30%, transparent);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-danger, #DC2626);
+      }
+
+      .radio-group { display: flex; flex-direction: column; gap: 0.625rem; }
+      .radio-option {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        cursor: pointer;
+      }
+      .radio-option input { cursor: pointer; }
+
+      /* Botones */
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.625rem;
+        margin-top: 0.25rem;
+      }
+      .btn {
+        padding: 0.4375rem 1rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: opacity 0.15s;
+      }
+      .btn:hover { opacity: 0.85; }
+      .btn:focus-visible { outline: 2px solid var(--dojo-primary, #1D4ED8); outline-offset: 2px; }
+      .btn-cancel {
+        background: transparent;
+        border-color: var(--dojo-border);
+        color: var(--dojo-text-secondary);
+      }
+      .btn-primary {
+        background: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+      }
+      .btn-danger {
+        background: var(--dojo-danger, #DC2626);
+        color: #fff;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Backdrop contenedor
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('role', 'dialog');
+    backdrop.setAttribute('aria-modal', 'true');
+    backdrop.setAttribute('aria-hidden', 'true');
+
+    // Cerrar al hacer clic en el backdrop (fuera del dialog)
+    backdrop.addEventListener('click', (e) => {
+      if (e.target === backdrop) this._close();
+    });
+
+    // Cerrar con Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this._isOpen()) this._close();
+    });
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+    backdrop.appendChild(dialog);
+    this._shadow.appendChild(backdrop);
+  }
+
+  // ── Construye el contenido según el modo ────────────────────────────────
+
+  private _buildContent(): void {
+    const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+    if (!dialog) return;
+    dialog.innerHTML = '';
+
+    if (this._mode === 'create')  this._buildCreateForm(dialog);
+    if (this._mode === 'rename')  this._buildRenameForm(dialog);
+    if (this._mode === 'delete')  this._buildDeleteConfirm(dialog);
+  }
+
+  // ── Formulario: Crear columna ─────────────────────────────────────────────
+
+  private _buildCreateForm(container: HTMLElement): void {
+    const title = document.createElement('h2');
+    title.className = 'dialog-title';
+    title.textContent = 'Nueva columna';
+    container.appendChild(title);
+
+    // Campo nombre
+    const nameField = document.createElement('div');
+    nameField.className = 'field';
+    const nameLbl = document.createElement('label');
+    nameLbl.textContent = 'Nombre';
+    nameLbl.setAttribute('for', 'col-name-input');
+    const nameInput = document.createElement('input');
+    nameInput.id = 'col-name-input';
+    nameInput.type = 'text';
+    nameInput.placeholder = 'Ej. En cola';
+    nameInput.maxLength = 50;
+    nameInput.setAttribute('aria-required', 'true');
+    nameField.appendChild(nameLbl);
+    nameField.appendChild(nameInput);
+    container.appendChild(nameField);
+
+    // Campo ícono
+    let selectedIcon = PRESET_ICONS[0];
+    const iconField = document.createElement('div');
+    iconField.className = 'field';
+    const iconLbl = document.createElement('label');
+    iconLbl.textContent = 'Ícono';
+    iconField.appendChild(iconLbl);
+
+    const iconGrid = document.createElement('div');
+    iconGrid.className = 'icon-grid';
+    iconGrid.setAttribute('role', 'listbox');
+    iconGrid.setAttribute('aria-label', 'Seleccionar ícono');
+
+    PRESET_ICONS.forEach((icon, idx) => {
+      const opt = document.createElement('button');
+      opt.className = 'icon-opt';
+      opt.textContent = icon;
+      opt.setAttribute('role', 'option');
+      opt.setAttribute('aria-pressed', idx === 0 ? 'true' : 'false');
+      opt.setAttribute('aria-label', `Ícono ${icon}`);
+      opt.addEventListener('click', () => {
+        selectedIcon = icon;
+        iconGrid.querySelectorAll('.icon-opt').forEach(o => o.setAttribute('aria-pressed', 'false'));
+        opt.setAttribute('aria-pressed', 'true');
+      });
+      iconGrid.appendChild(opt);
+    });
+    iconField.appendChild(iconGrid);
+    container.appendChild(iconField);
+
+    // Acciones
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-cancel';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._close());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-primary';
+    confirmBtn.textContent = 'Crear columna';
+    confirmBtn.addEventListener('click', () => {
+      const name = nameInput.value.trim();
+      if (!name) { nameInput.focus(); return; }
+      this.dispatchEvent(new CustomEvent('dojo:dialog-create-column', {
+        bubbles: true, composed: true,
+        detail: { name, icon: selectedIcon },
+      }));
+      this._close();
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    container.appendChild(actions);
+
+    // Focus trap: foco inicial en el input
+    setTimeout(() => nameInput.focus(), 50);
+  }
+
+  // ── Formulario: Renombrar columna ────────────────────────────────────────
+
+  private _buildRenameForm(container: HTMLElement): void {
+    const title = document.createElement('h2');
+    title.className = 'dialog-title';
+    title.textContent = 'Renombrar columna';
+    container.appendChild(title);
+
+    const nameField = document.createElement('div');
+    nameField.className = 'field';
+    const nameLbl = document.createElement('label');
+    nameLbl.textContent = 'Nuevo nombre';
+    nameLbl.setAttribute('for', 'col-rename-input');
+    const nameInput = document.createElement('input');
+    nameInput.id = 'col-rename-input';
+    nameInput.type = 'text';
+    nameInput.value = this._currentName;
+    nameInput.maxLength = 50;
+    nameInput.setAttribute('aria-required', 'true');
+    nameField.appendChild(nameLbl);
+    nameField.appendChild(nameInput);
+    container.appendChild(nameField);
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-cancel';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._close());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-primary';
+    confirmBtn.textContent = 'Guardar';
+    confirmBtn.addEventListener('click', () => {
+      const name = nameInput.value.trim();
+      if (!name) { nameInput.focus(); return; }
+      this.dispatchEvent(new CustomEvent('dojo:dialog-rename-column', {
+        bubbles: true, composed: true,
+        detail: { columnId: this._columnId, name },
+      }));
+      this._close();
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    container.appendChild(actions);
+
+    setTimeout(() => { nameInput.focus(); nameInput.select(); }, 50);
+  }
+
+  // ── Confirmación: Eliminar columna ───────────────────────────────────────
+
+  private _buildDeleteConfirm(container: HTMLElement): void {
+    const title = document.createElement('h2');
+    title.className = 'dialog-title';
+    title.textContent = 'Eliminar columna';
+    container.appendChild(title);
+
+    const warning = document.createElement('div');
+    warning.className = 'delete-warning';
+    warning.setAttribute('role', 'alert');
+    warning.textContent = `¿Seguro que quieres eliminar "${this._currentName}"?`;
+    container.appendChild(warning);
+
+    let actionChoice: 'delete' | 'move' = 'delete';
+    let targetColumnId = this._otherColumns[0]?.id ?? '';
+
+    const radioGroup = document.createElement('div');
+    radioGroup.className = 'radio-group';
+
+    if (this._otherColumns.length > 0) {
+      // Opción: Mover tareas
+      const moveLabel = document.createElement('label');
+      moveLabel.className = 'radio-option';
+      const moveRadio = document.createElement('input');
+      moveRadio.type = 'radio';
+      moveRadio.name = 'delete-action';
+      moveRadio.value = 'move';
+      moveLabel.appendChild(moveRadio);
+      moveLabel.appendChild(document.createTextNode('Mover tareas a:'));
+      radioGroup.appendChild(moveLabel);
+
+      // Select de columna destino
+      const targetField = document.createElement('div');
+      targetField.className = 'field';
+      const targetSelect = document.createElement('select');
+      targetSelect.setAttribute('aria-label', 'Columna destino');
+      this._otherColumns.forEach(col => {
+        const opt = document.createElement('option');
+        opt.value = col.id;
+        opt.textContent = `${col.icon} ${col.name}`;
+        targetSelect.appendChild(opt);
+      });
+      targetSelect.addEventListener('change', () => { targetColumnId = targetSelect.value; });
+      targetField.appendChild(targetSelect);
+      radioGroup.appendChild(targetField);
+
+      moveRadio.addEventListener('change', () => {
+        if (moveRadio.checked) { actionChoice = 'move'; targetColumnId = targetSelect.value; }
+      });
+
+      // Opción: Eliminar tareas
+      const delLabel = document.createElement('label');
+      delLabel.className = 'radio-option';
+      const delRadio = document.createElement('input');
+      delRadio.type = 'radio';
+      delRadio.name = 'delete-action';
+      delRadio.value = 'delete';
+      delRadio.checked = true;
+      actionChoice = 'delete';
+      delLabel.appendChild(delRadio);
+      delLabel.appendChild(document.createTextNode('Eliminar todas las tareas'));
+      radioGroup.appendChild(delLabel);
+
+      delRadio.addEventListener('change', () => {
+        if (delRadio.checked) actionChoice = 'delete';
+      });
+    } else {
+      const p = document.createElement('p');
+      p.style.cssText = 'font-size:0.875rem;color:var(--dojo-text-secondary);margin:0;';
+      p.textContent = 'La columna no tiene tareas.';
+      radioGroup.appendChild(p);
+    }
+    container.appendChild(radioGroup);
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-cancel';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._close());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-danger';
+    confirmBtn.textContent = 'Eliminar';
+    confirmBtn.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:dialog-delete-column', {
+        bubbles: true, composed: true,
+        detail: {
+          columnId: this._columnId,
+          action: actionChoice,
+          targetColumnId: actionChoice === 'move' ? targetColumnId : undefined,
+        },
+      }));
+      this._close();
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    container.appendChild(actions);
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private _open(): void {
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    if (backdrop) {
+      backdrop.setAttribute('aria-hidden', 'false');
+      backdrop.setAttribute('aria-label',
+        this._mode === 'create'  ? 'Crear columna' :
+        this._mode === 'rename'  ? 'Renombrar columna' :
+                                   'Eliminar columna'
+      );
+    }
+  }
+
+  private _close(): void {
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    if (backdrop) backdrop.setAttribute('aria-hidden', 'true');
+  }
+
+  private _isOpen(): boolean {
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    return backdrop?.getAttribute('aria-hidden') === 'false';
+  }
+}
+
+customElements.define(DojoColumnDialog.TAG, DojoColumnDialog);

--- a/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
+++ b/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
@@ -45,6 +45,11 @@ export class DojoColumnDialog extends HTMLElement {
   private _currentName = '';
   private _otherColumns: Column[] = [];
 
+  // B-1: referencia estable para poder añadir y quitar el listener
+  private _onDocKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this._isOpen()) this._close();
+  };
+
   constructor() {
     super();
     this._shadow = this.attachShadow({ mode: 'open' });
@@ -52,6 +57,11 @@ export class DojoColumnDialog extends HTMLElement {
 
   connectedCallback(): void {
     if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  disconnectedCallback(): void {
+    // B-1: garantizar limpieza aunque el dialog se desconecte mientras está abierto
+    document.removeEventListener('keydown', this._onDocKeydown);
   }
 
   // ── API pública ───────────────────────────────────────────────────────────
@@ -250,11 +260,6 @@ export class DojoColumnDialog extends HTMLElement {
       if (e.target === backdrop) this._close();
     });
 
-    // Cerrar con Escape
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && this._isOpen()) this._close();
-    });
-
     const dialog = document.createElement('div');
     dialog.className = 'dialog';
     backdrop.appendChild(dialog);
@@ -427,6 +432,9 @@ export class DojoColumnDialog extends HTMLElement {
 
     const radioGroup = document.createElement('div');
     radioGroup.className = 'radio-group';
+    // I-2: semántica ARIA para lectores de pantalla
+    radioGroup.setAttribute('role', 'radiogroup');
+    radioGroup.setAttribute('aria-label', 'Qué hacer con las tareas');
 
     if (this._otherColumns.length > 0) {
       // Opción: Mover tareas
@@ -451,7 +459,12 @@ export class DojoColumnDialog extends HTMLElement {
         opt.textContent = `${col.icon} ${col.name}`;
         targetSelect.appendChild(opt);
       });
-      targetSelect.addEventListener('change', () => { targetColumnId = targetSelect.value; });
+      // B-2: seleccionar una columna destino activa automáticamente la opción "mover"
+      targetSelect.addEventListener('change', () => {
+        targetColumnId = targetSelect.value;
+        moveRadio.checked = true;
+        actionChoice = 'move';
+      });
       targetField.appendChild(targetSelect);
       radioGroup.appendChild(targetField);
 
@@ -523,11 +536,15 @@ export class DojoColumnDialog extends HTMLElement {
                                    'Eliminar columna'
       );
     }
+    // B-1: registrar listener de Escape solo mientras el dialog está abierto
+    document.addEventListener('keydown', this._onDocKeydown);
   }
 
   private _close(): void {
     const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
     if (backdrop) backdrop.setAttribute('aria-hidden', 'true');
+    // B-1: limpiar listener al cerrar
+    document.removeEventListener('keydown', this._onDocKeydown);
   }
 
   private _isOpen(): boolean {

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -29,9 +29,11 @@
  */
 
 import type { Column, Task } from '../../../types/models.js';
-import { getAllColumns } from '../../../db/column.repository.js';
-import { getTasksByStatus } from '../../../db/task.repository.js';
+import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
+import { getTasksByStatus, updateTask, deleteTask } from '../../../db/task.repository.js';
 import '../../molecules/dojo-kanban-column/dojo-kanban-column.js';
+import '../../atoms/dojo-add-column-button/dojo-add-column-button.js';
+import '../../organisms/dojo-column-dialog/dojo-column-dialog.js';
 
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
@@ -49,6 +51,8 @@ export class DojoKanbanBoard extends HTMLElement {
   private _activeFilter: ActiveFilter = {};
   /** columnId → lista de todas las tareas de esa columna (sin filtrar) */
   private _tasksByColumn: Map<string, Task[]> = new Map();
+  /** Lista ordenada de columnas actualmente cargadas */
+  private _columns: Column[] = [];
 
   constructor() {
     super();
@@ -165,6 +169,17 @@ export class DojoKanbanBoard extends HTMLElement {
 
     // Área principal — empieza en estado loading
     this._showLoading();
+
+    // Diálogo de gestión de columnas (montado una sola vez)
+    const dialog = document.createElement('dojo-column-dialog');
+    this._shadow.appendChild(dialog);
+    this._shadow.addEventListener('dojo:dialog-create-column', (e) => this._handleCreate(e as CustomEvent));
+    this._shadow.addEventListener('dojo:dialog-rename-column', (e) => this._handleRename(e as CustomEvent));
+    this._shadow.addEventListener('dojo:dialog-delete-column', (e) => this._handleDelete(e as CustomEvent));
+    this._shadow.addEventListener('dojo:column-rename',        (e) => this._onColumnRenameRequest(e as CustomEvent));
+    this._shadow.addEventListener('dojo:column-delete',        (e) => this._onColumnDeleteRequest(e as CustomEvent));
+    this._shadow.addEventListener('dojo:column-reorder',       (e) => this._handleReorder(e as CustomEvent));
+    this._shadow.addEventListener('dojo:add-column',           () => this._onAddColumnRequest());
   }
 
   // ── Estados visuales ─────────────────────────────────────────────────────
@@ -248,6 +263,7 @@ export class DojoKanbanBoard extends HTMLElement {
         this._tasksByColumn.set(col.id, taskResults[i]);
       });
 
+      this._columns = columns;
       this._renderColumns(columns);
       this.removeAttribute('aria-busy');
 
@@ -283,6 +299,10 @@ export class DojoKanbanBoard extends HTMLElement {
       track.appendChild(colEl);
     }
 
+    // Botón "Añadir columna" al final del track
+    const addBtn = document.createElement('dojo-add-column-button');
+    track.appendChild(addBtn);
+
     this._setMainContent(track);
   }
 
@@ -317,6 +337,122 @@ export class DojoKanbanBoard extends HTMLElement {
       col.setAttribute('count', String(visible));
       col.setAttribute('total-count', String(total));
     });
+  }
+
+  // ── Handlers de gestión de columnas ────────────────────────────────────────
+
+  private _getDialog(): HTMLElement | null {
+    return this._shadow.querySelector('dojo-column-dialog');
+  }
+
+  private _onAddColumnRequest(): void {
+    const dialog = this._getDialog() as any;
+    if (dialog?.openCreate) dialog.openCreate();
+  }
+
+  private _onColumnRenameRequest(e: CustomEvent): void {
+    const { columnId } = e.detail as { columnId: string };
+    const col = this._columns.find(c => c.id === columnId);
+    if (!col) return;
+    const dialog = this._getDialog() as any;
+    if (dialog?.openRename) dialog.openRename(col.id, col.name);
+  }
+
+  private _onColumnDeleteRequest(e: CustomEvent): void {
+    const { columnId } = e.detail as { columnId: string };
+    const col = this._columns.find(c => c.id === columnId);
+    if (!col) return;
+    const otherColumns = this._columns.filter(c => c.id !== columnId);
+    const dialog = this._getDialog() as any;
+    if (dialog?.openDelete) dialog.openDelete(col.id, col.name, otherColumns);
+  }
+
+  private async _handleCreate(e: CustomEvent): Promise<void> {
+    const { name, icon } = e.detail as { name: string; icon: string };
+    const nextOrder = this._columns.length > 0
+      ? Math.max(...this._columns.map(c => c.order)) + 1
+      : 0;
+    try {
+      const newCol = await createColumn({ name, icon, order: nextOrder });
+      this._columns.push(newCol);
+      this._tasksByColumn.set(newCol.id, []);
+      this._renderColumns(this._columns);
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al crear columna:', err);
+    }
+  }
+
+  private async _handleRename(e: CustomEvent): Promise<void> {
+    const { columnId, name } = e.detail as { columnId: string; name: string };
+    try {
+      const updated = await updateColumn(columnId, { name });
+      const idx = this._columns.findIndex(c => c.id === columnId);
+      if (idx !== -1) this._columns[idx] = updated;
+      // Actualizar solo el atributo del elemento del DOM
+      const colEl = this._shadow.querySelector(`dojo-kanban-column[column-id="${columnId}"]`);
+      if (colEl) colEl.setAttribute('column-name', name);
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al renombrar columna:', err);
+    }
+  }
+
+  private async _handleDelete(e: CustomEvent): Promise<void> {
+    const { columnId, action, targetColumnId } = e.detail as {
+      columnId: string;
+      action: 'move' | 'delete';
+      targetColumnId?: string;
+    };
+    try {
+      const tasks = this._tasksByColumn.get(columnId) ?? [];
+
+      if (action === 'move' && targetColumnId) {
+        // Mover todas las tareas a la columna destino
+        const targetTasks = this._tasksByColumn.get(targetColumnId) ?? [];
+        const startOrder  = targetTasks.length;
+        await Promise.all(
+          tasks.map((t, i) => updateTask(t.id, { statusId: targetColumnId, order: startOrder + i }))
+        );
+        // Actualizar cache
+        this._tasksByColumn.set(targetColumnId, [
+          ...targetTasks,
+          ...tasks.map((t, i) => ({ ...t, statusId: targetColumnId, order: startOrder + i })),
+        ]);
+      } else {
+        // Eliminar todas las tareas de la columna
+        await Promise.all(tasks.map(t => deleteTask(t.id)));
+      }
+
+      await deleteColumn(columnId);
+      this._columns = this._columns.filter(c => c.id !== columnId);
+      this._tasksByColumn.delete(columnId);
+      this._renderColumns(this._columns);
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al eliminar columna:', err);
+    }
+  }
+
+  private async _handleReorder(e: CustomEvent): Promise<void> {
+    const { sourceId, targetId } = e.detail as { sourceId: string; targetId: string };
+    const srcIdx = this._columns.findIndex(c => c.id === sourceId);
+    const tgtIdx = this._columns.findIndex(c => c.id === targetId);
+    if (srcIdx === -1 || tgtIdx === -1) return;
+
+    // Reordenar en memoria
+    const moved = this._columns.splice(srcIdx, 1)[0];
+    this._columns.splice(tgtIdx, 0, moved);
+
+    // Persistir nuevos values de `order`
+    try {
+      await Promise.all(
+        this._columns.map((col, idx) => updateColumn(col.id, { order: idx }))
+      );
+      this._columns = this._columns.map((col, idx) => ({ ...col, order: idx }));
+      this._renderColumns(this._columns);
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al reordenar columnas:', err);
+      // Recargar desde IndexedDB para mantener consistencia
+      await this._loadBoard();
+    }
   }
 }
 


### PR DESCRIPTION
## Descripción

Implementa la gestión completa de columnas del tablero Kanban (US-02), cubriendo los 6 escenarios Gherkin definidos en el issue.

Closes #3

---

## Cambios

### Nuevos componentes

| Componente | Tipo | Propósito |
|---|---|---|
| `dojo-column-menu` | Atom | Menú contextual ⋮ con acciones Renombrar / Eliminar |
| `dojo-add-column-button` | Atom | Botón "Añadir columna" al final del track del tablero |
| `dojo-column-dialog` | Organism | Modal CRUD para crear, renombrar y eliminar columnas |

### Componentes modificados

| Componente | Tipo | Cambios |
|---|---|---|
| `dojo-kanban-column` | Molecule | Integración de `dojo-column-menu` + DnD de columnas |
| `dojo-kanban-board` | Organism | Manejo completo de eventos CRUD + estado `_columns[]` |

### Documentación

- `COOKBOOK.md` actualizado a `v0.8.0` con el **Paso 8 — Gestión de columnas**

---

## Funcionalidades implementadas

- **Crear columna**: botón `+` → dialog con nombre + 12 iconos preset → `createColumn()`
- **Renombrar columna**: menú ⋮ → dialog prefilled → `updateColumn()`
- **Eliminar columna con mover tareas**: dialog con radiogroup → `updateTask()` paralelo + `deleteColumn()`
- **Eliminar columna con borrar tareas**: dialog → `deleteTask()` paralelo + `deleteColumn()`
- **Reordenar columnas (DnD)**: drag nativo HTML5 con DataTransfer tipo `text/dojo-column-id` → `updateColumn({ order })` paralelo

---

## Notas técnicas

- El tipo DataTransfer `text/dojo-column-id` distingue el DnD de columnas del DnD de tareas (`text/plain`), evitando conflictos.
- El dialog registra un listener de `keydown` (Escape) en `document` que se limpia al cerrar y en `disconnectedCallback`.
- `_handleReorder` aplica el reorden en memoria primero (UX optimista) y hace fallback a `_loadBoard()` si la persistencia falla.
- `npm run build` → **0 errores** ✅
