### PR TITLE
feat(drag-and-drop): [US-03] Drag & Drop nativo de tareas entre columnas

### DIFF
--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -1,0 +1,236 @@
+/**
+ * dojo-task-card — Átomo
+ *
+ * Tarjeta arrastrable que representa una tarea en el tablero Kanban.
+ * Implementa la API nativa HTML5 Drag & Drop requerida por US-03.
+ *
+ * ## Atributos observados
+ * | Atributo       | Tipo   | Descripción                             |
+ * |----------------|--------|-----------------------------------------|
+ * | task-id        | string | UUID de la tarea en IndexedDB           |
+ * | task-title     | string | Título visible (máx. 120 chars)         |
+ * | task-priority  | string | low | medium | high | urgent             |
+ *
+ * ## Eventos despachados
+ * | Nombre          | Detalle          | Descripción                      |
+ * |-----------------|------------------|----------------------------------|
+ * | dojo:task-open  | { taskId }       | Usuario hizo clic en la tarjeta  |
+ *
+ * ## CSS Custom Properties
+ * --dojo-surface, --dojo-border, --dojo-radius, --dojo-text-*,
+ * --dojo-primary, --dojo-shadow,
+ * --dojo-priority-low, --dojo-priority-medium,
+ * --dojo-priority-high, --dojo-priority-urgent
+ */
+
+export class DojoTaskCard extends HTMLElement {
+  static readonly TAG = 'dojo-task-card';
+
+  static get observedAttributes(): string[] {
+    return ['task-id', 'task-title', 'task-priority'];
+  }
+
+  private _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) {
+      this._render();
+    }
+    this.setAttribute('draggable', 'true');
+    this.setAttribute('role', 'listitem');
+    this.addEventListener('dragstart', this._onDragStart);
+    this.addEventListener('dragend',   this._onDragEnd);
+    this.addEventListener('click',     this._onClick);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener('dragstart', this._onDragStart);
+    this.removeEventListener('dragend',   this._onDragEnd);
+    this.removeEventListener('click',     this._onClick);
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._render();
+  }
+
+  // ── Getters ──────────────────────────────────────────────────────────────
+
+  get taskId(): string    { return this.getAttribute('task-id') ?? ''; }
+  get taskTitle(): string { return this.getAttribute('task-title') ?? ''; }
+  get priority(): string  { return this.getAttribute('task-priority') ?? 'medium'; }
+
+  // ── Drag handlers ─────────────────────────────────────────────────────────
+
+  private _onDragStart = (e: DragEvent): void => {
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move';
+      // Usar tipo MIME personalizado para distinguir de arrastre de columnas
+      e.dataTransfer.setData('text/dojo-task-id', this.taskId);
+      // Fallback para compatibilidad con navegadores más antiguos
+      e.dataTransfer.setData('text/plain', this.taskId);
+    }
+    this.setAttribute('dragging', '');
+    // CRÍTICO: evitar que el column-drag se dispare cuando se arrastra una tarjeta
+    e.stopPropagation();
+  };
+
+  private _onDragEnd = (): void => {
+    this.removeAttribute('dragging');
+    // Limpiar cualquier indicador de drop que quedara pendiente
+    this.removeAttribute('drop-indicator');
+  };
+
+  private _onClick = (e: MouseEvent): void => {
+    // Evitar que el click del drag se interprete como tap
+    if (e.defaultPrevented) return;
+    this.dispatchEvent(new CustomEvent('dojo:task-open', {
+      bubbles: true, composed: true,
+      detail: { taskId: this.taskId },
+    }));
+  };
+
+  // ── Prioridades ───────────────────────────────────────────────────────────
+
+  private static readonly PRIORITY_CONFIG = {
+    low:    { label: 'Baja',    color: 'var(--dojo-priority-low,    #3B82F6)' },
+    medium: { label: 'Media',   color: 'var(--dojo-priority-medium, #F59E0B)' },
+    high:   { label: 'Alta',    color: 'var(--dojo-priority-high,   #F97316)' },
+    urgent: { label: 'Urgente', color: 'var(--dojo-priority-urgent, #EF4444)' },
+  } as const;
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const p       = this.priority as keyof typeof DojoTaskCard.PRIORITY_CONFIG;
+    const pConfig = DojoTaskCard.PRIORITY_CONFIG[p] ?? DojoTaskCard.PRIORITY_CONFIG.medium;
+
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        padding: 0.625rem 0.75rem;
+        cursor: grab;
+        user-select: none;
+        box-shadow: 0 1px 2px rgba(0,0,0,.06);
+        transition: box-shadow 0.15s, opacity 0.15s, transform 0.12s;
+        outline: none;
+        position: relative;
+      }
+
+      /* Estado: siendo arrastrada */
+      :host([dragging]) {
+        opacity: 0.4;
+        cursor: grabbing;
+        transform: rotate(1.5deg) scale(0.98);
+      }
+
+      /* Estado: hover */
+      :host(:hover:not([dragging])) {
+        box-shadow: 0 4px 10px rgba(0,0,0,.12);
+      }
+
+      /* Foco accesible */
+      :host(:focus-visible) {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Indicador de posición de drop — línea en la parte superior */
+      :host([drop-indicator="top"])::before {
+        content: '';
+        position: absolute;
+        top: -3px;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--dojo-primary, #1D4ED8);
+        border-radius: 2px;
+      }
+
+      /* Indicador de posición de drop — línea en la parte inferior */
+      :host([drop-indicator="bottom"])::after {
+        content: '';
+        position: absolute;
+        bottom: -3px;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--dojo-primary, #1D4ED8);
+        border-radius: 2px;
+      }
+
+      /* Título de la tarjeta */
+      .title {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--dojo-text-primary);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        line-height: 1.4;
+        word-break: break-word;
+        margin: 0 0 0.5rem 0;
+      }
+
+      /* Footer: prioridad */
+      .footer {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+      }
+
+      .priority-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        flex-shrink: 0;
+        background: ${pConfig.color};
+      }
+
+      .priority-label {
+        font-size: 0.6875rem;
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Título
+    const titleEl = document.createElement('p');
+    titleEl.className = 'title';
+    titleEl.textContent = this.taskTitle; // textContent es seguro contra XSS
+    this._shadow.appendChild(titleEl);
+
+    // Footer de prioridad
+    const footer = document.createElement('div');
+    footer.className = 'footer';
+    footer.setAttribute('aria-label', `Prioridad: ${pConfig.label}`);
+
+    const dot = document.createElement('span');
+    dot.className = 'priority-dot';
+    dot.setAttribute('aria-hidden', 'true');
+
+    const label = document.createElement('span');
+    label.className = 'priority-label';
+    label.setAttribute('aria-hidden', 'true');
+    label.textContent = pConfig.label;
+
+    footer.appendChild(dot);
+    footer.appendChild(label);
+    this._shadow.appendChild(footer);
+  }
+}
+
+customElements.define(DojoTaskCard.TAG, DojoTaskCard);

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -43,6 +43,10 @@ export class DojoTaskCard extends HTMLElement {
     }
     this.setAttribute('draggable', 'true');
     this.setAttribute('role', 'listitem');
