### PR TITLE
feat(tasks): [US-04] Crear tarea con formulario modal

### DIFF
--- a/src/components/atoms/dojo-add-task-button/dojo-add-task-button.ts
+++ b/src/components/atoms/dojo-add-task-button/dojo-add-task-button.ts
@@ -1,0 +1,122 @@
+/**
+ * dojo-add-task-button — Átomo
+ *
+ * Botón compacto "＋ Agregar tarea" situado al pie de cada columna del tablero.
+ * Al ser activado (clic o teclado) emite el evento `dojo:add-task` con el
+ * `columnId` que toma del atributo `column-id` del elemento padre más cercano.
+ *
+ * ## Atributos observados
+ * | Atributo   | Tipo   | Descripción                         |
+ * |------------|--------|-------------------------------------|
+ * | column-id  | string | ID de la columna a la que pertenece |
+ *
+ * ## Eventos despachados
+ * | Nombre        | Detalle        | Descripción                        |
+ * |---------------|----------------|------------------------------------|
+ * | dojo:add-task | { columnId }   | Usuario solicitó crear nueva tarea |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-border, --dojo-text-muted, --dojo-primary, --dojo-radius-sm
+ */
+
+export class DojoAddTaskButton extends HTMLElement {
+  static readonly TAG = 'dojo-add-task-button';
+
+  static get observedAttributes(): string[] {
+    return ['column-id'];
+  }
+
+  private _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  attributeChangedCallback(): void {
+    // Actualizar el columnId del botón interno si cambia el atributo
+    const btn = this._shadow.querySelector('button');
+    if (btn) btn.dataset.columnId = this.getAttribute('column-id') ?? '';
+  }
+
+  get columnId(): string {
+    return this.getAttribute('column-id') ?? '';
+  }
+
+  private _render(): void {
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+        padding: 0 0.5rem 0.5rem;
+        flex-shrink: 0;
+      }
+
+      button {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        width: 100%;
+        padding: 0.4375rem 0.625rem;
+        background: transparent;
+        border: 1px dashed var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+        font-size: 0.8125rem;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s, color 0.15s;
+        text-align: left;
+      }
+
+      button:hover {
+        background: color-mix(in srgb, var(--dojo-primary, #1D4ED8) 6%, transparent);
+        border-color: var(--dojo-primary, #1D4ED8);
+        color: var(--dojo-primary, #1D4ED8);
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      .icon {
+        font-size: 1rem;
+        line-height: 1;
+        flex-shrink: 0;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('aria-label', 'Agregar tarea a esta columna');
+    btn.dataset.columnId = this.columnId;
+
+    const icon = document.createElement('span');
+    icon.className = 'icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '+';
+
+    const label = document.createElement('span');
+    label.textContent = 'Agregar tarea';
+
+    btn.appendChild(icon);
+    btn.appendChild(label);
+    this._shadow.appendChild(btn);
+
+    btn.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:add-task', {
+        bubbles:  true,
+        composed: true,
+        detail:   { columnId: this.columnId },
+      }));
+    });
+  }
+}
+
+customElements.define(DojoAddTaskButton.TAG, DojoAddTaskButton);

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -27,6 +27,7 @@
  * | dojo:column-rename   | { columnId }                                    | Usuario eligió "Renombrar"     |
  * | dojo:column-delete   | { columnId }                                    | Usuario eligió "Eliminar"      |
  * | dojo:column-reorder  | { sourceId, targetId }                          | Columna arrastrada a posición  |
+ * | dojo:add-task        | { columnId }                                    | Usuario quiere crear una tarea |
  *
  * ## CSS Custom Properties heredadas
  * --dojo-surface, --dojo-border, --dojo-radius, --dojo-bg, --dojo-shadow
@@ -34,6 +35,7 @@
 
 import '../../atoms/dojo-column-header/dojo-column-header.js';
 import '../../atoms/dojo-column-menu/dojo-column-menu.js';
