### PR TITLE
feat(tasks): [US-06] Eliminación de tareas con diálogo de confirmación

### DIFF
--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -149,6 +149,37 @@ export class DojoTaskCard extends HTMLElement {
         outline-offset: 2px;
       }
 
+      /* Botón de eliminación rápida (US-06) */
+      .quick-delete-btn {
+        position: absolute;
+        top: 0.375rem;
+        right: 0.375rem;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.2rem 0.3rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.8125rem;
+        color: var(--dojo-text-secondary);
+        line-height: 1;
+        opacity: 0;
+        transition: opacity 0.15s, background 0.15s, color 0.15s;
+        z-index: 1;
+      }
+      :host(:hover) .quick-delete-btn,
+      :host(:focus-within) .quick-delete-btn {
+        opacity: 1;
+      }
+      .quick-delete-btn:hover {
+        background: #FEE2E2;
+        color: #EF4444;
+      }
+      .quick-delete-btn:focus-visible {
+        outline: 2px solid #EF4444;
+        outline-offset: 2px;
+        opacity: 1;
+      }
+
       /* Indicador de posición de drop — línea en la parte superior */
       :host([drop-indicator="top"])::before {
         content: '';
@@ -210,6 +241,20 @@ export class DojoTaskCard extends HTMLElement {
       }
     `;
     this._shadow.appendChild(style);
+
+    // Botón de eliminación rápida (US-06)
+    const quickDeleteBtn = document.createElement('button');
+    quickDeleteBtn.className = 'quick-delete-btn';
+    quickDeleteBtn.setAttribute('aria-label', `Eliminar tarea: ${this.taskTitle}`);
+    quickDeleteBtn.textContent = '🗑';
+    quickDeleteBtn.addEventListener('click', (e: MouseEvent) => {
+      e.stopPropagation(); // Evitar que dispare dojo:task-open
+      this.dispatchEvent(new CustomEvent('dojo:task-delete-request', {
+        bubbles: true, composed: true,
+        detail: { taskId: this.taskId, taskTitle: this.taskTitle },
+      }));
+    });
+    this._shadow.appendChild(quickDeleteBtn);
 
     // Título
     const titleEl = document.createElement('p');

--- a/src/components/organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.ts
+++ b/src/components/organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.ts
@@ -1,0 +1,282 @@
+/**
+ * dojo-delete-confirm-dialog — Organismo
+ *
+ * Diálogo modal de confirmación para eliminar una tarea.
+ * Implementa los criterios de aceptación de US-06 (Eliminar tarea).
+ *
+ * ## API Pública
+ * | Método                          | Descripción                                 |
+ * |---------------------------------|---------------------------------------------|
+ * | show(taskId, taskTitle): void   | Abre el diálogo con el título de la tarea   |
+ * | hide(): void                    | Cierra el diálogo sin confirmar             |
+ *
+ * ## Eventos despachados
+ * | Nombre                    | Detalle       | Descripción                     |
+ * |---------------------------|---------------|---------------------------------|
+ * | dojo:task-delete-confirm  | { taskId }    | Usuario confirmó la eliminación |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*,
+ * --dojo-primary, --dojo-radius, --dojo-radius-sm, --dojo-shadow
+ */
+
+// ── Clase ──────────────────────────────────────────────────────────────────
+
+export class DojoDeleteConfirmDialog extends HTMLElement {
+  static readonly TAG = 'dojo-delete-confirm-dialog';
+
+  private _shadow: ShadowRoot;
+  private _taskId: string = '';
+
+  /** Referencia estable para poder eliminar el listener de teclado. */
+  private _onDocKeydown = (e: KeyboardEvent): void => {
+    if (!this._isOpen()) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hide();
+      return;
+    }
+    // Focus trap: mantener Tab dentro del diálogo (WCAG 2.1 SC 2.1.2)
+    if (e.key === 'Tab') {
+      const focusable = this._getFocusable();
+      if (focusable.length < 2) return;
+      const first  = focusable[0];
+      const last   = focusable[focusable.length - 1];
+      const active = this._shadow.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) this._render();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('keydown', this._onDocKeydown);
+  }
+
+  // ── API pública ───────────────────────────────────────────────────────────
+
+  show(taskId: string, taskTitle: string): void {
+    this._taskId = taskId;
+    const titleEl = this._shadow.querySelector<HTMLElement>('.dialog-task-title');
+    if (titleEl) titleEl.textContent = `"${taskTitle}"`;
+    this.setAttribute('open', '');
+    document.removeEventListener('keydown', this._onDocKeydown);
+    document.addEventListener('keydown', this._onDocKeydown);
+    // Foco al botón Cancelar por defecto (acción segura)
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLElement>('.cancel-btn')?.focus();
+    });
+  }
+
+  hide(): void {
+    this.removeAttribute('open');
+    document.removeEventListener('keydown', this._onDocKeydown);
+  }
+
+  // ── Estado ────────────────────────────────────────────────────────────────
+
+  private _isOpen(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  private _getFocusable(): HTMLElement[] {
+    const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+    if (!dialog) return [];
+    return Array.from(
+      dialog.querySelectorAll<HTMLElement>('button:not([disabled])')
+    ).filter(el => el.offsetParent !== null);
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host { display: contents; }
+
+      /* ── Backdrop ── */
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+        z-index: 300;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease;
+      }
+      :host([open]) .backdrop {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      /* ── Diálogo ── */
+      .dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -56%);
+        z-index: 301;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+        padding: 1.5rem;
+        width: 360px;
+        max-width: calc(100vw - 2rem);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease, transform 0.18s ease;
+      }
+      :host([open]) .dialog {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translate(-50%, -50%);
+      }
+
+      /* ── Ícono ── */
+      .dialog-icon {
+        font-size: 2rem;
+        text-align: center;
+        margin-bottom: 0.75rem;
+        line-height: 1;
+      }
+
+      /* ── Título ── */
+      .dialog-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        text-align: center;
+        margin: 0 0 0.375rem;
+      }
+
+      /* ── Nombre de la tarea ── */
+      .dialog-task-title {
+        display: block;
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        text-align: center;
+        margin: 0 0 1.25rem;
+        word-break: break-word;
+      }
+
+      /* ── Acciones ── */
+      .dialog-actions {
+        display: flex;
+        gap: 0.625rem;
+        justify-content: flex-end;
+      }
+
+      .cancel-btn {
+        padding: 0.4375rem 1rem;
+        background: transparent;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        cursor: pointer;
+        font-family: inherit;
+        transition: background 0.15s;
+      }
+      .cancel-btn:hover { background: var(--dojo-bg); }
+      .cancel-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      .confirm-btn {
+        padding: 0.4375rem 1rem;
+        background: #EF4444;
+        border: none;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #fff;
+        cursor: pointer;
+        font-family: inherit;
+        transition: background 0.15s;
+      }
+      .confirm-btn:hover  { background: #DC2626; }
+      .confirm-btn:focus-visible {
+        outline: 2px solid #EF4444;
+        outline-offset: 2px;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Backdrop
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.addEventListener('click', () => this.hide());
+    this._shadow.appendChild(backdrop);
+
+    // Diálogo
+    const dialog = document.createElement('div');
+    dialog.className = 'dialog';
+    dialog.setAttribute('role', 'alertdialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', 'delete-dialog-title');
+    dialog.setAttribute('aria-describedby', 'delete-dialog-desc');
+
+    const icon = document.createElement('div');
+    icon.className = 'dialog-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '🗑️';
+
+    const titleEl = document.createElement('h2');
+    titleEl.id = 'delete-dialog-title';
+    titleEl.className = 'dialog-title';
+    titleEl.textContent = '¿Eliminar tarea?';
+
+    const desc = document.createElement('span');
+    desc.id = 'delete-dialog-desc';
+    desc.className = 'dialog-task-title';
+    // El texto se inyecta en show() vía textContent (nunca innerHTML)
+
+    const actions = document.createElement('div');
+    actions.className = 'dialog-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'cancel-btn';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this.hide());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'confirm-btn';
+    confirmBtn.textContent = 'Eliminar';
+    confirmBtn.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:task-delete-confirm', {
+        bubbles:  true,
+        composed: true,
+        detail:   { taskId: this._taskId },
+      }));
+      this.hide();
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+
+    dialog.appendChild(icon);
+    dialog.appendChild(titleEl);
+    dialog.appendChild(desc);
+    dialog.appendChild(actions);
+
+    this._shadow.appendChild(dialog);
+  }
+}
+
+customElements.define(DojoDeleteConfirmDialog.TAG, DojoDeleteConfirmDialog);

--- a/src/components/organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.ts
+++ b/src/components/organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.ts
@@ -27,6 +27,8 @@ export class DojoDeleteConfirmDialog extends HTMLElement {
 
   private _shadow: ShadowRoot;
   private _taskId: string = '';
+  /** Elemento que abrió el diálogo — el foco regresa aquí al cerrar (WCAG 2.1 SC 2.4.3). */
+  private _triggerEl: HTMLElement | null = null;
 
   /** Referencia estable para poder eliminar el listener de teclado. */
   private _onDocKeydown = (e: KeyboardEvent): void => {
@@ -68,10 +70,14 @@ export class DojoDeleteConfirmDialog extends HTMLElement {
 
   // ── API pública ───────────────────────────────────────────────────────────
 
-  show(taskId: string, taskTitle: string): void {
-    this._taskId = taskId;
+  show(taskId: string, taskTitle: string, triggerEl?: HTMLElement): void {
+    this._taskId    = taskId;
+    this._triggerEl = triggerEl ?? null;
     const titleEl = this._shadow.querySelector<HTMLElement>('.dialog-task-title');
     if (titleEl) titleEl.textContent = `"${taskTitle}"`;
+    // Marcar como visible para lectores de pantalla (Fix #2)
+    const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+    dialog?.setAttribute('aria-hidden', 'false');
     this.setAttribute('open', '');
     document.removeEventListener('keydown', this._onDocKeydown);
     document.addEventListener('keydown', this._onDocKeydown);
@@ -84,6 +90,13 @@ export class DojoDeleteConfirmDialog extends HTMLElement {
   hide(): void {
     this.removeAttribute('open');
     document.removeEventListener('keydown', this._onDocKeydown);
+    // Ocultar del árbol AT mientras está cerrado (Fix #2)
+    const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+    dialog?.setAttribute('aria-hidden', 'true');
+    // Devolver foco al disparador (Fix #3 — WCAG 2.1 SC 2.4.3)
+    const trigger = this._triggerEl;
+    this._triggerEl = null;
+    requestAnimationFrame(() => trigger?.focus());
   }
 
   // ── Estado ────────────────────────────────────────────────────────────────
@@ -231,6 +244,8 @@ export class DojoDeleteConfirmDialog extends HTMLElement {
     dialog.setAttribute('aria-modal', 'true');
     dialog.setAttribute('aria-labelledby', 'delete-dialog-title');
     dialog.setAttribute('aria-describedby', 'delete-dialog-desc');
+    // Oculto del árbol AT hasta que se abra con show() (Fix #2)
+    dialog.setAttribute('aria-hidden', 'true');
 
     const icon = document.createElement('div');
     icon.className = 'dialog-icon';

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -38,6 +38,7 @@ import '../../atoms/dojo-add-column-button/dojo-add-column-button.js';
 import '../../organisms/dojo-column-dialog/dojo-column-dialog.js';
 import '../../organisms/dojo-task-dialog/dojo-task-dialog.js';
 import '../../organisms/dojo-task-detail/dojo-task-detail.js';
+import '../../organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.js';
 
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
@@ -196,6 +197,11 @@ export class DojoKanbanBoard extends HTMLElement {
     this._shadow.appendChild(taskDetail);
     this._shadow.addEventListener('dojo:task-open',            (e) => this._onTaskOpen(e as CustomEvent));
     this._shadow.addEventListener('dojo:task-field-updated',   (e) => this._handleTaskFieldUpdated(e as CustomEvent));
+    // US-06: Eliminar tarea
+    const deleteDialog = document.createElement('dojo-delete-confirm-dialog');
+    this._shadow.appendChild(deleteDialog);
+    this._shadow.addEventListener('dojo:task-delete-request',  (e) => this._onTaskDeleteRequest(e as CustomEvent));
+    this._shadow.addEventListener('dojo:task-delete-confirm',  (e) => this._handleTaskDeleteConfirm(e as CustomEvent));
   }
 
   // ── Estados visuales ─────────────────────────────────────────────────────
@@ -505,6 +511,10 @@ export class DojoKanbanBoard extends HTMLElement {
   private _getTaskDetail(): HTMLElement | null {
     return this._shadow.querySelector('dojo-task-detail');
   }
+
+  private _getDeleteDialog(): HTMLElement | null {
+    return this._shadow.querySelector('dojo-delete-confirm-dialog');
+  }
   private _onAddColumnRequest(): void {
     const dialog = this._getDialog() as any;
     if (dialog?.openCreate) dialog.openCreate();
@@ -730,6 +740,42 @@ export class DojoKanbanBoard extends HTMLElement {
       this._updateColumnCounts();
     } catch (err) {
       console.error('[dojo-kanban-board] Error al actualizar tarea:', err);
+    }
+  }
+  // ── Handlers de eliminación de tarea (US-06) ─────────────────────────────
+
+  private _onTaskDeleteRequest(e: CustomEvent): void {
+    const { taskId, taskTitle } = e.detail as { taskId: string; taskTitle: string };
+    const dialog = this._getDeleteDialog() as any;
+    if (dialog?.show) dialog.show(taskId, taskTitle);
+  }
+
+  private async _handleTaskDeleteConfirm(e: CustomEvent): Promise<void> {
+    const { taskId } = e.detail as { taskId: string };
+
+    // Localizar columna desde el caché
+    let columnId: string | null = null;
+    for (const [colId, tasks] of this._tasksByColumn) {
+      if (tasks.some(t => t.id === taskId)) { columnId = colId; break; }
+    }
+    if (!columnId) return;
+
+    try {
+      await deleteTask(taskId);
+
+      // Actualizar caché
+      const remaining = (this._tasksByColumn.get(columnId) ?? []).filter(t => t.id !== taskId);
+      this._tasksByColumn.set(columnId, remaining.map((t, i) => ({ ...t, order: i })));
+
+      // Cerrar panel de detalle si estaba mostrando esta tarea
+      const detail = this._getTaskDetail() as any;
+      if (detail?.close) detail.close();
+
+      // Refrescar columna + conteos
+      this._refreshColumnCards(columnId);
+      this._updateColumnCounts();
+    } catch (err) {
+      console.error('[dojo-kanban-board] Error al eliminar tarea:', err);
     }
   }
 }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -746,8 +746,12 @@ export class DojoKanbanBoard extends HTMLElement {
 
   private _onTaskDeleteRequest(e: CustomEvent): void {
     const { taskId, taskTitle } = e.detail as { taskId: string; taskTitle: string };
+    // Guardar referencia al elemento disparador para devolver el foco al cerrar (Fix #3)
+    const trigger = e.composedPath()
+      .find((el): el is HTMLElement => el instanceof HTMLElement && typeof (el as HTMLElement).focus === 'function'
+      ) ?? null;
     const dialog = this._getDeleteDialog() as any;
-    if (dialog?.show) dialog.show(taskId, taskTitle);
+    if (dialog?.show) dialog.show(taskId, taskTitle, trigger);
   }
 
   private async _handleTaskDeleteConfirm(e: CustomEvent): Promise<void> {
@@ -767,9 +771,9 @@ export class DojoKanbanBoard extends HTMLElement {
       const remaining = (this._tasksByColumn.get(columnId) ?? []).filter(t => t.id !== taskId);
       this._tasksByColumn.set(columnId, remaining.map((t, i) => ({ ...t, order: i })));
 
-      // Cerrar panel de detalle si estaba mostrando esta tarea
+      // Cerrar panel de detalle solo si estaba mostrando la tarea eliminada (Fix #1)
       const detail = this._getTaskDetail() as any;
-      if (detail?.close) detail.close();
+      if (detail?.currentTaskId === taskId && detail?.close) detail.close();
 
       // Refrescar columna + conteos
       this._refreshColumnCards(columnId);

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -470,6 +470,37 @@ export class DojoTaskDetail extends HTMLElement {
         flex-shrink: 0;
       }
 
+      /* ── Footer de peligro (US-06) ── */
+      .panel-footer {
+        flex-shrink: 0;
+        padding: 0.875rem 1.25rem;
+        border-top: 1px solid var(--dojo-border);
+        display: flex;
+        justify-content: flex-end;
+      }
+      .delete-task-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.4375rem 0.875rem;
+        background: transparent;
+        border: 1px solid #EF4444;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: #EF4444;
+        cursor: pointer;
+        font-family: inherit;
+        transition: background 0.15s, color 0.15s;
+      }
+      .delete-task-btn:hover {
+        background: #FEE2E2;
+      }
+      .delete-task-btn:focus-visible {
+        outline: 2px solid #EF4444;
+        outline-offset: 2px;
+      }
+
       /* ── Metadatos (solo lectura) ── */
       .metadata {
         border-top: 1px solid var(--dojo-border);
@@ -542,6 +573,25 @@ export class DojoTaskDetail extends HTMLElement {
     body.appendChild(this._buildMetadata(task));
 
     panel.appendChild(body);
+
+    // ── Footer de eliminación (US-06) ──────────────────────────────────────
+    const footer = document.createElement('div');
+    footer.className = 'panel-footer';
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'delete-task-btn';
+    deleteBtn.setAttribute('aria-label', `Eliminar tarea: ${task.title}`);
+    deleteBtn.textContent = '🗑 Eliminar tarea';
+    deleteBtn.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:task-delete-request', {
+        bubbles:  true,
+        composed: true,
+        detail:   { taskId: task.id, taskTitle: task.title },
+      }));
+    });
+
+    footer.appendChild(deleteBtn);
+    panel.appendChild(footer);
   }
 
   // ── Secciones del formulario ──────────────────────────────────────────────

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -99,6 +99,11 @@ export class DojoTaskDetail extends HTMLElement {
 
   // ── API pública ───────────────────────────────────────────────────────────
 
+  /** Id de la tarea actualmente en edición (null si el panel está cerrado). */
+  get currentTaskId(): string | null {
+    return this._task?.id ?? null;
+  }
+
   openTask(task: Task, columns: Column[], labels: Label[]): void {
     this._task           = { ...task };
     this._columns        = columns;


### PR DESCRIPTION
## Descripción

Implementa US-06: eliminación de tareas con confirmación previa.

## Cambios

### Nuevo organismo: `dojo-delete-confirm-dialog`
- Diálogo modal `role=\"alertdialog\"` con backdrop animado
- `show(taskId, taskTitle)`: nombre de tarea inyectado vía `textContent` (seguro contra XSS)
- Foco inicial en botón **Cancelar** (acción segura por defecto)
- `Escape` y click en backdrop cancelan sin eliminar
- Botón **Eliminar** emite `dojo:task-delete-confirm { taskId }`
- Focus trap (Tab) contiene el foco dentro del diálogo (WCAG 2.1 SC 2.1.2)

### Modificado: `dojo-task-card`
- Botón 🗑 de eliminación rápida visible en hover/focus-within
- `stopPropagation()` previene apertura del panel de detalle
- Emite `dojo:task-delete-request { taskId, taskTitle }`

### Modificado: `dojo-task-detail`
- Footer con botón **Eliminar tarea** (borde rojo, acción destructiva)
- Emite `dojo:task-delete-request { taskId, taskTitle }`

### Modificado: `dojo-kanban-board`
- Monta `dojo-delete-confirm-dialog`
- `_onTaskDeleteRequest()` → abre diálogo
- `_handleTaskDeleteConfirm()` → `deleteTask()` + actualiza caché + refresca columna + cierra panel de detalle

## Criterios de aceptación cubiertos

- ✅ Botón \"Eliminar tarea\" en el panel de detalle
- ✅ Diálogo muestra el título de la tarea a eliminar
- ✅ Confirmar → tarea eliminada de IndexedDB
- ✅ Tarjeta desaparece del tablero
- ✅ Panel de detalle se cierra
- ✅ Conteo de tareas actualizado
- ✅ Cancelar → tarea permanece intacta
- ✅ Botón de eliminación rápida en hover de tarjeta

Closes #7