### PR TITLE
feat(tasks): [US-08] Prioridad de tarea: iconos y filtro multi-selección

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -22,6 +22,7 @@
    - [Paso 8 — Implementación de la Gestión de Columnas del Tablero (US-02 / Issue #3)](#paso-8--implementación-de-la-gestión-de-columnas-del-tablero-us-02--issue-3)
    - [Paso 9 — Implementación de la Eliminación de Tareas (US-06 / Issue #7)](#paso-9--implementación-de-la-eliminación-de-tareas-us-06--issue-7)
    - [Paso 10 — Implementación de Descripción Markdown con bloques de código (US-07 / Issue #8)](#paso-10--implementación-de-descripción-markdown-con-bloques-de-código-us-07--issue-8)
+   - [Paso 11 — Implementación de Prioridad de Tarea (US-08 / Issue #9)](#paso-11--implementación-de-prioridad-de-tarea-us-08--issue-9)
 
 ---
 
@@ -980,4 +981,45 @@ Todo el parser Markdown usa manipulación DOM explícita (`document.createElemen
 | 4. XSS: scripts no ejecutados | US-05 / markdown.ts (`textContent`) |
 | 5. Parser propio sin dependencias externas | US-05 / markdown.ts |
 | 6. Descripción vacía → mensaje "Sin descripción" | US-05 |
+
+---
+
+### Paso 11 — Implementación de Prioridad de Tarea (US-08 / Issue #9)
+
+**Issue asociado:** [#9 — US-08 Prioridad de tarea](https://github.com/Code-Dojo-Labs/agent-app/issues/9)  
+**PR:** ✅ Mergeado en `init` — [#26](https://github.com/Code-Dojo-Labs/agent-app/pull/26)  
+**Branch:** `feat/9-prioridad-tarea`
+
+#### Descripción
+
+Implementa la visualización de prioridad con iconos standardizados (⬇️/➡️/⬆️/🔥) en tarjetas Kanban y el panel de detalle, y añade una barra de filtros por prioridad sobre el tablero. El tipo `Priority` y el campo en el modelo ya existían.
+
+#### Cambios por archivo
+
+| Archivo | Cambios |
+|---|---|
+| `dojo-task-card.ts` | `PRIORITY_CONFIG` actualizado con iconos US-08; `priority-dot` → `priority-icon` con emoji |
+| `dojo-task-dialog.ts` | `PRIORITIES` actualizado con iconos `⬇️/➡️/⬆️/🔥` |
+| `dojo-task-detail.ts` | `PRIORITIES` actualizado con iconos `⬇️/➡️/⬆️/🔥` |
+| `dojo-kanban-board.ts` | `ActiveFilter.priority → priorities?: Priority[]`; `_filterTasks()` multi-prioridad; `activeFilter` setter refresca columnas; barra de filtros `_buildFilterBar()` |
+
+#### Barra de filtros
+
+```
+[ Prioridad: ] [ ⬇️ Baja ] [ ➡️ Media ] [ ⬆️ Alta ] [ 🔥 Urgente ] [ ✕ Limpiar ]
+```
+
+- Toggle chips con `aria-pressed` — permite seleccionar 0 a 4 prioridades simultáneamente
+- Al cambiar selección: `activeFilter.priorities` se actualiza → `_refreshColumnCards()` por cada columna + `_updateColumnCounts()`
+- "✕ Limpiar" aparece solo cuando hay filtros activos
+- `role="group"` + `aria-label` en el contenedor (accesibilidad)
+
+#### Criterios US-08 cubiertos
+
+| Scenario | Estado |
+|---|---|
+| 1. Prioridad por defecto "medium" al crear tarea | ✅ `dojo-task-dialog` (pre-existente) |
+| 2. Ícono y texto en la tarjeta (⬇️/➡️/⬆️/🔥) | ✅ este PR |
+| 3. Cambiar prioridad desde panel de detalle | ✅ `dojo-task-detail` (selector + auto-save pre-existente, iconos fijados aquí) |
+| 4. Filtrar por una o más prioridades | ✅ este PR (`_buildFilterBar` + `_filterTasks`) |
 

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -101,10 +101,10 @@ export class DojoTaskCard extends HTMLElement {
   // ── Prioridades ───────────────────────────────────────────────────────────
 
   private static readonly PRIORITY_CONFIG = {
-    low:    { label: 'Baja',    color: 'var(--dojo-priority-low,    #3B82F6)' },
-    medium: { label: 'Media',   color: 'var(--dojo-priority-medium, #F59E0B)' },
-    high:   { label: 'Alta',    color: 'var(--dojo-priority-high,   #F97316)' },
-    urgent: { label: 'Urgente', color: 'var(--dojo-priority-urgent, #EF4444)' },
+    low:    { icon: '⬇️', label: 'Baja',    color: 'var(--dojo-priority-low,    #3B82F6)' },
+    medium: { icon: '➡️', label: 'Media',   color: 'var(--dojo-priority-medium, #F59E0B)' },
+    high:   { icon: '⬆️', label: 'Alta',    color: 'var(--dojo-priority-high,   #F97316)' },
+    urgent: { icon: '🔥', label: 'Urgente', color: 'var(--dojo-priority-urgent, #EF4444)' },
   } as const;
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -225,12 +225,10 @@ export class DojoTaskCard extends HTMLElement {
         gap: 0.375rem;
       }
 
-      .priority-dot {
-        width: 7px;
-        height: 7px;
-        border-radius: 50%;
+      .priority-icon {
+        font-size: 0.875rem;
+        line-height: 1;
         flex-shrink: 0;
-        background: ${pConfig.color};
       }
 
       .priority-label {
@@ -267,16 +265,17 @@ export class DojoTaskCard extends HTMLElement {
     footer.className = 'footer';
     footer.setAttribute('aria-label', `Prioridad: ${pConfig.label}`);
 
-    const dot = document.createElement('span');
-    dot.className = 'priority-dot';
-    dot.setAttribute('aria-hidden', 'true');
+    const iconEl = document.createElement('span');
+    iconEl.className = 'priority-icon';
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.textContent = pConfig.icon;
 
     const label = document.createElement('span');
     label.className = 'priority-label';
     label.setAttribute('aria-hidden', 'true');
     label.textContent = pConfig.label;
 
-    footer.appendChild(dot);
+    footer.appendChild(iconEl);
     footer.appendChild(label);
     this._shadow.appendChild(footer);
   }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -860,8 +860,13 @@ export class DojoKanbanBoard extends HTMLElement {
           sourceColumnId,
           tasks.map(t => t.id === taskId ? updated : t),
         );
-        // Refresco de tarjeta: solo re-renderizar si cambió título o prioridad
-        if (changes.title !== undefined || changes.priority !== undefined) {
+        // Refresco de tarjeta en la misma columna:
+        // Si hay filtro de prioridades activo y cambió la prioridad, refrescamos la columna
+        // completa para que las tarjetas que ya no cumplan el filtro desaparezcan (US-08 S4).
+        // En cualquier otro caso actualizamos solo los atributos para evitar re-render completo.
+        if (changes.priority !== undefined && this._activeFilter.priorities?.length) {
+          this._refreshColumnCards(sourceColumnId);
+        } else if (changes.title !== undefined || changes.priority !== undefined) {
           const colEl = this._shadow.querySelector(
             `dojo-kanban-column[column-id="${CSS.escape(sourceColumnId)}"]`
           );

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -28,7 +28,7 @@
  * --dojo-shadow, --dojo-radius, --dojo-primary
  */
 
-import type { Column, Task } from '../../../types/models.js';
+import type { Column, Task, Priority } from '../../../types/models.js';
 import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
 import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import { getAllLabels } from '../../../db/label.repository.js';
@@ -43,7 +43,7 @@ import '../../organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.js
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
 interface ActiveFilter {
-  priority?: string;
+  priorities?: Priority[];
   labelIds?: string[];
 }
 
@@ -79,6 +79,7 @@ export class DojoKanbanBoard extends HTMLElement {
    */
   set activeFilter(filter: ActiveFilter) {
     this._activeFilter = filter;
+    this._columns.forEach(col => this._refreshColumnCards(col.id));
     this._updateColumnCounts();
   }
 
@@ -169,8 +170,73 @@ export class DojoKanbanBoard extends HTMLElement {
         font-size: 0.875rem;
       }
       .retry-btn:hover { opacity: 0.9; }
+
+      /* ── Barra de filtros ── */
+      .filter-bar {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-bottom: 1px solid var(--dojo-border);
+        background: var(--dojo-surface);
+        flex-wrap: wrap;
+        flex-shrink: 0;
+        min-height: 40px;
+      }
+      .filter-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--dojo-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        white-space: nowrap;
+      }
+      .filter-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem 0.625rem;
+        background: transparent;
+        border: 1px solid var(--dojo-border);
+        border-radius: 999px;
+        font-size: 0.75rem;
+        color: var(--dojo-text-secondary);
+        cursor: pointer;
+        font-family: inherit;
+        transition: background 0.14s, color 0.14s, border-color 0.14s;
+        white-space: nowrap;
+      }
+      .filter-chip:hover {
+        background: var(--dojo-bg);
+        border-color: var(--dojo-text-secondary);
+        color: var(--dojo-text-primary);
+      }
+      .filter-chip.active {
+        background: var(--dojo-primary, #1D4ED8);
+        border-color: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-weight: 600;
+      }
+      .filter-chip:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+      .filter-clear {
+        padding: 0.25rem 0.5rem;
+        background: transparent;
+        border: none;
+        font-size: 0.75rem;
+        color: var(--dojo-text-secondary);
+        cursor: pointer;
+        font-family: inherit;
+        text-decoration: underline;
+      }
+      .filter-clear:hover { color: var(--dojo-text-primary); }
     `;
     this._shadow.appendChild(style);
+
+    // Barra de filtros de prioridad (US-08)
+    this._shadow.appendChild(this._buildFilterBar());
 
     // Área principal — empieza en estado loading
     this._showLoading();
@@ -202,6 +268,76 @@ export class DojoKanbanBoard extends HTMLElement {
     this._shadow.appendChild(deleteDialog);
     this._shadow.addEventListener('dojo:task-delete-request',  (e) => this._onTaskDeleteRequest(e as CustomEvent));
     this._shadow.addEventListener('dojo:task-delete-confirm',  (e) => this._handleTaskDeleteConfirm(e as CustomEvent));
+  }
+
+  // ── Barra de filtros (US-08) ─────────────────────────────────────────────
+
+  private _buildFilterBar(): HTMLElement {
+    const FILTER_PRIORITIES: { value: Priority; icon: string; label: string }[] = [
+      { value: 'low',    icon: '⬇️', label: 'Baja'    },
+      { value: 'medium', icon: '➡️', label: 'Media'   },
+      { value: 'high',   icon: '⬆️', label: 'Alta'    },
+      { value: 'urgent', icon: '🔥', label: 'Urgente' },
+    ];
+
+    const bar = document.createElement('div');
+    bar.className = 'filter-bar';
+    bar.setAttribute('role', 'group');
+    bar.setAttribute('aria-label', 'Filtrar por prioridad');
+
+    const lbl = document.createElement('span');
+    lbl.className = 'filter-label';
+    lbl.textContent = 'Prioridad:';
+    bar.appendChild(lbl);
+
+    const selectedPriorities = new Set<Priority>();
+
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'filter-clear';
+    clearBtn.type = 'button';
+    clearBtn.textContent = '✕ Limpiar';
+    clearBtn.setAttribute('aria-label', 'Limpiar filtros de prioridad');
+    clearBtn.style.display = 'none';
+
+    for (const p of FILTER_PRIORITIES) {
+      const btn = document.createElement('button');
+      btn.className = 'filter-chip';
+      btn.type = 'button';
+      btn.setAttribute('aria-pressed', 'false');
+      btn.setAttribute('data-priority', p.value);
+      btn.textContent = `${p.icon} ${p.label}`;
+      btn.addEventListener('click', () => {
+        const isActive = selectedPriorities.has(p.value);
+        if (isActive) {
+          selectedPriorities.delete(p.value);
+          btn.classList.remove('active');
+          btn.setAttribute('aria-pressed', 'false');
+        } else {
+          selectedPriorities.add(p.value);
+          btn.classList.add('active');
+          btn.setAttribute('aria-pressed', 'true');
+        }
+        clearBtn.style.display = selectedPriorities.size > 0 ? '' : 'none';
+        const newPriorities = selectedPriorities.size > 0
+          ? (Array.from(selectedPriorities) as Priority[])
+          : undefined;
+        this.activeFilter = { ...this._activeFilter, priorities: newPriorities };
+      });
+      bar.appendChild(btn);
+    }
+
+    clearBtn.addEventListener('click', () => {
+      selectedPriorities.clear();
+      bar.querySelectorAll<HTMLButtonElement>('.filter-chip').forEach(b => {
+        b.classList.remove('active');
+        b.setAttribute('aria-pressed', 'false');
+      });
+      clearBtn.style.display = 'none';
+      this.activeFilter = { ...this._activeFilter, priorities: undefined };
+    });
+    bar.appendChild(clearBtn);
+
+    return bar;
   }
 
   // ── Estados visuales ─────────────────────────────────────────────────────
@@ -339,8 +475,9 @@ export class DojoKanbanBoard extends HTMLElement {
    * Las tarjetas se proyectan en el default slot del componente.
    */
   private _renderTaskCards(colEl: Element, tasks: Task[]): void {
-    const sorted = [...tasks].sort((a, b) => a.order - b.order);
-    for (const task of sorted) {
+    const sorted   = [...tasks].sort((a, b) => a.order - b.order);
+    const filtered = this._filterTasks(sorted);
+    for (const task of filtered) {
       const card = document.createElement('dojo-task-card');
       card.setAttribute('task-id',       task.id);
       card.setAttribute('task-title',    task.title);
@@ -372,9 +509,9 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private _filterTasks(tasks: Task[]): Task[] {
-    const { priority, labelIds } = this._activeFilter;
+    const { priorities, labelIds } = this._activeFilter;
     return tasks.filter(task => {
-      if (priority && task.priority !== priority) return false;
+      if (priorities && priorities.length > 0 && !priorities.includes(task.priority)) return false;
       if (labelIds && labelIds.length > 0) {
         const taskLabelIds = task.labelIds ?? [];
         const hasLabel = labelIds.some(id => taskLabelIds.includes(id));

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -33,10 +33,10 @@ import { pickTextColor } from '../../../utils/contrast.js';
 // ── Constantes ─────────────────────────────────────────────────────────────
 
 const PRIORITIES: { value: Priority; label: string; icon: string }[] = [
-  { value: 'low',    label: 'Baja',    icon: '🔵' },
-  { value: 'medium', label: 'Media',   icon: '🟡' },
-  { value: 'high',   label: 'Alta',    icon: '🟠' },
-  { value: 'urgent', label: 'Urgente', icon: '🔴' },
+  { value: 'low',    label: 'Baja',    icon: '⬇️' },
+  { value: 'medium', label: 'Media',   icon: '➡️' },
+  { value: 'high',   label: 'Alta',    icon: '⬆️' },
+  { value: 'urgent', label: 'Urgente', icon: '🔥' },
 ];
 
 // ── Clase ──────────────────────────────────────────────────────────────────

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -27,10 +27,10 @@
 import type { Priority } from '../../../types/models.js';
 
 const PRIORITIES: { value: Priority; label: string }[] = [
-  { value: 'low',    label: '🔵 Baja'    },
-  { value: 'medium', label: '🟡 Media'   },
-  { value: 'high',   label: '🟠 Alta'    },
-  { value: 'urgent', label: '🔴 Urgente' },
+  { value: 'low',    label: '⬇️ Baja'    },
+  { value: 'medium', label: '➡️ Media'   },
+  { value: 'high',   label: '⬆️ Alta'    },
+  { value: 'urgent', label: '🔥 Urgente' },
 ];
 
 export class DojoTaskDialog extends HTMLElement {


### PR DESCRIPTION
## Cambios

Implementa **US-08** (Prioridad de tarea): visualización con iconos estandarizados y filtrado multi-prioridad.

### Iconos de prioridad (US-08 Scenario 2)

| Prioridad | Ícono | Texto   |
|-----------|-------|---------|
| low       | ⬇️    | Baja    |
| medium    | ➡️    | Media   |
| high      | ⬆️    | Alta    |
| urgent    | 🔥    | Urgente |

Actualizado en: tarjeta Kanban, dialog de creación y panel de detalle.

### Barra de filtros por prioridad (US-08 Scenario 4)

Chips toggle sobre el tablero: selección múltiple de 0-4 prioridades. Al cambiar la selección se refresca la visibilidad de tarjetas en todas las columnas y se actualizan los conteos (X/Y). Botón "✕ Limpiar" aparece cuando hay filtros activos.

### Cambios técnicos
- `ActiveFilter.priority` (single) → `priorities?: Priority[]` (multi)
- `_filterTasks()` soporta múltiples prioridades (`includes()`)
- `_renderTaskCards()` aplica filtro antes de renderizar
- `activeFilter` setter refresca columnas (`_refreshColumnCards`) además de conteos
- `_buildFilterBar()`: nuevo método privado con chips ARIA (`aria-pressed`, `role="group"`)

Closes #9