+    // WCAG 2.1 SC 2.1.1 (Keyboard, Level A): permite foco por teclado
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
     this.addEventListener('dragstart', this._onDragStart);
     this.addEventListener('dragend',   this._onDragEnd);
     this.addEventListener('click',     this._onClick);

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -45,6 +45,8 @@ export class DojoKanbanColumn extends HTMLElement {
   private _shadow: ShadowRoot;
   /** ID de la tarjeta ante la cual se soltará la tarea en curso (null = al final) */
   private _dropBeforeId: string | null = null;
+  /** Último valor enviado a _setDropIndicator para evitar mutaciones DOM redundantes */
+  private _lastDropIndicatorId: string | null | undefined = undefined;
 
   constructor() {
     super();
@@ -348,6 +350,10 @@ export class DojoKanbanColumn extends HTMLElement {
 
   /** Pone el indicador de drop en la tarjeta correcta. */
   private _setDropIndicator(beforeId: string | null): void {
+    // Guard: evitar mutaciones DOM si la posición no ha cambiado
+    if (beforeId === this._lastDropIndicatorId) return;
+    this._lastDropIndicatorId = beforeId;
+
     const slot = this._shadow.querySelector('slot');
     if (!slot) return;
     const cards = (slot as HTMLSlotElement).assignedElements();
@@ -364,6 +370,7 @@ export class DojoKanbanColumn extends HTMLElement {
 
   /** Elimina todos los indicadores de drop de las tarjetas asignadas al slot. */
   private _clearDropIndicators(): void {
+    this._lastDropIndicatorId = undefined; // limpiar cache
     const slot = this._shadow.querySelector('slot');
     if (!slot) return;
     (slot as HTMLSlotElement).assignedElements()

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -21,12 +21,12 @@
  * (default) | Tarjetas de tarea (`<dojo-task-card>`) proyectadas aquí      |
  *
  * ## Eventos despachados
- * | Nombre               | Detalle                       | Descripción                    |
- * |----------------------|-------------------------------|--------------------------------|
- * | dojo:column-drop     | { columnId, taskId }          | Tarea dropeada en la columna   |
- * | dojo:column-rename   | { columnId }                  | Usuario eligió "Renombrar"     |
- * | dojo:column-delete   | { columnId }                  | Usuario eligió "Eliminar"      |
- * | dojo:column-reorder  | { sourceId, targetId }        | Columna arrastrada a posición  |
+ * | Nombre               | Detalle                                         | Descripción                    |
+ * |----------------------|-------------------------------------------------|--------------------------------|
+ * | dojo:column-drop     | { columnId, taskId, beforeTaskId: string|null } | Tarea dropeada en la columna   |
+ * | dojo:column-rename   | { columnId }                                    | Usuario eligió "Renombrar"     |
+ * | dojo:column-delete   | { columnId }                                    | Usuario eligió "Eliminar"      |
+ * | dojo:column-reorder  | { sourceId, targetId }                          | Columna arrastrada a posición  |
  *
  * ## CSS Custom Properties heredadas
  * --dojo-surface, --dojo-border, --dojo-radius, --dojo-bg, --dojo-shadow
@@ -43,6 +43,8 @@ export class DojoKanbanColumn extends HTMLElement {
   }
 
   private _shadow: ShadowRoot;
+  /** ID de la tarjeta ante la cual se soltará la tarea en curso (null = al final) */
+  private _dropBeforeId: string | null = null;
 
   constructor() {
     super();
@@ -279,54 +281,111 @@ export class DojoKanbanColumn extends HTMLElement {
     this.addEventListener('drop',       this._onColumnDrop);
   }
 
-  // ── Drag & Drop (drop target) ─────────────────────────────────────────────
+  // ── Drop target para tareas ──────────────────────────────────────────────
 
   private _onDragOver = (e: DragEvent): void => {
+    // Reaccionar solo ante arrastres de tarjetas de tarea
+    if (!e.dataTransfer?.types.includes('text/dojo-task-id')) return;
     e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    e.dataTransfer.dropEffect = 'move';
     this.setAttribute('drag-over', '');
+    // Calcular posición y actualizar indicador visual
+    this._dropBeforeId = this._getDropBeforeId(e);
+    this._setDropIndicator(this._dropBeforeId);
   };
 
   private _onDragLeave = (e: DragEvent): void => {
-    // Solo quitar el atributo cuando el puntero sale del host o de sus hijos
     if (!this.contains(e.relatedTarget as Node)) {
       this.removeAttribute('drag-over');
+      this._clearDropIndicators();
+      this._dropBeforeId = null;
     }
   };
 
   private _onDrop = (e: DragEvent): void => {
     e.preventDefault();
     this.removeAttribute('drag-over');
+    this._clearDropIndicators();
 
-    const taskId = e.dataTransfer?.getData('text/plain');
+    const taskId = e.dataTransfer?.getData('text/dojo-task-id');
     if (!taskId) return;
+
+    const beforeTaskId = this._dropBeforeId;
+    this._dropBeforeId = null;
 
     this.dispatchEvent(new CustomEvent('dojo:column-drop', {
       bubbles:  true,
       composed: true,
       detail: {
-        columnId: this.columnId,
+        columnId:   this.columnId,
         taskId,
+        beforeTaskId,
       },
     }));
   };
 
+  // ── Utilidades de posición de drop ────────────────────────────────────────
+
+  /**
+   * Calcula ante qué tarjeta se soltará la tarea arrastrada.
+   * Cuando el puntero está por encima del centro de una tarjeta,
+   * se inserta antes de esa tarjeta; si está debajo del centro de
+   * la última tarjeta, se inserta al final (retorna null).
+   */
+  private _getDropBeforeId(e: DragEvent): string | null {
+    const slot = this._shadow.querySelector('slot');
+    if (!slot) return null;
+    const cards = (slot as HTMLSlotElement).assignedElements() as HTMLElement[];
+    for (const card of cards) {
+      const rect  = card.getBoundingClientRect();
+      const midY  = rect.top + rect.height / 2;
+      if (e.clientY < midY) {
+        return card.getAttribute('task-id') ?? null;
+      }
+    }
+    return null; // insertar al final
+  }
+
+  /** Pone el indicador de drop en la tarjeta correcta. */
+  private _setDropIndicator(beforeId: string | null): void {
+    const slot = this._shadow.querySelector('slot');
+    if (!slot) return;
+    const cards = (slot as HTMLSlotElement).assignedElements();
+    cards.forEach(card => card.removeAttribute('drop-indicator'));
+
+    if (beforeId !== null) {
+      const target = cards.find(c => c.getAttribute('task-id') === beforeId);
+      if (target) target.setAttribute('drop-indicator', 'top');
+    } else if (cards.length > 0) {
+      // Insertar al final: indicador bajo la última tarjeta
+      cards[cards.length - 1].setAttribute('drop-indicator', 'bottom');
+    }
+  }
+
+  /** Elimina todos los indicadores de drop de las tarjetas asignadas al slot. */
+  private _clearDropIndicators(): void {
+    const slot = this._shadow.querySelector('slot');
+    if (!slot) return;
+    (slot as HTMLSlotElement).assignedElements()
+      .forEach(card => card.removeAttribute('drop-indicator'));
+  }
+
   private _attachDragListeners(): void {
-    this.addEventListener('dragover',   this._onDragOver);
-    this.addEventListener('dragleave',  this._onDragLeave);
-    this.addEventListener('drop',       this._onDrop);
+    this.addEventListener('dragover',  this._onDragOver);
+    this.addEventListener('dragleave', this._onDragLeave);
+    this.addEventListener('drop',      this._onDrop);
   }
 
   private _detachDragListeners(): void {
-    this.removeEventListener('dragover',   this._onDragOver);
-    this.removeEventListener('dragleave',  this._onDragLeave);
-    this.removeEventListener('drop',       this._onDrop);
-    // También limpiar los listeners de drag de columna
-    this.removeEventListener('dragstart',  this._onColumnDragStart);
-    this.removeEventListener('dragend',    this._onColumnDragEnd);
-    this.removeEventListener('dragover',   this._onColumnDragOver);
-    this.removeEventListener('dragleave',  this._onColumnDragLeave);
-    this.removeEventListener('drop',       this._onColumnDrop);
+    this.removeEventListener('dragover',  this._onDragOver);
+    this.removeEventListener('dragleave', this._onDragLeave);
+    this.removeEventListener('drop',      this._onDrop);
+    // Limpiar también los listeners de drag de columna
+    this.removeEventListener('dragstart', this._onColumnDragStart);
+    this.removeEventListener('dragend',   this._onColumnDragEnd);
+    this.removeEventListener('dragover',  this._onColumnDragOver);
+    this.removeEventListener('dragleave', this._onColumnDragLeave);
+    this.removeEventListener('drop',      this._onColumnDrop);
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -335,7 +335,7 @@ export class DojoKanbanBoard extends HTMLElement {
    */
   private _refreshColumnCards(columnId: string): void {
     const colEl = this._shadow.querySelector(
-      `dojo-kanban-column[column-id="${columnId}"]`
+      `dojo-kanban-column[column-id="${CSS.escape(columnId)}"]`
     );
     if (!colEl) return;
     colEl.querySelectorAll('dojo-task-card').forEach(el => el.remove());

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -30,8 +30,9 @@
 
 import type { Column, Task } from '../../../types/models.js';
 import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
-import { getTasksByStatus, updateTask, deleteTask } from '../../../db/task.repository.js';
+import { getTasksByStatus, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import '../../molecules/dojo-kanban-column/dojo-kanban-column.js';
+import '../../atoms/dojo-task-card/dojo-task-card.js';
 import '../../atoms/dojo-add-column-button/dojo-add-column-button.js';
 import '../../organisms/dojo-column-dialog/dojo-column-dialog.js';
 
@@ -180,6 +181,8 @@ export class DojoKanbanBoard extends HTMLElement {
     this._shadow.addEventListener('dojo:column-delete',        (e) => this._onColumnDeleteRequest(e as CustomEvent));
     this._shadow.addEventListener('dojo:column-reorder',       (e) => this._handleReorder(e as CustomEvent));
     this._shadow.addEventListener('dojo:add-column',           () => this._onAddColumnRequest());
+    // US-03: Drag & Drop de tareas
+    this._shadow.addEventListener('dojo:column-drop',          (e) => this._handleTaskDrop(e as CustomEvent));
   }
 
   // ── Estados visuales ─────────────────────────────────────────────────────
@@ -296,6 +299,10 @@ export class DojoKanbanBoard extends HTMLElement {
       colEl.setAttribute('total-count', String(total));
       if (col.color) colEl.setAttribute('accent-color', col.color);
 
+      // US-03: Renderizar tarjetas de tarea en la columna
+      const tasks = this._tasksByColumn.get(col.id) ?? [];
+      this._renderTaskCards(colEl, tasks);
+
       track.appendChild(colEl);
     }
 
@@ -306,7 +313,37 @@ export class DojoKanbanBoard extends HTMLElement {
     this._setMainContent(track);
   }
 
-  // ── Conteo con filtros ────────────────────────────────────────────────────
+  // ── Renderizado y refresco de tarjetas de tarea (US-03) ───────────────────────────────────────
+
+  /**
+   * Crea y agrega `dojo-task-card` como hijos directos del elemento de columna.
+   * Las tarjetas se proyectan en el default slot del componente.
+   */
+  private _renderTaskCards(colEl: Element, tasks: Task[]): void {
+    const sorted = [...tasks].sort((a, b) => a.order - b.order);
+    for (const task of sorted) {
+      const card = document.createElement('dojo-task-card');
+      card.setAttribute('task-id',       task.id);
+      card.setAttribute('task-title',    task.title);
+      card.setAttribute('task-priority', task.priority);
+      colEl.appendChild(card);
+    }
+  }
+
+  /**
+   * Reemplaza las tarjetas de una columna ya renderizada sin recrear el elemento columna.
+   */
+  private _refreshColumnCards(columnId: string): void {
+    const colEl = this._shadow.querySelector(
+      `dojo-kanban-column[column-id="${columnId}"]`
+    );
+    if (!colEl) return;
+    colEl.querySelectorAll('dojo-task-card').forEach(el => el.remove());
+    const tasks = this._tasksByColumn.get(columnId) ?? [];
+    this._renderTaskCards(colEl, tasks);
+  }
+
+  // ── Conteo con filtros ──────────────────────────────────────────────────────────────────────────
 
   private _getColumnCounts(columnId: string): { visible: number; total: number } {
     const tasks = this._tasksByColumn.get(columnId) ?? [];
@@ -337,6 +374,110 @@ export class DojoKanbanBoard extends HTMLElement {
       col.setAttribute('count', String(visible));
       col.setAttribute('total-count', String(total));
     });
+  }
+
+  // ── Handler: Drop de tarea (US-03) ───────────────────────────────────────
+
+  /**
+   * Maneja `dojo:column-drop` para mover tareas entre columnas o reordenarlas
+   * dentro de la misma. Detecta el tipo de operación por comparación de columnId.
+   */
+  private async _handleTaskDrop(e: CustomEvent): Promise<void> {
+    const { columnId: targetColumnId, taskId, beforeTaskId } = e.detail as {
+      columnId:     string;
+      taskId:       string;
+      beforeTaskId: string | null;
+    };
+
+    // Localizar la columna origen desde el caché
+    let sourceColumnId: string | null = null;
+    for (const [colId, tasks] of this._tasksByColumn) {
+      if (tasks.some(t => t.id === taskId)) {
+        sourceColumnId = colId;
+        break;
+      }
+    }
+    if (!sourceColumnId) return;
+
+    try {
+      if (sourceColumnId === targetColumnId) {
+        // ── Reordenamiento dentro de la misma columna ─────────────────────
+        const tasks      = this._tasksByColumn.get(targetColumnId) ?? [];
+        const orderedIds = this._computeReorderedIds(tasks, taskId, beforeTaskId);
+        await reorderTasks(targetColumnId, orderedIds);
+        const taskMap = new Map(tasks.map(t => [t.id, t]));
+        this._tasksByColumn.set(
+          targetColumnId,
+          orderedIds.map((id, order) => ({ ...taskMap.get(id)!, order })),
+        );
+      } else {
+        // ── Movimiento entre columnas ──────────────────────────────────────
+        const sourceTasks = this._tasksByColumn.get(sourceColumnId) ?? [];
+        const targetTasks = this._tasksByColumn.get(targetColumnId) ?? [];
+        const movedTask   = sourceTasks.find(t => t.id === taskId);
+        if (!movedTask) return;
+
+        const newTargetTasks = this._insertAtPosition(
+          [...targetTasks],
+          { ...movedTask, statusId: targetColumnId },
+          beforeTaskId,
+        );
+        const newSourceTasks = sourceTasks.filter(t => t.id !== taskId);
+
+        await updateTask(taskId, { statusId: targetColumnId });
+        await reorderTasks(targetColumnId, newTargetTasks.map(t => t.id));
+        if (newSourceTasks.length > 0) {
+          await reorderTasks(sourceColumnId, newSourceTasks.map(t => t.id));
+        }
+
+        this._tasksByColumn.set(
+          sourceColumnId,
+          newSourceTasks.map((t, i) => ({ ...t, order: i })),
+        );
+        this._tasksByColumn.set(
+          targetColumnId,
+          newTargetTasks.map((t, i) => ({ ...t, order: i, statusId: targetColumnId })),
+        );
+
+        this._refreshColumnCards(sourceColumnId);
+      }
+
+      this._refreshColumnCards(targetColumnId);
+      this._updateColumnCounts();
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al procesar drop de tarea:', err);
+    }
+  }
+
+  /**
+   * Calcula el array de IDs resultante al mover `movingId` antes de `beforeId`.
+   * Si `beforeId` es null, la tarea se añade al final.
+   */
+  private _computeReorderedIds(
+    tasks:    Task[],
+    movingId: string,
+    beforeId: string | null,
+  ): string[] {
+    const others = tasks.filter(t => t.id !== movingId);
+    if (beforeId === null) return [...others.map(t => t.id), movingId];
+    const idx = others.findIndex(t => t.id === beforeId);
+    if (idx === -1)        return [...others.map(t => t.id), movingId];
+    const result = others.map(t => t.id);
+    result.splice(idx, 0, movingId);
+    return result;
+  }
+
+  /**
+   * Inserta `task` en `tasks` antes del elemento con id `beforeId`.
+   * Si `beforeId` es null o no existe, inserta al final.
+   */
+  private _insertAtPosition(tasks: Task[], task: Task, beforeId: string | null): Task[] {
+    if (beforeId === null) return [...tasks, task];
+    const idx = tasks.findIndex(t => t.id === beforeId);
+    if (idx === -1)        return [...tasks, task];
+    const result = [...tasks];
+    result.splice(idx, 0, task);
+    return result;
   }
 
   // ── Handlers de gestión de columnas ────────────────────────────────────────


### PR DESCRIPTION
## Resumen

Implementa la historia de usuario **US-03 — Drag & Drop de tareas** utilizando la API nativa HTML5 Drag & Drop (sin dependencias externas).

Closes #4

---

## Cambios incluidos

### 🆕 `dojo-task-card` (nuevo átomo)
- Tarjeta arrastrable con `draggable="true"` y eventos `dragstart`/`dragend`
- Usa `text/dojo-task-id` como tipo MIME personalizado para distinguir de arrastres de columnas
- Indicador visual de posición de drop mediante CSS pseudo-elementos (`::before`/`::after`) activados por el atributo `drop-indicator`
- Renderizado seguro con `textContent` (sin riesgo de XSS)
- `e.stopPropagation()` en `dragstart` para evitar que se dispare el handler de drag de columna

### 🔧 `dojo-kanban-column` (mejorado)
- Detección de posición de drop: compara `event.clientY` con el centro de cada tarjeta para calcular `beforeTaskId`
- Guards de tipo MIME: `_onDragOver` solo reacciona a `text/dojo-task-id`; `_onColumnDragOver` solo a `text/dojo-column-id`
- Elimina el conflicto previo entre los handlers de task-drop y column-drop
- Emite `dojo:column-drop` con `{ columnId, taskId, beforeTaskId: string | null }`
- Método `_setDropIndicator` / `_clearDropIndicators` para feedback visual en las tarjetas

### 🔧 `dojo-kanban-board` (extendido)
- Importa e importa `dojo-task-card`
- `_renderTaskCards(colEl, tasks)`: crea tarjetas sloteadas en cada columna al cargar
- `_refreshColumnCards(columnId)`: reemplaza tarjetas post-drop sin recrear la columna
- `_handleTaskDrop`: detecta si es movimiento entre columnas (`statusId`) o reordenamiento (`order`), llama a `updateTask` / `reorderTasks` y actualiza el caché `_tasksByColumn`
- `_computeReorderedIds` / `_insertAtPosition`: helpers puros para calcular nuevos órdenes

---

## Criterios de aceptación cubiertos

| Escenario | Estado |
|-----------|--------|
| Mover tarea a otra columna y actualizar `statusId` en IndexedDB | ✅ |
| Indicador visual durante el arrastre (cursor grab, zona de drop resaltada, línea de posición) | ✅ |
| Reordenar tareas en la misma columna y actualizar `order` en IndexedDB | ✅ |
| Uso exclusivo de eventos nativos `dragstart`, `dragover`, `dragleave`, `drop` | ✅ |
| Zero dependencias externas | ✅ |