+import '../../atoms/dojo-add-task-button/dojo-add-task-button.js';
 
 export class DojoKanbanColumn extends HTMLElement {
   static readonly TAG = 'dojo-kanban-column';
@@ -161,6 +163,12 @@ export class DojoKanbanColumn extends HTMLElement {
         text-align: center;
         pointer-events: none;
       }
+
+      /* Zona inferior: botón agregar tarea */
+      .col-footer {
+        padding: 0.375rem 0.5rem 0.5rem;
+        border-top: 1px solid var(--dojo-border);
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -219,6 +227,15 @@ export class DojoKanbanColumn extends HTMLElement {
     });
 
     this._shadow.appendChild(content);
+
+    // ── Zona inferior: botón "Agregar tarea" ──────────────────────────────
+    const footer = document.createElement('div');
+    footer.className = 'col-footer';
+
+    const addTaskBtn = document.createElement('dojo-add-task-button') as HTMLElement;
+    addTaskBtn.setAttribute('column-id', this.columnId);
+    footer.appendChild(addTaskBtn);
+    this._shadow.appendChild(footer);
   }
 
   // ── Actualización dinámica del header ────────────────────────────────────

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -30,11 +30,12 @@
 
 import type { Column, Task } from '../../../types/models.js';
 import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
-import { getTasksByStatus, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
+import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import '../../molecules/dojo-kanban-column/dojo-kanban-column.js';
 import '../../atoms/dojo-task-card/dojo-task-card.js';
 import '../../atoms/dojo-add-column-button/dojo-add-column-button.js';
 import '../../organisms/dojo-column-dialog/dojo-column-dialog.js';
+import '../../organisms/dojo-task-dialog/dojo-task-dialog.js';
 
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
@@ -183,6 +184,11 @@ export class DojoKanbanBoard extends HTMLElement {
     this._shadow.addEventListener('dojo:add-column',           () => this._onAddColumnRequest());
     // US-03: Drag & Drop de tareas
     this._shadow.addEventListener('dojo:column-drop',          (e) => this._handleTaskDrop(e as CustomEvent));
+    // US-04: Crear tarea
+    const taskDialog = document.createElement('dojo-task-dialog');
+    this._shadow.appendChild(taskDialog);
+    this._shadow.addEventListener('dojo:add-task',             (e) => this._onAddTaskRequest(e as CustomEvent));
+    this._shadow.addEventListener('dojo:dialog-create-task',   (e) => this._handleCreateTask(e as CustomEvent));
   }
 
   // ── Estados visuales ─────────────────────────────────────────────────────
@@ -485,7 +491,9 @@ export class DojoKanbanBoard extends HTMLElement {
   private _getDialog(): HTMLElement | null {
     return this._shadow.querySelector('dojo-column-dialog');
   }
-
+  private _getTaskDialog(): HTMLElement | null {
+    return this._shadow.querySelector('dojo-task-dialog');
+  }
   private _onAddColumnRequest(): void {
     const dialog = this._getDialog() as any;
     if (dialog?.openCreate) dialog.openCreate();
@@ -593,6 +601,41 @@ export class DojoKanbanBoard extends HTMLElement {
       console.error('[dojo-kanban-board] Error al reordenar columnas:', err);
       // Recargar desde IndexedDB para mantener consistencia
       await this._loadBoard();
+    }
+  }
+
+  // ── Handlers de creación de tarea (US-04) ─────────────────────────
+
+  private _onAddTaskRequest(e: CustomEvent): void {
+    const { columnId } = e.detail as { columnId: string };
+    const col = this._columns.find(c => c.id === columnId);
+    if (!col) return;
+    const taskDialog = this._getTaskDialog() as any;
+    if (taskDialog?.openCreate) taskDialog.openCreate(col.id, col.name);
+  }
+
+  private async _handleCreateTask(e: CustomEvent): Promise<void> {
+    const { statusId, title, description, priority } = e.detail as {
+      statusId:    string;
+      title:       string;
+      description: string;
+      priority:    string;
+    };
+    const tasks = this._tasksByColumn.get(statusId) ?? [];
+    try {
+      const newTask = await createTask({
+        title,
+        description,
+        statusId,
+        priority:  priority as Task['priority'],
+        labelIds:  [],
+        order:     tasks.length,
+      });
+      this._tasksByColumn.set(statusId, [...tasks, newTask]);
+      this._refreshColumnCards(statusId);
+      this._updateColumnCounts();
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al crear tarea:', err);
     }
   }
 }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -621,6 +621,11 @@ export class DojoKanbanBoard extends HTMLElement {
       description: string;
       priority:    string;
     };
+    // Validar que la columna exista (puede haberse eliminado mientras el diálogo estaba abierto)
+    if (!this._columns.some(c => c.id === statusId)) {
+      console.warn('[dojo-kanban-board] statusId no corresponde a ninguna columna activa:', statusId);
+      return;
+    }
     const tasks = this._tasksByColumn.get(statusId) ?? [];
     try {
       const newTask = await createTask({

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -77,6 +77,9 @@ export class DojoTaskDialog extends HTMLElement {
     const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
     if (!backdrop) return;
     backdrop.setAttribute('aria-hidden', 'false');
+    // Remover primero para evitar acumular listeners duplicados si se invoca
+    // openCreate() varias veces sin cerrar el diálogo entre llamadas.
+    document.removeEventListener('keydown', this._onDocKeydown);
     document.addEventListener('keydown', this._onDocKeydown);
   }
 
@@ -298,10 +301,10 @@ export class DojoTaskDialog extends HTMLElement {
     titleInput.setAttribute('aria-describedby', 'task-title-error');
 
     titleInput.addEventListener('input', () => {
-      const len = titleInput.value.length;
+      // Usar trim() para que el contador y la limpieza de error reflejen el valor real
+      const len = titleInput.value.trim().length;
       charCount.textContent = `${len} / ${MAX_TITLE}`;
       charCount.classList.toggle('near-limit', len >= MAX_TITLE * 0.9);
-      // Limpiar error si el usuario empieza a escribir
       if (len > 0) {
         titleInput.removeAttribute('aria-invalid');
         titleError.removeAttribute('aria-live');
@@ -325,10 +328,12 @@ export class DojoTaskDialog extends HTMLElement {
     descLabel.setAttribute('for', 'task-desc-input');
     descLabel.textContent = 'Descripción (Markdown, opcional)';
 
+    const MAX_DESC = 2000;
     const descInput = document.createElement('textarea');
     descInput.id = 'task-desc-input';
     descInput.placeholder = 'Describe la tarea…';
     descInput.rows = 3;
+    descInput.maxLength = MAX_DESC;
 
     descField.appendChild(descLabel);
     descField.appendChild(descInput);

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -1,0 +1,411 @@
+/**
+ * dojo-task-dialog — Organismo
+ *
+ * Diálogo modal para crear tareas en el tablero Kanban.
+ * Implementa los criterios de aceptación de US-04.
+ *
+ * ## API Pública
+ * | Método                          | Descripción                              |
+ * |---------------------------------|------------------------------------------|
+ * | openCreate(columnId, colName)   | Abre el formulario de creación de tarea  |
+ *
+ * ## Eventos despachados
+ * | Nombre                    | Detalle                                       | Descripción           |
+ * |---------------------------|-----------------------------------------------|-----------------------|
+ * | dojo:dialog-create-task   | { statusId, title, description, priority }    | Usuario confirmó crear|
+ *
+ * ## Validaciones (US-04)
+ * - Título obligatorio (no vacío)
+ * - Título máximo 120 caracteres (impide entrada + muestra error)
+ * - Prioridad por defecto: "medium"
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*, --dojo-primary,
+ * --dojo-danger, --dojo-radius, --dojo-radius-sm, --dojo-shadow
+ */
+
+import type { Priority } from '../../../types/models.js';
+
+const PRIORITIES: { value: Priority; label: string }[] = [
+  { value: 'low',    label: '🔵 Baja'    },
+  { value: 'medium', label: '🟡 Media'   },
+  { value: 'high',   label: '🟠 Alta'    },
+  { value: 'urgent', label: '🔴 Urgente' },
+];
+
+export class DojoTaskDialog extends HTMLElement {
+  static readonly TAG = 'dojo-task-dialog';
+
+  private _shadow: ShadowRoot;
+  private _columnId  = '';
+  private _columnName = '';
+
+  // Referencia estable para poder eliminar el listener de teclado
+  private _onDocKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this._isOpen()) this._close();
+  };
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('keydown', this._onDocKeydown);
+  }
+
+  // ── API pública ───────────────────────────────────────────────────────────
+
+  openCreate(columnId: string, columnName: string): void {
+    this._columnId   = columnId;
+    this._columnName = columnName;
+    this._buildForm();
+    this._open();
+  }
+
+  // ── Estado del diálogo ────────────────────────────────────────────────────
+
+  private _isOpen(): boolean {
+    return this._shadow.querySelector('.backdrop')?.getAttribute('aria-hidden') === 'false';
+  }
+
+  private _open(): void {
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    if (!backdrop) return;
+    backdrop.setAttribute('aria-hidden', 'false');
+    document.addEventListener('keydown', this._onDocKeydown);
+  }
+
+  private _close(): void {
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    if (!backdrop) return;
+    backdrop.setAttribute('aria-hidden', 'true');
+    document.removeEventListener('keydown', this._onDocKeydown);
+  }
+
+  // ── Render base ───────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: contents; }
+
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.45);
+        z-index: 300;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+      }
+      .backdrop[aria-hidden="false"] { display: flex; }
+
+      .dialog {
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius);
+        box-shadow: var(--dojo-shadow);
+        width: 100%;
+        max-width: 460px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.125rem;
+        animation: dlg-in 0.18s ease;
+      }
+      @keyframes dlg-in {
+        from { opacity: 0; transform: scale(0.96) translateY(-8px); }
+        to   { opacity: 1; transform: none; }
+      }
+
+      .dialog-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0;
+      }
+      .dialog-subtitle {
+        font-size: 0.8125rem;
+        color: var(--dojo-text-secondary);
+        margin: 0;
+        margin-top: -0.5rem;
+      }
+
+      /* Campos de formulario */
+      .field { display: flex; flex-direction: column; gap: 0.375rem; }
+
+      .field-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+
+      .field label {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--dojo-text-secondary);
+      }
+
+      .char-count {
+        font-size: 0.75rem;
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+      }
+      .char-count.near-limit { color: var(--dojo-danger, #DC2626); }
+
+      .field input,
+      .field textarea,
+      .field select {
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.9375rem;
+        color: var(--dojo-text-primary);
+        background: var(--dojo-bg);
+        width: 100%;
+        box-sizing: border-box;
+        transition: border-color 0.15s;
+        font-family: inherit;
+      }
+      .field input:focus,
+      .field textarea:focus,
+      .field select:focus {
+        outline: none;
+        border-color: var(--dojo-primary, #1D4ED8);
+        box-shadow: 0 0 0 2px color-mix(in srgb, var(--dojo-primary, #1D4ED8) 20%, transparent);
+      }
+      .field input[aria-invalid="true"],
+      .field textarea[aria-invalid="true"] {
+        border-color: var(--dojo-danger, #DC2626);
+      }
+
+      .field textarea {
+        resize: vertical;
+        min-height: 80px;
+        line-height: 1.5;
+      }
+
+      .field-error {
+        font-size: 0.75rem;
+        color: var(--dojo-danger, #DC2626);
+        display: none;
+      }
+      .field-error[aria-live] { display: block; }
+
+      /* Acciones */
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.625rem;
+        margin-top: 0.25rem;
+      }
+      .btn {
+        padding: 0.4375rem 1rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: opacity 0.15s;
+      }
+      .btn:hover { opacity: 0.85; }
+      .btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+      .btn-cancel {
+        background: transparent;
+        border-color: var(--dojo-border);
+        color: var(--dojo-text-secondary);
+      }
+      .btn-primary {
+        background: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('role', 'dialog');
+    backdrop.setAttribute('aria-modal', 'true');
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.setAttribute('aria-labelledby', 'task-dlg-title');
+
+    // Cerrar al clicar fuera del diálogo
+    backdrop.addEventListener('click', (e) => {
+      if (e.target === backdrop) this._close();
+    });
+
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+    backdrop.appendChild(dialog);
+    this._shadow.appendChild(backdrop);
+  }
+
+  // ── Formulario de creación ────────────────────────────────────────────────
+
+  private _buildForm(): void {
+    const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+    if (!dialog) return;
+    dialog.innerHTML = '';
+
+    // ── Título del diálogo ─────────────────────────────────────────────────
+    const h2 = document.createElement('h2');
+    h2.id = 'task-dlg-title';
+    h2.className = 'dialog-title';
+    h2.textContent = 'Nueva tarea';
+    dialog.appendChild(h2);
+
+    const subtitle = document.createElement('p');
+    subtitle.className = 'dialog-subtitle';
+    // textContent es seguro (no hay input del usuario aquí)
+    subtitle.textContent = `En columna: ${this._columnName}`;
+    dialog.appendChild(subtitle);
+
+    // ── Campo: Título (obligatorio, máx 120) ───────────────────────────────
+    const MAX_TITLE = 120;
+    const titleField = document.createElement('div');
+    titleField.className = 'field';
+
+    const titleHeader = document.createElement('div');
+    titleHeader.className = 'field-header';
+
+    const titleLabel = document.createElement('label');
+    titleLabel.setAttribute('for', 'task-title-input');
+    titleLabel.textContent = 'Título *';
+
+    const charCount = document.createElement('span');
+    charCount.className = 'char-count';
+    charCount.setAttribute('aria-live', 'polite');
+    charCount.textContent = `0 / ${MAX_TITLE}`;
+
+    titleHeader.appendChild(titleLabel);
+    titleHeader.appendChild(charCount);
+    titleField.appendChild(titleHeader);
+
+    const titleInput = document.createElement('input');
+    titleInput.id = 'task-title-input';
+    titleInput.type = 'text';
+    titleInput.placeholder = 'Ej. Implementar autenticación';
+    titleInput.maxLength = MAX_TITLE;
+    titleInput.setAttribute('aria-required', 'true');
+    titleInput.setAttribute('aria-describedby', 'task-title-error');
+
+    titleInput.addEventListener('input', () => {
+      const len = titleInput.value.length;
+      charCount.textContent = `${len} / ${MAX_TITLE}`;
+      charCount.classList.toggle('near-limit', len >= MAX_TITLE * 0.9);
+      // Limpiar error si el usuario empieza a escribir
+      if (len > 0) {
+        titleInput.removeAttribute('aria-invalid');
+        titleError.removeAttribute('aria-live');
+      }
+    });
+
+    const titleError = document.createElement('span');
+    titleError.id = 'task-title-error';
+    titleError.className = 'field-error';
+    titleError.textContent = 'El título es obligatorio.';
+
+    titleField.appendChild(titleInput);
+    titleField.appendChild(titleError);
+    dialog.appendChild(titleField);
+
+    // ── Campo: Descripción (opcional) ─────────────────────────────────────
+    const descField = document.createElement('div');
+    descField.className = 'field';
+
+    const descLabel = document.createElement('label');
+    descLabel.setAttribute('for', 'task-desc-input');
+    descLabel.textContent = 'Descripción (Markdown, opcional)';
+
+    const descInput = document.createElement('textarea');
+    descInput.id = 'task-desc-input';
+    descInput.placeholder = 'Describe la tarea…';
+    descInput.rows = 3;
+
+    descField.appendChild(descLabel);
+    descField.appendChild(descInput);
+    dialog.appendChild(descField);
+
+    // ── Campo: Prioridad (default medium) ─────────────────────────────────
+    const priField = document.createElement('div');
+    priField.className = 'field';
+
+    const priLabel = document.createElement('label');
+    priLabel.setAttribute('for', 'task-priority-select');
+    priLabel.textContent = 'Prioridad';
+
+    const priSelect = document.createElement('select');
+    priSelect.id = 'task-priority-select';
+    priSelect.setAttribute('aria-label', 'Seleccionar prioridad');
+
+    PRIORITIES.forEach(({ value, label }) => {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = label;
+      if (value === 'medium') opt.selected = true;
+      priSelect.appendChild(opt);
+    });
+
+    priField.appendChild(priLabel);
+    priField.appendChild(priSelect);
+    dialog.appendChild(priField);
+
+    // ── Acciones ───────────────────────────────────────────────────────────
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn btn-cancel';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._close());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn btn-primary';
+    confirmBtn.textContent = 'Crear tarea';
+    confirmBtn.addEventListener('click', () => {
+      const title = titleInput.value.trim();
+
+      // Validación: título obligatorio
+      if (!title) {
+        titleInput.setAttribute('aria-invalid', 'true');
+        titleError.setAttribute('aria-live', 'assertive');
+        titleInput.focus();
+        return;
+      }
+
+      this.dispatchEvent(new CustomEvent('dojo:dialog-create-task', {
+        bubbles:  true,
+        composed: true,
+        detail: {
+          statusId:    this._columnId,
+          title,
+          description: descInput.value.trim(),
+          priority:    priSelect.value as Priority,
+        },
+      }));
+      this._close();
+    });
+
+    // Enter en el campo título también confirma
+    titleInput.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') confirmBtn.click();
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    dialog.appendChild(actions);
+
+    // Foco inicial al input de título
+    setTimeout(() => titleInput.focus(), 50);
+  }
+}
+
+customElements.define(DojoTaskDialog.TAG, DojoTaskDialog);


### PR DESCRIPTION
## Descripción

Implementa **US-04 – Crear tarea** (Issue #5). Permite al usuario agregar nuevas tareas a cualquier columna del tablero Kanban mediante un formulario modal.

---

## Cambios

### `dojo-add-task-button` (nuevo átomo)
- Botón tipo "＋ Agregar tarea" en el pie de cada columna.
- Emite `dojo:add-task` con `{ columnId }` al hacer clic.
- Estilizado con borde punteado, hover con color primario, `focus-visible` accesible.

### `dojo-task-dialog` (nuevo organismo)
- Diálogo modal singleton montado en `dojo-kanban-board`.
- API pública: `openCreate(columnId: string, columnName: string)`.
- Formulario:
  - **Título** (obligatorio, máximo 120 caracteres, contador en tiempo real).
  - **Descripción** (opcional, Markdown).
  - **Prioridad** (`select`: Baja / Media / Alta / Urgente, por defecto Media).
- Validación: título vacío muestra error accessible (`aria-live="assertive"`).
- Cierre con: botón Cancelar, clic en backdrop, tecla `Escape`.
- Animación de entrada, foco inicial al input título.

### `dojo-kanban-column` (actualizado)
- Importa y renderiza `dojo-add-task-button` en un `div.col-footer` al pie.
- Nueva entrada en la tabla de eventos del JSDoc: `dojo:add-task`.

### `dojo-kanban-board` (actualizado)
- Importa `dojo-task-dialog` y lo monta como singleton en `_render()`.
- Escucha `dojo:add-task` → llama a `taskDialog.openCreate(columnId, columnName)`.
- Escucha `dojo:dialog-create-task` → persiste con `createTask()`, actualiza caché `_tasksByColumn`, llama a `_refreshColumnCards()` y `_updateColumnCounts()`.
- Importa `createTask` desde `task.repository`.

---

## Criterios de aceptación cubiertos (US-04 Gherkin)

| Escenario | Estado |
|---|---|
| Crear tarea solo con título | ✅ |
| Crear tarea con todos los campos | ✅ |
| Error al enviar título vacío | ✅ |
| Título truncado a 120 caracteres | ✅ |
| La columna donde se abre el diálogo establece `statusId` | ✅ |

---

## Seguridad
- No hay usos de `innerHTML` con contenido de usuario — todos los textos del formulario usan `element.textContent` o `element.value`.
- `innerHTML = ''` se usa únicamente para limpiar el Shadow DOM (contenido estático).
- Sin dependencias externas.

Closes #5