### PR TITLE
[US-11] feat(labels): panel de gestión de etiquetas con edición y propagación al tablero

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -25,6 +25,7 @@
    - [Paso 11 — Implementación de Prioridad de Tarea (US-08 / Issue #9)](#paso-11--implementación-de-prioridad-de-tarea-us-08--issue-9)
    - [Paso 12 — Implementación de Crear Etiqueta (US-09 / Issue #10)](#paso-12--implementación-de-crear-etiqueta-us-09--issue-10)
    - [Paso 13 — Implementación de Reutilización de Etiquetas (US-10 / Issue #11)](#paso-13--implementación-de-reutilización-de-etiquetas-us-10--issue-11)
+   - [Paso 14 — Implementación de Editar Etiqueta (US-11 / Issue #12)](#paso-14--implementación-de-editar-etiqueta-us-11--issue-12)
 
 ---
 
@@ -1224,4 +1225,98 @@ Antes de aplicar `backgroundColor`, el chip valida el color contra la expresión
 | B: Atributo JSON serializado | `card.setAttribute('task-labels', JSON.stringify(...))` — más frágil y detectable en DevTools como ruido | Descartado |
 
 **Justificación:** Los Web Components permiten comunicar estado complejo a través de propiedades JS, reservando los atributos HTML para datos primitivos (IDs, flags semánticos). Serializar/deserializar JSON en atributos añade garbage colection overhead y expone datos internos como texto en el DOM inspeccionable.
+
+---
+
+### Paso 14 — Implementación de Editar Etiqueta (US-11 / Issue #12)
+
+**Fecha:** 2026-03-26  
+**Agente ejecutor:** `builder`  
+**Issue asociado:** [#12 — US-11 Editar etiqueta](https://github.com/Code-Dojo-Labs/agent-app/issues/12)  
+**Branch:** `feat/12-editar-etiqueta` (basada en `feat/11-reutilizacion-etiquetas`)
+
+#### Descripción
+
+Este paso implementa el **panel de administración de etiquetas** accesible desde el header de la aplicación. El usuario puede editar el nombre o el color de cualquier etiqueta, y los cambios se propagan automáticamente a todos los chips visibles en el tablero, sin necesidad de recargar.
+
+#### Archivos nuevos
+
+| Archivo | Descripción |
+|---|---|
+| `src/components/organisms/dojo-label-manager/dojo-label-manager.ts` | Nuevo organismo: panel lateral slide-in con listado y formulario de edición inline por etiqueta |
+
+#### Archivos modificados
+
+| Archivo | Cambios |
+|---|---|
+| `src/components/organisms/dojo-app/dojo-app.ts` | Botón "Gestionar etiquetas" en header; monta `<dojo-label-manager>`; listener `dojo:label-updated` que llama a `board.refreshLabel()` |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | Nuevo método público `refreshLabel(label)` que actualiza `_labels[]` y refresca los chips de las tarjetas afectadas |
+
+#### Arquitectura de comunicación (US-11)
+
+```
+Usuario hace clic en "Gestionar etiquetas" (header)
+            │
+            ▼
+  dojo-app llama a labelMgr.show()
+            │
+            ▼
+  dojo-label-manager carga getAllLabels() → muestra lista
+            │
+  Usuario hace clic en ✏️ → formulario inline por etiqueta
+            │
+  Usuario guarda → updateLabel(id, { name, color })
+            │
+            ▼
+  dojo:label-updated (bubbles+composed) sube hasta dojo-app Shadow Root
+            │
+            ▼
+  dojo-app listener → board.refreshLabel(label)
+            │
+            ▼
+  dojo-kanban-board._labels[] actualizado
+  Para cada tarea con ese labelId → card.taskLabels = _getTaskLabels(task)
+            │
+            ▼
+  dojo-task-card setter → _render() → chips actualizados sin recargar bd
+```
+
+#### `dojo-label-manager` — API pública
+
+| Método  | Descripción |
+|---|---|
+| `show()` | Carga todas las etiquetas y muestra el panel con animación slide-in |
+| `hide()` | Cierra el panel; también responde a clic en backdrop y tecla Escape |
+
+#### Selectores CSS de `dojo-label-manager`
+
+| Selector | Propósito |
+|---|---|
+| `.backdrop` | Capa oscura semitransparente; click cierra el panel |
+| `.panel` | Drawer lateral derecho, width `min(360px, 100vw)`, slide-in |
+| `.panel-header` | Título + botón de cierre (✕) |
+| `.panel-content` | Área desplazable con la lista |
+| `.label-list` | `<ul role="list">` de todas las etiquetas |
+| `.label-row` | Fila: dot color + nombre + botón editar |
+| `.edit-form` | Formulario inline de edición (nombre + paleta + acciones) |
+| `.color-swatch` | Swatch de la paleta (mismo estilo que en `dojo-task-detail`) |
+| `.edit-name-input` | Campo de texto para el nombre (max 30 chars) |
+
+#### Criterios US-11 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| 1. Acceder al panel de administración desde el header | ✅ Botón "Gestionar etiquetas" en `.app-header` |
+| 2. Editar el nombre de una etiqueta | ✅ `updateLabel()` + detección de duplicados por repositorio |
+| 3. Editar el color de una etiqueta | ✅ Paleta de 12 colores + color personalizado (`<input type="color">`) |
+| 4. Propagación automática a tarjetas visibles | ✅ `board.refreshLabel()` itera `_tasksByColumn` y actualiza `.taskLabels` |
+
+#### Decisión de diseño: Panel en `dojo-app` vs. dentro de `dojo-kanban-board`
+
+| Opción | Descripción | Decisión |
+|---|---|---|
+| **A: Panel en `dojo-app`** | El botón y el panel de gestión viven en el nivel de la app raíz | ✅ Elegida |
+| B: Panel dentro del board | El botón estaría en la barra de filtros, el panel en el shadow del board | Descartada |
+
+**Justificación:** El issue especifica "botón en el header de la aplicación". El header está en `dojo-app`. Para evitar que el organismo board asuma responsabilidades de gestión global, el panel de etiquetas se monta en el shadow de `dojo-app`, que actúa como coordinador de nivel de aplicación.
 

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -23,6 +23,8 @@
    - [Paso 9 — Implementación de la Eliminación de Tareas (US-06 / Issue #7)](#paso-9--implementación-de-la-eliminación-de-tareas-us-06--issue-7)
    - [Paso 10 — Implementación de Descripción Markdown con bloques de código (US-07 / Issue #8)](#paso-10--implementación-de-descripción-markdown-con-bloques-de-código-us-07--issue-8)
    - [Paso 11 — Implementación de Prioridad de Tarea (US-08 / Issue #9)](#paso-11--implementación-de-prioridad-de-tarea-us-08--issue-9)
+   - [Paso 12 — Implementación de Crear Etiqueta (US-09 / Issue #10)](#paso-12--implementación-de-crear-etiqueta-us-09--issue-10)
+   - [Paso 13 — Implementación de Reutilización de Etiquetas (US-10 / Issue #11)](#paso-13--implementación-de-reutilización-de-etiquetas-us-10--issue-11)
 
 ---
 
@@ -1022,4 +1024,204 @@ Implementa la visualización de prioridad con iconos standardizados (⬇️/➡�
 | 2. Ícono y texto en la tarjeta (⬇️/➡️/⬆️/🔥) | ✅ este PR |
 | 3. Cambiar prioridad desde panel de detalle | ✅ `dojo-task-detail` (selector + auto-save pre-existente, iconos fijados aquí) |
 | 4. Filtrar por una o más prioridades | ✅ este PR (`_buildFilterBar` + `_filterTasks`) |
+
+---
+
+### Paso 12 — Implementación de Crear Etiqueta (US-09 / Issue #10)
+
+**Fecha:** 2026-03-26  
+**Agente ejecutor:** `builder`  
+**Issue asociado:** [#10 — US-09 Crear etiqueta](https://github.com/Code-Dojo-Labs/agent-app/issues/10)  
+**PR:** 🔄 En revisión — [#27](https://github.com/Code-Dojo-Labs/agent-app/pull/27)  
+**Branch:** `feat/10-crear-etiqueta`
+
+#### Descripción
+
+El agente Builder implementó el flujo completo de **búsqueda en tiempo real y creación inline de etiquetas** directamente desde el panel de detalle de tarea (`dojo-task-detail`). La infraestructura subyacente (modelo `Label`, repositorio `label.repository.ts`, Object Store en IndexedDB) ya existía; este paso añade la capa de interfaz de usuario.
+
+#### Archivo modificado
+
+| Archivo | Cambios |
+|---|---|
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Import de `createLabel`; ~90 líneas de CSS nuevas; `_buildLabelsField` refactorizado (400 → 460 líneas netas) |
+
+#### Lógica de implementación
+
+**Estado de cierre del picker** (variables de closure locales en `_buildLabelsField`):
+
+| Variable | Tipo | Propósito |
+|---|---|---|
+| `searchTerm` | `string` | Término actual del campo de búsqueda |
+| `showCreateForm` | `boolean` | Indica si el formulario inline de creación está visible |
+| `pendingColor` | `string` | Color seleccionado para la nueva etiqueta |
+
+**Flujo de creación:**
+
+```
+Usuario escribe en el campo de búsqueda
+        │
+        ▼
+_allLabels filtrado en tiempo real (includes, case-insensitive)
+        │
+   ┌────┴────┐
+   │ Hay     │ No hay coincidencia exacta
+   │ match   │        │
+   │ exacto  │        ▼
+   │         │  Muestra "Crear etiqueta '[nombre]'"
+   └────┬────┘        │
+        │             ▼ (click)
+        │        showCreateForm = true → renderPicker()
+        │             │
+        │             ▼
+        │    Formulario inline:
+        │    - 12 colores predefinidos (swatches)
+        │    - <input type="color"> personalizado
+        │    - Botones Cancelar / Crear
+        │             │
+        │             ▼ (click Crear)
+        │    createLabel({ name, color }) → IndexedDB
+        │    auto-assign: _save({ labelIds: [..., newLabel.id] })
+        │    _allLabels actualizado en memoria
+        │    renderChips() + renderPicker() + cerrar picker
+        │
+        ▼
+   Chip de la etiqueta aparece inmediatamente en el panel
+```
+
+#### Paleta de colores predefinidos (12 colores)
+
+| Índice | Hex | Color |
+|---|---|---|
+| 0 | `#EF4444` | Rojo |
+| 1 | `#F97316` | Naranja |
+| 2 | `#F59E0B` | Ámbar |
+| 3 | `#EAB308` | Amarillo |
+| 4 | `#22C55E` | Verde |
+| 5 | `#10B981` | Esmeralda |
+| 6 | `#3B82F6` | Azul |
+| 7 | `#6366F1` | Índigo |
+| 8 | `#8B5CF6` | Violeta |
+| 9 | `#EC4899` | Rosa |
+| 10 | `#06B6D4` | Cian |
+| 11 | `#84CC16` | Lima |
+
+#### Selectores CSS añadidos
+
+| Selector | Propósito |
+|---|---|
+| `.labels-search` | Campo de búsqueda en el picker |
+| `.label-create-option` | Opción "Crear etiqueta '[nombre]'" |
+| `.label-create-form` | Contenedor del formulario inline |
+| `.label-create-form-title` | Título del formulario ("Color para…") |
+| `.label-color-palette` | Contenedor de swatches de color |
+| `.color-swatch` | Botón circular de color predefinido |
+| `.label-custom-color-row` | Fila con `<input type="color">` |
+| `.label-color-input` | Input de color personalizado |
+| `.label-error` | Mensaje de error con `role="alert"` |
+| `.label-create-actions` | Fila de acciones (Cancelar / Crear) |
+| `.label-btn` | Botón genérico (Cancelar) |
+| `.label-btn-primary` | Botón primario (Crear) |
+
+#### Criterios US-09 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| 1. Crear etiqueta desde selector de etiquetas de una tarea | ✅ Flujo completo implementado |
+| 2. Nombre de etiqueta obligatorio | ✅ Validación a nivel UI y repositorio |
+| 3. Nombre de etiqueta con máximo 30 caracteres | ✅ `maxLength=30` en `searchInput` |
+| 4. Color de etiqueta obligatorio | ✅ Pre-selección de color por defecto; error si `!pendingColor` |
+| 5. Búsqueda en tiempo real entre etiquetas existentes | ✅ Filtrado `includes()` case-insensitive en `renderPicker()` |
+
+#### Decisión de diseño: Import directo de `createLabel` en `dojo-task-detail`
+
+Se evaluaron dos opciones para la creación de etiquetas:
+
+| Opción | Descripción | Decisión |
+|---|---|---|
+| **A: Import directo** | `dojo-task-detail` importa `createLabel` y lo llama directamente | ✅ Elegida |
+| B: Event-driven | `dojo-task-detail` despacha `dojo:label-create`; `dojo-kanban-board` lo maneja | Descartada |
+
+**Justificación:** La creación de etiquetas es parte inherente del flujo de edición de tareas, que ya reside en `dojo-task-detail`. Añadir un event round-trip añadiría complejidad sin beneficio de desacoplamiento real, dado que la etiqueta creada se persiste en IndexedDB (accesible globalmente). La próxima vez que `_onTaskOpen` en el board llame a `getAllLabels()`, la nueva etiqueta estará disponible automáticamente.
+
+---
+
+### Paso 13 — Implementación de Reutilización de Etiquetas (US-10 / Issue #11)
+
+**Fecha:** 2026-03-26  
+**Agente ejecutor:** `builder`  
+**Issue asociado:** [#11 — US-10 Reutilización de etiquetas](https://github.com/Code-Dojo-Labs/agent-app/issues/11)  
+**Branch:** `feat/11-reutilizacion-etiquetas` (basada en `feat/10-crear-etiqueta`)
+
+#### Descripción
+
+Este paso añade la **visualización de chips de etiquetas en las tarjetas del tablero Kanban** y la **detección de duplicados por diferencia de capitalización** en el selector de etiquetas. El objetivo es que el usuario vea, de un vistazo en el tablero, qué etiquetas tiene cada tarea, sin necesidad de abrir el panel de detalle.
+
+#### Archivos modificados
+
+| Archivo | Cambios |
+|---|---|
+| `src/components/atoms/dojo-task-card/dojo-task-card.ts` | Imports `Label` + `pickTextColor`; campo `_labels`; getter/setter `taskLabels`; CSS `.chip-row` / `.task-label-chip`; render de chips entre título y footer |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | `Label` en type imports; campo `_labels`; carga paralela en `_loadBoard`; setter `taskLabels` en `_renderTaskCards`; helpers `_getTaskLabels` y `_handleLabelCreated`; listener `dojo:label-created`; propagación de cambios en `_handleTaskFieldUpdated` |
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Despacha `dojo:label-created` tras crear etiqueta; aviso de duplicado por diferente capitalización; CSS `.label-info-notice` |
+
+#### Arquitectura de comunicación (US-10)
+
+```
+[dojo-task-detail] ── dojo:label-created (bubbles+composed) ──▶ [dojo-kanban-board]
+                                                                         │
+                                                               _handleLabelCreated()
+                                                               actualiza _labels[]
+                                                               (caché en memoria)
+
+[dojo-kanban-board]
+  _loadBoard()   ── Promise.all([getAllColumns(), getAllLabels()]) ──▶ IndexedDB
+  _renderTaskCards() ── .taskLabels = _getTaskLabels(task) ──▶ [dojo-task-card]
+  _handleTaskFieldUpdated() ── si changes.labelIds ──▶ actualiza card.taskLabels
+```
+
+#### Propiedad `taskLabels` en `dojo-task-card`
+
+La tarjeta recibe un array de objetos `Label` mediante la propiedad JS (no atributo HTML, ya que los atributos son siempre strings). El setter llama a `_render()` si el elemento está conectado, lo que garantiza re-render reactivo ante cualquier cambio de etiquetas desde el tablero.
+
+```typescript
+set taskLabels(labels: Label[]) {
+  this._labels = [...labels];
+  if (this.isConnected) this._render();
+}
+```
+
+#### Seguridad del color en chips
+
+Antes de aplicar `backgroundColor`, el chip valida el color contra la expresión regular `/^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/`. Si no pasa la validación (p.ej., valor corrupto en BD), usa `var(--dojo-border)` como fallback. El contraste de texto se delega a `pickTextColor()` de `utils/contrast.ts`, con `try/catch` para aislar posibles errores en valores edge.
+
+#### Selectores CSS añadidos en `dojo-task-card`
+
+| Selector | Propósito |
+|---|---|
+| `.chip-row` | Fila flex envolvente de chips de etiquetas |
+| `.task-label-chip` | Chip individual: color de fondo dinámico, texto truncado a 80 px |
+
+#### Selectores CSS añadidos en `dojo-task-detail`
+
+| Selector | Propósito |
+|---|---|
+| `.label-info-notice` | Aviso informativo cuando el nombre tecleado coincide (sin distinguir mayúsculas) con una etiqueta existente |
+
+#### Criterios US-10 cubiertos
+
+| Scenario | Estado |
+|---|---|
+| S1 — Asignar etiqueta existente a una tarea (picker con scroll) | ✅ Heredado de US-09; picker funciona con lista completa |
+| S2 — Prevención de duplicados por capitalización diferente | ✅ `else` branch en `renderPicker()` muestra `.label-info-notice` |
+| S3 — Ver etiquetas asignadas en las tarjetas del tablero | ✅ Chips `.task-label-chip` renderizados en `dojo-task-card` |
+| S4 — Etiqueta nueva visible en el tablero sin recargar | ✅ `dojo:label-created` actualiza `_labels[]` en el board; setter `taskLabels` re-renderiza la tarjeta activa |
+
+#### Decisión de diseño: Propiedad JS vs. atributo HTML para `taskLabels`
+
+| Opción | Descripción | Decisión |
+|---|---|---|
+| **A: Propiedad JS** | `card.taskLabels = Label[]` — permite pasar objetos complejos | ✅ Elegida |
+| B: Atributo JSON serializado | `card.setAttribute('task-labels', JSON.stringify(...))` — más frágil y detectable en DevTools como ruido | Descartado |
+
+**Justificación:** Los Web Components permiten comunicar estado complejo a través de propiedades JS, reservando los atributos HTML para datos primitivos (IDs, flags semánticos). Serializar/deserializar JSON en atributos añade garbage colection overhead y expone datos internos como texto en el DOM inspeccionable.
 

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -11,6 +11,11 @@
  * | task-title     | string | Título visible (máx. 120 chars)         |
  * | task-priority  | string | low | medium | high | urgent             |
  *
+ * ## Propiedades públicas
+ * | Propiedad   | Tipo     | Descripción                                     |
+ * |-------------|----------|-------------------------------------------------|
+ * | taskLabels  | Label[]  | Etiquetas asociadas; re-renderiza automáticamente|
+ *
  * ## Eventos despachados
  * | Nombre          | Detalle          | Descripción                      |
  * |-----------------|------------------|----------------------------------|
@@ -23,6 +28,9 @@
  * --dojo-priority-high, --dojo-priority-urgent
  */
 
+import type { Label } from '../../../types/models.js';
+import { pickTextColor } from '../../../utils/contrast.js';
+
 export class DojoTaskCard extends HTMLElement {
   static readonly TAG = 'dojo-task-card';
 
@@ -31,6 +39,15 @@ export class DojoTaskCard extends HTMLElement {
   }
 
   private _shadow: ShadowRoot;
+
+  /** Etiquetas asociadas a esta tarjeta (US-10) */
+  private _labels: Label[] = [];
+
+  get taskLabels(): Label[] { return this._labels; }
+  set taskLabels(labels: Label[]) {
+    this._labels = [...labels];
+    if (this.isConnected) this._render();
+  }
 
   constructor() {
     super();
@@ -237,6 +254,28 @@ export class DojoTaskCard extends HTMLElement {
         text-transform: uppercase;
         letter-spacing: 0.03em;
       }
+
+      /* Chips de etiquetas (US-10) */
+      .chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.1875rem;
+        margin-top: 0.25rem;
+        margin-bottom: 0.25rem;
+      }
+      .task-label-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.1rem 0.375rem;
+        border-radius: 999px;
+        font-size: 0.625rem;
+        font-weight: 500;
+        line-height: 1.4;
+        max-width: 80px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -259,6 +298,27 @@ export class DojoTaskCard extends HTMLElement {
     titleEl.className = 'title';
     titleEl.textContent = this.taskTitle; // textContent es seguro contra XSS
     this._shadow.appendChild(titleEl);
+
+    // Chips de etiquetas (US-10)
+    if (this._labels.length > 0) {
+      const HEX_COLOR_RE = /^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/;
+      const chipRow = document.createElement('div');
+      chipRow.className = 'chip-row';
+      chipRow.setAttribute('aria-label', 'Etiquetas');
+      for (const lbl of this._labels) {
+        const chip = document.createElement('span');
+        chip.className = 'task-label-chip';
+        chip.textContent = lbl.name;
+        if (HEX_COLOR_RE.test(lbl.color)) {
+          chip.style.backgroundColor = lbl.color;
+          try { chip.style.color = pickTextColor(lbl.color); } catch { chip.style.color = '#fff'; }
+        } else {
+          chip.style.backgroundColor = 'var(--dojo-border)';
+        }
+        chipRow.appendChild(chip);
+      }
+      this._shadow.appendChild(chipRow);
+    }
 
     // Footer de prioridad
     const footer = document.createElement('div');

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -309,6 +309,7 @@ export class DojoTaskCard extends HTMLElement {
         const chip = document.createElement('span');
         chip.className = 'task-label-chip';
         chip.textContent = lbl.name;
+        chip.setAttribute('title', lbl.name); // Tooltip para nombres truncados (WCAG 2.1 SC 1.4.4)
         if (HEX_COLOR_RE.test(lbl.color)) {
           chip.style.backgroundColor = lbl.color;
           try { chip.style.color = pickTextColor(lbl.color); } catch { chip.style.color = '#fff'; }

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -13,6 +13,9 @@
  */
 
 import '../dojo-kanban-board/dojo-kanban-board.js';
+import '../dojo-label-manager/dojo-label-manager.js';
+
+import type { Label } from '../../../types/models.js';
 
 export class DojoApp extends HTMLElement {
   static readonly TAG = 'dojo-app';
@@ -72,6 +75,33 @@ export class DojoApp extends HTMLElement {
         margin-left: auto;
       }
 
+      /* Botón Gestionar etiquetas */
+      .manage-labels-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.3125rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s, border-color 0.15s;
+        margin-left: auto;
+        white-space: nowrap;
+      }
+      .manage-labels-btn:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .manage-labels-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
       /* ── Área del tablero (ocupa el espacio restante) ─────────────── */
       .board-area {
         flex: 1;
@@ -102,12 +132,27 @@ export class DojoApp extends HTMLElement {
     subtitle.className = 'app-subtitle';
     subtitle.textContent = 'Zero Dependencies';
 
+    const manageLabelBtn = document.createElement('button');
+    manageLabelBtn.className = 'manage-labels-btn';
+    manageLabelBtn.type = 'button';
+    manageLabelBtn.setAttribute('aria-label', 'Gestionar etiquetas');
+    const btnIcon = document.createElement('span');
+    btnIcon.setAttribute('aria-hidden', 'true');
+    btnIcon.textContent = '🏷️';
+    const btnText = document.createElement('span');
+    btnText.textContent = 'Gestionar etiquetas';
+    manageLabelBtn.appendChild(btnIcon);
+    manageLabelBtn.appendChild(btnText);
+    manageLabelBtn.addEventListener('click', () => {
+      (labelMgr as any).show();
+    });
+
     appHeader.appendChild(logo);
     appHeader.appendChild(title);
-    appHeader.appendChild(subtitle);
+    appHeader.appendChild(manageLabelBtn);
     this._shadow.appendChild(appHeader);
 
-    // ── Área del tablero ────────────────────────────────────────────────────
+    // ── Área del tablero ────────────────────────────────────────────────────────────────────
     const boardArea = document.createElement('main');
     boardArea.className = 'board-area';
     boardArea.setAttribute('role', 'main');
@@ -115,6 +160,16 @@ export class DojoApp extends HTMLElement {
     const board = document.createElement('dojo-kanban-board');
     boardArea.appendChild(board);
     this._shadow.appendChild(boardArea);
+
+    // ── Panel de gestión de etiquetas (US-11) ───────────────────────────────────────
+    const labelMgr = document.createElement('dojo-label-manager');
+    this._shadow.appendChild(labelMgr);
+
+    // Cuando se actualiza una etiqueta, propagar al tablero para refrescar los chips
+    this._shadow.addEventListener('dojo:label-updated', (e: Event) => {
+      const { label } = (e as CustomEvent).detail as { label: Label };
+      (board as any).refreshLabel?.(label);
+    });
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -28,7 +28,7 @@
  * --dojo-shadow, --dojo-radius, --dojo-primary
  */
 
-import type { Column, Task, Priority } from '../../../types/models.js';
+import type { Column, Task, Label, Priority } from '../../../types/models.js';
 import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
 import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import { getAllLabels } from '../../../db/label.repository.js';
@@ -58,6 +58,8 @@ export class DojoKanbanBoard extends HTMLElement {
   private _tasksByColumn: Map<string, Task[]> = new Map();
   /** Lista ordenada de columnas actualmente cargadas */
   private _columns: Column[] = [];
+  /** Lista completa de etiquetas (US-10) */
+  private _labels: Label[] = [];
 
   constructor() {
     super();
@@ -268,6 +270,8 @@ export class DojoKanbanBoard extends HTMLElement {
     this._shadow.appendChild(deleteDialog);
     this._shadow.addEventListener('dojo:task-delete-request',  (e) => this._onTaskDeleteRequest(e as CustomEvent));
     this._shadow.addEventListener('dojo:task-delete-confirm',  (e) => this._handleTaskDeleteConfirm(e as CustomEvent));
+    // US-10: sincronizar etiquetas nuevas creadas desde el panel de detalle
+    this._shadow.addEventListener('dojo:label-created',        (e) => this._handleLabelCreated(e as CustomEvent));
   }
 
   // ── Barra de filtros (US-08) ─────────────────────────────────────────────
@@ -411,7 +415,11 @@ export class DojoKanbanBoard extends HTMLElement {
     this._tasksByColumn.clear();
 
     try {
-      const columns = await getAllColumns();
+      const [columns, labels] = await Promise.all([
+        getAllColumns(),
+        getAllLabels(),
+      ]);
+      this._labels = labels;
 
       // Cargar tareas de todas las columnas en paralelo
       const taskResults = await Promise.all(
@@ -482,6 +490,7 @@ export class DojoKanbanBoard extends HTMLElement {
       card.setAttribute('task-id',       task.id);
       card.setAttribute('task-title',    task.title);
       card.setAttribute('task-priority', task.priority);
+      (card as any).taskLabels = this._getTaskLabels(task);
       colEl.appendChild(card);
     }
   }
@@ -506,6 +515,23 @@ export class DojoKanbanBoard extends HTMLElement {
     const total = tasks.length;
     const visible = this._filterTasks(tasks).length;
     return { visible, total };
+  }
+
+  /** Resuelve los objetos Label para una tarea a partir del caché local (US-10). */
+  private _getTaskLabels(task: Task): Label[] {
+    return (task.labelIds ?? [])
+      .map(id => this._labels.find(l => l.id === id))
+      .filter((l): l is Label => l !== undefined);
+  }
+
+  /** Añade una etiqueta recién creada al caché local para que los chips se muestren sin recargar (US-10). */
+  private _handleLabelCreated(e: CustomEvent): void {
+    const { label } = e.detail as { label: Label };
+    if (!this._labels.find(l => l.id === label.id)) {
+      this._labels = [...this._labels, label].sort((a, b) =>
+        a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })
+      );
+    }
   }
 
   private _filterTasks(tasks: Task[]): Task[] {
@@ -866,7 +892,10 @@ export class DojoKanbanBoard extends HTMLElement {
         // En cualquier otro caso actualizamos solo los atributos para evitar re-render completo.
         if (changes.priority !== undefined && this._activeFilter.priorities?.length) {
           this._refreshColumnCards(sourceColumnId);
-        } else if (changes.title !== undefined || changes.priority !== undefined) {
+        } else if (changes.labelIds !== undefined && this._activeFilter.labelIds?.length) {
+          // Etiquetas cambiaron y hay filtro activo — puede que la tarjeta deba desaparecer
+          this._refreshColumnCards(sourceColumnId);
+        } else if (changes.title !== undefined || changes.priority !== undefined || changes.labelIds !== undefined) {
           const colEl = this._shadow.querySelector(
             `dojo-kanban-column[column-id="${CSS.escape(sourceColumnId)}"]`
           );
@@ -875,6 +904,7 @@ export class DojoKanbanBoard extends HTMLElement {
             if (cardEl) {
               if (changes.title    !== undefined) cardEl.setAttribute('task-title',    updated.title);
               if (changes.priority !== undefined) cardEl.setAttribute('task-priority', updated.priority);
+              if (changes.labelIds !== undefined) (cardEl as any).taskLabels = this._getTaskLabels(updated);
             }
           }
         }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -85,6 +85,28 @@ export class DojoKanbanBoard extends HTMLElement {
     this._updateColumnCounts();
   }
 
+  /**
+   * Actualiza una etiqueta en el caché local y refresca los chips de todas las
+   * tarjetas visibles que la tienen asignada. Llamado por dojo-app tras recibir
+   * el evento `dojo:label-updated` desde dojo-label-manager (US-11).
+   */
+  refreshLabel(updatedLabel: Label): void {
+    this._labels = this._labels.map(l => l.id === updatedLabel.id ? updatedLabel : l);
+    for (const [columnId, tasks] of this._tasksByColumn) {
+      for (const task of tasks) {
+        if ((task.labelIds ?? []).includes(updatedLabel.id)) {
+          const colEl = this._shadow.querySelector(
+            `dojo-kanban-column[column-id="${CSS.escape(columnId)}"]`
+          );
+          if (colEl) {
+            const cardEl = colEl.querySelector(`dojo-task-card[task-id="${CSS.escape(task.id)}"]`);
+            if (cardEl) (cardEl as any).taskLabels = this._getTaskLabels(task);
+          }
+        }
+      }
+    }
+  }
+
   // ── Render inicial (estructura vacía con loading) ─────────────────────────
 
   private _render(): void {

--- a/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
+++ b/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
@@ -67,8 +67,17 @@ export class DojoLabelManager extends HTMLElement {
     if (name === 'open') {
       const panel = this._shadow.querySelector<HTMLElement>('.panel');
       const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
-      if (panel) panel.setAttribute('aria-hidden', newVal === null ? 'true' : 'false');
-      if (backdrop) backdrop.classList.toggle('visible', newVal !== null);
+      const isOpen = newVal !== null;
+      if (panel) {
+        panel.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        // inert previene el foco por teclado cuando el panel está cerrado (WCAG 2.1 SC 2.1.2)
+        if (isOpen) {
+          panel.removeAttribute('inert');
+        } else {
+          panel.setAttribute('inert', '');
+        }
+      }
+      if (backdrop) backdrop.classList.toggle('visible', isOpen);
     }
   }
 
@@ -367,6 +376,7 @@ export class DojoLabelManager extends HTMLElement {
     panel.setAttribute('aria-modal', 'true');
     panel.setAttribute('aria-labelledby', 'lm-title');
     panel.setAttribute('aria-hidden', 'true');
+    panel.setAttribute('inert', ''); // Panel inactivo por defecto (WCAG 2.1 SC 2.1.2)
 
     // Header
     const panelHeader = document.createElement('div');

--- a/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
+++ b/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
@@ -1,0 +1,603 @@
+/**
+ * dojo-label-manager — Organismo
+ *
+ * Panel lateral para gestionar las etiquetas existentes.
+ * Permite editar el nombre y el color de cualquier etiqueta.
+ * Los cambios se persisten en IndexedDB y se propagan al tablero
+ * mediante el evento `dojo:label-updated`.
+ *
+ * ## API pública
+ * | Método  | Descripción                                        |
+ * |---------|----------------------------------------------------|
+ * | show()  | Abre el panel y carga las etiquetas desde IndexedDB|
+ * | hide()  | Cierra el panel                                    |
+ *
+ * ## Eventos despachados
+ * | Nombre              | Detalle       | Descripción                         |
+ * |---------------------|---------------|-------------------------------------|
+ * | dojo:label-updated  | { label }     | Etiqueta actualizada en IndexedDB   |
+ *
+ * ## Atributos observados
+ * | Atributo | Valores      | Descripción        |
+ * |----------|--------------|--------------------|
+ * | open     | presente/ausente | Panel visible  |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*,
+ * --dojo-primary, --dojo-shadow, --dojo-radius
+ */
+
+import type { Label } from '../../../types/models.js';
+import { getAllLabels, updateLabel } from '../../../db/label.repository.js';
+
+// ── Paleta de colores (idéntica a dojo-task-detail) ────────────────────────
+const PRESET_COLORS = [
+  '#EF4444', '#F97316', '#F59E0B', '#EAB308',
+  '#22C55E', '#10B981', '#3B82F6', '#6366F1',
+  '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16',
+] as const;
+
+const PRESET_COLOR_NAMES = [
+  'Rojo', 'Naranja', 'Ámbar', 'Amarillo',
+  'Verde', 'Esmeralda', 'Azul', 'Índigo',
+  'Violeta', 'Rosa', 'Cian', 'Lima',
+] as const;
+
+// ── Clase ──────────────────────────────────────────────────────────────────
+
+export class DojoLabelManager extends HTMLElement {
+  static readonly TAG = 'dojo-label-manager';
+
+  static get observedAttributes(): string[] { return ['open']; }
+
+  private _shadow: ShadowRoot;
+  private _labels: Label[] = [];
+  private _editingId: string | null = null;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._render();
+  }
+
+  attributeChangedCallback(name: string, _oldVal: string | null, newVal: string | null): void {
+    if (name === 'open') {
+      const panel = this._shadow.querySelector<HTMLElement>('.panel');
+      const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+      if (panel) panel.setAttribute('aria-hidden', newVal === null ? 'true' : 'false');
+      if (backdrop) backdrop.classList.toggle('visible', newVal !== null);
+    }
+  }
+
+  // ── API pública ──────────────────────────────────────────────────────────
+
+  async show(): Promise<void> {
+    this._labels = await getAllLabels();
+    this._labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }));
+    this._editingId = null;
+    this.setAttribute('open', '');
+    this._buildContent();
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLButtonElement>('.panel-close')?.focus();
+    });
+  }
+
+  hide(): void {
+    this.removeAttribute('open');
+    this._editingId = null;
+  }
+
+  // ── Render base ──────────────────────────────────────────────────────────
+
+  private _render(): void {
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      /* Capa de oscurecimiento */
+      .backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,.45);
+        z-index: 40;
+      }
+      .backdrop.visible { display: block; }
+
+      /* Panel lateral */
+      .panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(360px, 100vw);
+        background: var(--dojo-surface);
+        border-left: 1px solid var(--dojo-border);
+        box-shadow: -4px 0 16px rgba(0,0,0,.12);
+        z-index: 50;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transform: translateX(100%);
+        transition: transform 0.25s ease;
+      }
+      :host([open]) .panel {
+        transform: translateX(0);
+      }
+
+      /* Header del panel */
+      .panel-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.875rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+        flex-shrink: 0;
+      }
+      .panel-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0;
+        flex: 1;
+      }
+      .panel-close {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-size: 1.125rem;
+        color: var(--dojo-text-secondary);
+        padding: 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        line-height: 1;
+        transition: color 0.15s, background 0.15s;
+      }
+      .panel-close:hover { color: var(--dojo-text-primary); background: var(--dojo-bg); }
+      .panel-close:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Contenido desplazable */
+      .panel-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0.5rem 0;
+      }
+
+      /* Estado vacío */
+      .empty-state {
+        padding: 1.25rem;
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        text-align: center;
+        margin: 0;
+      }
+
+      /* Lista de etiquetas */
+      .label-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .label-row {
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+        padding: 0.5rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+      }
+      .label-row:last-child { border-bottom: none; }
+
+      /* Chip/punto de color */
+      .label-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      /* Nombre */
+      .label-name {
+        flex: 1;
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      /* Botón editar */
+      .edit-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        flex-shrink: 0;
+        line-height: 1;
+        transition: background 0.15s, color 0.15s;
+      }
+      .edit-btn:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .edit-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Formulario de edición inline */
+      .edit-form {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.625rem 0;
+      }
+
+      .edit-form-label {
+        font-size: 0.6875rem;
+        font-weight: 700;
+        color: var(--dojo-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .edit-name-input {
+        font-size: 0.8125rem;
+        padding: 0.375rem 0.5rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        font-family: inherit;
+        outline: none;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .edit-name-input:focus {
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+
+      /* Paleta de colores */
+      .edit-color-palette {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3125rem;
+      }
+      .color-swatch {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        cursor: pointer;
+        padding: 0;
+        outline: none;
+        transition: border-color 0.12s, transform 0.12s;
+      }
+      .color-swatch.selected,
+      .color-swatch:focus-visible {
+        border-color: var(--dojo-text-primary, #111);
+        transform: scale(1.2);
+      }
+
+      /* Fila de color personalizado */
+      .edit-custom-color-row {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.8125rem;
+        color: var(--dojo-text-secondary);
+      }
+      .edit-color-input {
+        width: 36px;
+        height: 22px;
+        border: 1px solid var(--dojo-border);
+        border-radius: 3px;
+        padding: 0 2px;
+        cursor: pointer;
+        background: transparent;
+      }
+
+      /* Mensaje de error */
+      .edit-error {
+        font-size: 0.75rem;
+        color: #EF4444;
+        margin: 0;
+      }
+
+      /* Acciones del formulario */
+      .edit-actions {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: flex-end;
+        padding-top: 0.25rem;
+      }
+      .edit-btn-secondary {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        border: 1px solid var(--dojo-border);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        transition: background 0.15s;
+      }
+      .edit-btn-secondary:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .edit-btn-primary {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        background: var(--dojo-primary, #1D4ED8);
+        border: 1px solid var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-weight: 600;
+        transition: opacity 0.15s;
+      }
+      .edit-btn-primary:hover { opacity: 0.88; }
+      .edit-btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+      .edit-btn-secondary:focus-visible,
+      .edit-btn-primary:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Backdrop
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.addEventListener('click', () => this.hide());
+    this._shadow.appendChild(backdrop);
+
+    // Panel
+    const panel = document.createElement('aside');
+    panel.className = 'panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'true');
+    panel.setAttribute('aria-labelledby', 'lm-title');
+    panel.setAttribute('aria-hidden', 'true');
+
+    // Header
+    const panelHeader = document.createElement('div');
+    panelHeader.className = 'panel-header';
+
+    const panelTitle = document.createElement('h2');
+    panelTitle.id = 'lm-title';
+    panelTitle.className = 'panel-title';
+    panelTitle.textContent = 'Gestionar etiquetas';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'panel-close';
+    closeBtn.type = 'button';
+    closeBtn.textContent = '✕';
+    closeBtn.setAttribute('aria-label', 'Cerrar panel de etiquetas');
+    closeBtn.addEventListener('click', () => this.hide());
+
+    panelHeader.appendChild(panelTitle);
+    panelHeader.appendChild(closeBtn);
+    panel.appendChild(panelHeader);
+
+    // Contenido desplazable (se rellena en _buildContent)
+    const content = document.createElement('div');
+    content.className = 'panel-content';
+    panel.appendChild(content);
+
+    this._shadow.appendChild(panel);
+
+    // Teclado: Escape cierra el panel
+    this._shadow.addEventListener('keydown', ((e: Event) => {
+      if ((e as KeyboardEvent).key === 'Escape' && this.hasAttribute('open')) this.hide();
+    }) as EventListener);
+  }
+
+  // ── Construcción dinámica del listado ────────────────────────────────────
+
+  private _buildContent(): void {
+    const content = this._shadow.querySelector('.panel-content');
+    if (!content) return;
+    content.innerHTML = '';
+
+    if (this._labels.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'No hay etiquetas. Crea una desde el panel de detalle de una tarea.';
+      content.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'label-list';
+    list.setAttribute('role', 'list');
+
+    for (const label of this._labels) {
+      list.appendChild(this._buildLabelRow(label));
+    }
+
+    content.appendChild(list);
+  }
+
+  private _buildLabelRow(label: Label): HTMLLIElement {
+    const item = document.createElement('li');
+    item.className = 'label-row';
+    item.dataset['labelId'] = label.id;
+
+    if (this._editingId === label.id) {
+      item.appendChild(this._buildEditForm(label));
+    } else {
+      const dot = document.createElement('span');
+      dot.className = 'label-dot';
+      dot.style.backgroundColor = label.color;
+      dot.setAttribute('aria-hidden', 'true');
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'label-name';
+      nameEl.textContent = label.name;
+      nameEl.setAttribute('title', label.name);
+
+      const editBtn = document.createElement('button');
+      editBtn.className = 'edit-btn';
+      editBtn.type = 'button';
+      editBtn.textContent = '✏️';
+      editBtn.setAttribute('aria-label', `Editar etiqueta "${label.name}"`);
+      editBtn.addEventListener('click', () => {
+        this._editingId = label.id;
+        this._buildContent();
+        requestAnimationFrame(() => {
+          this._shadow.querySelector<HTMLInputElement>('.edit-name-input')?.focus();
+        });
+      });
+
+      item.appendChild(dot);
+      item.appendChild(nameEl);
+      item.appendChild(editBtn);
+    }
+
+    return item;
+  }
+
+  private _buildEditForm(label: Label): HTMLElement {
+    const form = document.createElement('div');
+    form.className = 'edit-form';
+
+    // Nombre
+    const nameSection = document.createElement('label');
+    nameSection.className = 'edit-form-label';
+    nameSection.textContent = 'Nombre';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'edit-name-input';
+    nameInput.value = label.name;
+    nameInput.maxLength = 30;
+    nameInput.setAttribute('aria-label', 'Nombre de la etiqueta');
+    nameSection.appendChild(nameInput);
+    form.appendChild(nameSection);
+
+    // Color — título
+    const colorTitle = document.createElement('div');
+    colorTitle.className = 'edit-form-label';
+    colorTitle.textContent = 'Color';
+    form.appendChild(colorTitle);
+
+    // Estado pendiente de color
+    let pendingColor: string = label.color;
+
+    // Paleta de swatches
+    const palette = document.createElement('div');
+    palette.className = 'edit-color-palette';
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.className = 'edit-color-input';
+    colorInput.value = pendingColor;
+    colorInput.setAttribute('aria-label', 'Color personalizado');
+
+    for (let i = 0; i < PRESET_COLORS.length; i++) {
+      const c = PRESET_COLORS[i];
+      const swatch = document.createElement('button');
+      swatch.type = 'button';
+      swatch.className = 'color-swatch' + (pendingColor === c ? ' selected' : '');
+      swatch.style.backgroundColor = c;
+      swatch.setAttribute('aria-label', `Color ${PRESET_COLOR_NAMES[i]}`);
+      swatch.setAttribute('title', PRESET_COLOR_NAMES[i]);
+      swatch.dataset['color'] = c;
+      swatch.addEventListener('click', () => {
+        pendingColor = c;
+        colorInput.value = c;
+        palette.querySelectorAll('.color-swatch').forEach(s => {
+          s.classList.toggle('selected', (s as HTMLElement).dataset['color'] === c);
+        });
+      });
+      palette.appendChild(swatch);
+    }
+
+    colorInput.addEventListener('input', () => {
+      pendingColor = colorInput.value;
+      palette.querySelectorAll('.color-swatch').forEach(s => {
+        s.classList.toggle('selected', (s as HTMLElement).dataset['color'] === pendingColor);
+      });
+    });
+
+    form.appendChild(palette);
+
+    // Fila de color personalizado
+    const customRow = document.createElement('div');
+    customRow.className = 'edit-custom-color-row';
+    const customLabel = document.createElement('span');
+    customLabel.textContent = 'Personalizado:';
+    customRow.appendChild(customLabel);
+    customRow.appendChild(colorInput);
+    form.appendChild(customRow);
+
+    // Mensaje de error
+    const errorEl = document.createElement('p');
+    errorEl.className = 'edit-error';
+    errorEl.setAttribute('role', 'alert');
+    errorEl.style.display = 'none';
+    form.appendChild(errorEl);
+
+    // Acciones
+    const actions = document.createElement('div');
+    actions.className = 'edit-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'edit-btn-secondary';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => {
+      this._editingId = null;
+      this._buildContent();
+    });
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'edit-btn-primary';
+    saveBtn.textContent = 'Guardar';
+    saveBtn.addEventListener('click', async () => {
+      const newName = nameInput.value.trim();
+      if (!newName) {
+        errorEl.textContent = 'El nombre no puede estar vacío.';
+        errorEl.style.display = '';
+        return;
+      }
+      saveBtn.disabled = true;
+      saveBtn.textContent = '…';
+      try {
+        const updated = await updateLabel(label.id, { name: newName, color: pendingColor });
+        // Actualizar caché local
+        this._labels = this._labels.map(l => l.id === updated.id ? updated : l);
+        this._editingId = null;
+        this._buildContent();
+        // Notificar al tablero para que propague los cambios a las tarjetas
+        this.dispatchEvent(new CustomEvent('dojo:label-updated', {
+          bubbles: true, composed: true,
+          detail: { label: updated },
+        }));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Error al guardar la etiqueta';
+        errorEl.textContent = msg;
+        errorEl.style.display = '';
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Guardar';
+      }
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(saveBtn);
+    form.appendChild(actions);
+
+    return form;
+  }
+}
+
+customElements.define(DojoLabelManager.TAG, DojoLabelManager);

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -611,6 +611,17 @@ export class DojoTaskDetail extends HTMLElement {
         outline-offset: 2px;
       }
 
+      /* Aviso cuando la etiqueta ya existe con distinta capitaliz. (US-10) */
+      .label-info-notice {
+        padding: 0.375rem 0.75rem;
+        font-size: 0.75rem;
+        color: var(--dojo-primary, #1D4ED8);
+        background: color-mix(in srgb, var(--dojo-primary, #1D4ED8) 8%, transparent);
+        border-top: 1px solid var(--dojo-border);
+        line-height: 1.4;
+        margin: 0;
+      }
+
       /* ── Footer de peligro (US-06) ── */
       .panel-footer {
         flex-shrink: 0;
@@ -1192,6 +1203,11 @@ export class DojoTaskDetail extends HTMLElement {
           );
           const currentIds = this._task?.labelIds ?? [];
           this._save({ labelIds: [...currentIds, newLabel.id] });
+          // Notificar al tablero para actualizar su caché de etiquetas (US-10)
+          this.dispatchEvent(new CustomEvent('dojo:label-created', {
+            bubbles: true, composed: true,
+            detail: { label: newLabel },
+          }));
           searchTerm     = '';
           showCreateForm = false;
           pendingColor   = PRESET_COLORS[0];
@@ -1327,6 +1343,15 @@ export class DojoTaskDetail extends HTMLElement {
               if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); activate(); }
             });
             picker.appendChild(createOpt);
+          }
+        } else {
+          // La etiqueta ya existe con el mismo nombre (puede que diferente capitaliz.) — US-10 S2
+          const matchedLabel = this._allLabels.find(l => l.name.toLowerCase() === trimmed.toLowerCase())!;
+          if (matchedLabel.name !== trimmed) {
+            const notice = document.createElement('p');
+            notice.className = 'label-info-notice';
+            notice.textContent = `ℹ️\u00a0«${matchedLabel.name}» ya existe — selecciónala en la lista.`;
+            picker.appendChild(notice);
           }
         }
       }

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -29,6 +29,7 @@
 import type { Task, Column, Label, Priority } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
 import { pickTextColor } from '../../../utils/contrast.js';
+import { createLabel } from '../../../db/label.repository.js';
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
@@ -491,6 +492,125 @@ export class DojoTaskDetail extends HTMLElement {
         flex-shrink: 0;
       }
 
+      /* ── Etiquetas — búsqueda y creación (US-09) ── */
+      .labels-search {
+        display: block;
+        width: 100%;
+        padding: 0.4375rem 0.75rem;
+        border: none;
+        border-bottom: 1px solid var(--dojo-border);
+        background: transparent;
+        font-size: 0.8125rem;
+        color: var(--dojo-text-primary);
+        box-sizing: border-box;
+        font-family: inherit;
+        outline: none;
+      }
+      .labels-search:focus {
+        border-bottom-color: var(--dojo-primary, #1D4ED8);
+        background: var(--dojo-bg);
+      }
+      .label-create-option {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.4375rem 0.75rem;
+        cursor: pointer;
+        font-size: 0.8125rem;
+        color: var(--dojo-primary, #1D4ED8);
+        font-weight: 500;
+        border-top: 1px solid var(--dojo-border);
+      }
+      .label-create-option:hover { background: var(--dojo-bg); }
+      .label-create-option:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: -2px;
+      }
+      .label-create-form {
+        padding: 0.625rem 0.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        border-top: 1px solid var(--dojo-border);
+      }
+      .label-create-form-title {
+        font-size: 0.6875rem;
+        font-weight: 700;
+        color: var(--dojo-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .label-color-palette {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3125rem;
+      }
+      .color-swatch {
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        cursor: pointer;
+        padding: 0;
+        outline: none;
+        transition: border-color 0.12s, transform 0.12s;
+      }
+      .color-swatch.selected,
+      .color-swatch:focus-visible {
+        border-color: var(--dojo-text-primary, #111);
+        transform: scale(1.2);
+      }
+      .label-custom-color-row {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.8125rem;
+        color: var(--dojo-text-secondary);
+      }
+      .label-color-input {
+        width: 36px;
+        height: 22px;
+        border: 1px solid var(--dojo-border);
+        border-radius: 3px;
+        padding: 0 2px;
+        cursor: pointer;
+        background: transparent;
+      }
+      .label-error {
+        font-size: 0.75rem;
+        color: #EF4444;
+      }
+      .label-create-actions {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: flex-end;
+      }
+      .label-btn {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        border: 1px solid var(--dojo-border);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        transition: background 0.15s;
+      }
+      .label-btn:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .label-btn-primary {
+        background: var(--dojo-primary, #1D4ED8);
+        border-color: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-weight: 600;
+      }
+      .label-btn-primary:hover { opacity: 0.88; }
+      .label-btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+      .label-btn:focus-visible,
+      .label-btn-primary:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
       /* ── Footer de peligro (US-06) ── */
       .panel-footer {
         flex-shrink: 0;
@@ -842,6 +962,12 @@ export class DojoTaskDetail extends HTMLElement {
   }
 
   private _buildLabelsField(task: Task): HTMLElement {
+    const PRESET_COLORS = [
+      '#EF4444', '#F97316', '#F59E0B', '#EAB308',
+      '#22C55E', '#10B981', '#3B82F6', '#6366F1',
+      '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16',
+    ];
+
     const section = document.createElement('div');
     section.className = 'section';
 
@@ -858,27 +984,49 @@ export class DojoTaskDetail extends HTMLElement {
     picker.id = 'labels-picker-dropdown';
     picker.setAttribute('aria-label', 'Selector de etiquetas disponibles');
 
-    // Navegación por teclado dentro del picker (Fix #4: ArrowDown/ArrowUp + Escape)
+    // ── Estado de cierre del picker ───────────────────────────────────────
+    let searchTerm     = '';
+    let showCreateForm = false;
+    let pendingColor   = PRESET_COLORS[0];
+
+    // Navegación por teclado dentro del picker
     picker.addEventListener('keydown', (ev: KeyboardEvent) => {
-      const checkboxes = Array.from(picker.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'));
-      if (!checkboxes.length) return;
-      const current = checkboxes.indexOf(this._shadow.activeElement as HTMLInputElement);
-      if (ev.key === 'ArrowDown') {
+      if (ev.key === 'Escape') {
         ev.preventDefault();
-        const next = current >= 0 ? (current + 1) % checkboxes.length : 0;
-        checkboxes[next].focus();
-      } else if (ev.key === 'ArrowUp') {
-        ev.preventDefault();
-        const prev = current >= 0 ? (current - 1 + checkboxes.length) % checkboxes.length : checkboxes.length - 1;
-        checkboxes[prev].focus();
-      } else if (ev.key === 'Escape') {
-        ev.preventDefault();
-        this._labelsPickerOpen = false;
-        picker.classList.remove('open');
-        chips.querySelector<HTMLElement>('.add-label-btn')?.focus();
+        if (showCreateForm) {
+          showCreateForm = false;
+          renderPicker();
+          requestAnimationFrame(() =>
+            picker.querySelector<HTMLInputElement>('.labels-search')?.focus()
+          );
+        } else {
+          this._labelsPickerOpen = false;
+          picker.classList.remove('open');
+          chips.querySelector<HTMLElement>('.add-label-btn')?.focus();
+        }
+        return;
+      }
+      if (ev.key === 'ArrowDown' || ev.key === 'ArrowUp') {
+        const focusable = Array.from(
+          picker.querySelectorAll<HTMLElement>(
+            'input[type="checkbox"], .label-create-option, .color-swatch, .label-btn, .label-btn-primary, input[type="color"]'
+          )
+        );
+        if (focusable.length < 2) return;
+        const current = focusable.indexOf(this._shadow.activeElement as HTMLElement);
+        if (ev.key === 'ArrowDown') {
+          ev.preventDefault();
+          const next = current >= 0 ? (current + 1) % focusable.length : 0;
+          focusable[next].focus();
+        } else {
+          ev.preventDefault();
+          const prev = current >= 0 ? (current - 1 + focusable.length) % focusable.length : focusable.length - 1;
+          focusable[prev].focus();
+        }
       }
     });
 
+    // ── Render chips ───────────────────────────────────────────────────────
     const renderChips = (): void => {
       chips.innerHTML = '';
       const currentIds = this._task?.labelIds ?? [];
@@ -888,7 +1036,6 @@ export class DojoTaskDetail extends HTMLElement {
         if (!label) return;
 
         let textColor = '#ffffff';
-        // Fix #6: validar formato hex antes de llamar a pickTextColor
         const HEX_COLOR_RE = /^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/;
         if (HEX_COLOR_RE.test(label.color)) {
           try { textColor = pickTextColor(label.color); } catch { /* sin cambios */ }
@@ -896,10 +1043,10 @@ export class DojoTaskDetail extends HTMLElement {
           console.warn('[dojo-task-detail] Color de etiqueta inválido (se usa blanco):', label.color);
         }
 
-        const chip    = document.createElement('span');
-        chip.className  = 'label-chip';
+        const chip = document.createElement('span');
+        chip.className = 'label-chip';
         chip.style.backgroundColor = label.color;
-        chip.style.color              = textColor;
+        chip.style.color = textColor;
 
         const chipText = document.createElement('span');
         chipText.textContent = label.name;
@@ -920,7 +1067,6 @@ export class DojoTaskDetail extends HTMLElement {
         chips.appendChild(chip);
       });
 
-      // Botón abrir/cerrar picker
       const addBtn = document.createElement('button');
       addBtn.className = 'add-label-btn';
       addBtn.textContent = '＋ Etiqueta';
@@ -930,58 +1076,252 @@ export class DojoTaskDetail extends HTMLElement {
         this._labelsPickerOpen = !this._labelsPickerOpen;
         picker.classList.toggle('open', this._labelsPickerOpen);
         addBtn.setAttribute('aria-expanded', String(this._labelsPickerOpen));
-        // Fix #4: mover foco al primer checkbox al abrir
         if (this._labelsPickerOpen) {
-          requestAnimationFrame(() => {
-            picker.querySelector<HTMLInputElement>('input[type="checkbox"]')?.focus();
-          });
+          requestAnimationFrame(() =>
+            picker.querySelector<HTMLInputElement>('.labels-search')?.focus()
+          );
         }
       });
       chips.appendChild(addBtn);
     };
 
+    // ── Formulario inline de creación (US-09) ─────────────────────────────
+    const buildCreateForm = (name: string): HTMLElement => {
+      const form = document.createElement('div');
+      form.className = 'label-create-form';
+      form.setAttribute('role', 'group');
+      form.setAttribute('aria-label', `Crear etiqueta "${name}"`);
+
+      const formTitle = document.createElement('span');
+      formTitle.className = 'label-create-form-title';
+      formTitle.textContent = `Color para "${name}"`;
+      form.appendChild(formTitle);
+
+      const palette = document.createElement('div');
+      palette.className = 'label-color-palette';
+      PRESET_COLORS.forEach(c => {
+        const swatch = document.createElement('button');
+        swatch.type = 'button';
+        swatch.className = 'color-swatch' + (pendingColor === c ? ' selected' : '');
+        swatch.style.backgroundColor = c;
+        swatch.setAttribute('aria-label', `Color ${c}`);
+        swatch.setAttribute('aria-pressed', String(pendingColor === c));
+        swatch.addEventListener('click', () => {
+          pendingColor = c;
+          palette.querySelectorAll<HTMLButtonElement>('.color-swatch').forEach(s => {
+            const active = s.getAttribute('aria-label') === `Color ${c}`;
+            s.classList.toggle('selected', active);
+            s.setAttribute('aria-pressed', String(active));
+          });
+          const ci = form.querySelector<HTMLInputElement>('.label-color-input');
+          if (ci) ci.value = c;
+        });
+        palette.appendChild(swatch);
+      });
+      form.appendChild(palette);
+
+      const customRow = document.createElement('div');
+      customRow.className = 'label-custom-color-row';
+      const customLbl = document.createElement('span');
+      customLbl.textContent = 'Personalizado:';
+      const colorInput = document.createElement('input');
+      colorInput.type = 'color';
+      colorInput.className = 'label-color-input';
+      colorInput.value = pendingColor;
+      colorInput.setAttribute('aria-label', 'Color personalizado para la etiqueta');
+      colorInput.addEventListener('input', () => {
+        pendingColor = colorInput.value;
+        palette.querySelectorAll<HTMLButtonElement>('.color-swatch').forEach(s => {
+          const active = s.getAttribute('aria-label') === `Color ${pendingColor}`;
+          s.classList.toggle('selected', active);
+          s.setAttribute('aria-pressed', String(active));
+        });
+      });
+      customRow.appendChild(customLbl);
+      customRow.appendChild(colorInput);
+      form.appendChild(customRow);
+
+      const errorEl = document.createElement('span');
+      errorEl.className = 'label-error';
+      errorEl.setAttribute('role', 'alert');
+      errorEl.setAttribute('aria-live', 'polite');
+      errorEl.style.display = 'none';
+      form.appendChild(errorEl);
+
+      const actions = document.createElement('div');
+      actions.className = 'label-create-actions';
+
+      const cancelBtn = document.createElement('button');
+      cancelBtn.type = 'button';
+      cancelBtn.className = 'label-btn';
+      cancelBtn.textContent = 'Cancelar';
+      cancelBtn.addEventListener('click', () => {
+        showCreateForm = false;
+        pendingColor = PRESET_COLORS[0];
+        renderPicker();
+        requestAnimationFrame(() =>
+          picker.querySelector<HTMLInputElement>('.labels-search')?.focus()
+        );
+      });
+
+      const confirmBtn = document.createElement('button');
+      confirmBtn.type = 'button';
+      confirmBtn.className = 'label-btn label-btn-primary';
+      confirmBtn.textContent = 'Crear';
+      confirmBtn.setAttribute('aria-label', `Confirmar creación de etiqueta "${name}"`);
+      confirmBtn.addEventListener('click', async () => {
+        if (!pendingColor) {
+          errorEl.textContent = 'Debes seleccionar un color.';
+          errorEl.style.display = '';
+          return;
+        }
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = '…';
+        try {
+          const newLabel = await createLabel({ name, color: pendingColor });
+          this._allLabels = [...this._allLabels, newLabel].sort((a, b) =>
+            a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })
+          );
+          const currentIds = this._task?.labelIds ?? [];
+          this._save({ labelIds: [...currentIds, newLabel.id] });
+          searchTerm     = '';
+          showCreateForm = false;
+          pendingColor   = PRESET_COLORS[0];
+          renderChips();
+          renderPicker();
+          this._labelsPickerOpen = false;
+          picker.classList.remove('open');
+          chips.querySelector<HTMLElement>('.add-label-btn')?.focus();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : 'Error al crear la etiqueta';
+          errorEl.textContent = msg;
+          errorEl.style.display = '';
+          confirmBtn.disabled = false;
+          confirmBtn.textContent = 'Crear';
+        }
+      });
+
+      actions.appendChild(cancelBtn);
+      actions.appendChild(confirmBtn);
+      form.appendChild(actions);
+      return form;
+    };
+
+    // ── Render picker con búsqueda (US-09) ────────────────────────────────
     const renderPicker = (): void => {
       picker.innerHTML = '';
-      if (this._allLabels.length === 0) {
-        const empty = document.createElement('p');
-        empty.style.cssText = 'padding:.5rem .75rem;font-size:.8125rem;color:var(--dojo-text-secondary)';
-        empty.textContent = 'No hay etiquetas disponibles.';
-        picker.appendChild(empty);
-        return;
-      }
-      this._allLabels.forEach(label => {
-        const currentIds = this._task?.labelIds ?? [];
-        const isSelected = currentIds.includes(label.id);
 
-        const optionEl = document.createElement('label');
-        optionEl.className = 'label-option';
-
-        const cb = document.createElement('input');
-        cb.type    = 'checkbox';
-        cb.checked = isSelected;
-        cb.setAttribute('aria-label', label.name);
-        cb.addEventListener('change', () => {
-          const ids    = this._task?.labelIds ?? [];
-          const newIds = cb.checked
-            ? [...ids, label.id]
-            : ids.filter(id => id !== label.id);
-          this._save({ labelIds: newIds });
-          renderChips();
+      // Campo de búsqueda — siempre visible
+      const searchInput = document.createElement('input');
+      searchInput.type = 'text';
+      searchInput.className = 'labels-search';
+      searchInput.placeholder = 'Buscar o crear etiqueta…';
+      searchInput.maxLength = 30;
+      searchInput.value = searchTerm;
+      searchInput.setAttribute('aria-label', 'Buscar etiqueta');
+      searchInput.setAttribute('autocomplete', 'off');
+      searchInput.addEventListener('input', () => {
+        const newVal = searchInput.value;
+        if (newVal === searchTerm) return;
+        searchTerm = newVal;
+        const trimmedNew = newVal.trim();
+        if (showCreateForm) {
+          const hasExact = this._allLabels.some(
+            l => l.name.toLowerCase() === trimmedNew.toLowerCase()
+          );
+          if (!trimmedNew || hasExact) showCreateForm = false;
+        }
+        renderPicker();
+        requestAnimationFrame(() => {
+          const s = picker.querySelector<HTMLInputElement>('.labels-search');
+          if (s) { s.focus(); const len = s.value.length; s.setSelectionRange(len, len); }
         });
-
-        const dot = document.createElement('span');
-        dot.className           = 'label-dot';
-        dot.style.backgroundColor = label.color;
-        dot.setAttribute('aria-hidden', 'true');
-
-        const namePart = document.createElement('span');
-        namePart.textContent = label.name;
-
-        optionEl.appendChild(cb);
-        optionEl.appendChild(dot);
-        optionEl.appendChild(namePart);
-        picker.appendChild(optionEl);
       });
+      picker.appendChild(searchInput);
+
+      const trimmed = searchTerm.trim();
+      const filtered = trimmed
+        ? this._allLabels.filter(l => l.name.toLowerCase().includes(trimmed.toLowerCase()))
+        : this._allLabels;
+
+      // Lista de etiquetas (filtradas o completa)
+      if (filtered.length === 0 && !trimmed) {
+        const empty = document.createElement('p');
+        empty.style.cssText = 'padding:.375rem .75rem;font-size:.8125rem;color:var(--dojo-text-secondary);margin:0';
+        empty.textContent = 'No hay etiquetas. Escribe un nombre para crear una.';
+        picker.appendChild(empty);
+      } else {
+        filtered.forEach(label => {
+          const currentIds = this._task?.labelIds ?? [];
+          const isSelected = currentIds.includes(label.id);
+
+          const optionEl = document.createElement('label');
+          optionEl.className = 'label-option';
+
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = isSelected;
+          cb.setAttribute('aria-label', label.name);
+          cb.addEventListener('change', () => {
+            const ids = this._task?.labelIds ?? [];
+            const newIds = cb.checked
+              ? [...ids, label.id]
+              : ids.filter(id => id !== label.id);
+            this._save({ labelIds: newIds });
+            renderChips();
+          });
+
+          const dot = document.createElement('span');
+          dot.className = 'label-dot';
+          dot.style.backgroundColor = label.color;
+          dot.setAttribute('aria-hidden', 'true');
+
+          const namePart = document.createElement('span');
+          namePart.textContent = label.name;
+
+          optionEl.appendChild(cb);
+          optionEl.appendChild(dot);
+          optionEl.appendChild(namePart);
+          picker.appendChild(optionEl);
+        });
+      }
+
+      // Opción / formulario de creación cuando no hay coincidencia exacta
+      if (trimmed) {
+        const hasExact = this._allLabels.some(
+          l => l.name.toLowerCase() === trimmed.toLowerCase()
+        );
+        if (!hasExact) {
+          if (showCreateForm) {
+            picker.appendChild(buildCreateForm(trimmed));
+          } else {
+            const createOpt = document.createElement('div');
+            createOpt.className = 'label-create-option';
+            createOpt.setAttribute('role', 'button');
+            createOpt.setAttribute('tabindex', '0');
+            const icon = document.createElement('span');
+            icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = '＋';
+            const labelEl = document.createElement('span');
+            labelEl.textContent = `Crear etiqueta "${trimmed}"`;
+            createOpt.appendChild(icon);
+            createOpt.appendChild(labelEl);
+            const activate = (): void => {
+              showCreateForm = true;
+              pendingColor   = PRESET_COLORS[0];
+              renderPicker();
+              requestAnimationFrame(() =>
+                picker.querySelector<HTMLInputElement>('.labels-search')?.focus()
+              );
+            };
+            createOpt.addEventListener('click', activate);
+            createOpt.addEventListener('keydown', (ev: KeyboardEvent) => {
+              if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); activate(); }
+            });
+            picker.appendChild(createOpt);
+          }
+        }
+      }
     };
 
     renderChips();

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -967,6 +967,11 @@ export class DojoTaskDetail extends HTMLElement {
       '#22C55E', '#10B981', '#3B82F6', '#6366F1',
       '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16',
     ];
+    const PRESET_COLOR_NAMES = [
+      'Rojo', 'Naranja', 'Ámbar', 'Amarillo',
+      'Verde', 'Esmeralda', 'Azul', 'Índigo',
+      'Violeta', 'Rosa', 'Cian', 'Lima',
+    ];
 
     const section = document.createElement('div');
     section.className = 'section';
@@ -1104,12 +1109,15 @@ export class DojoTaskDetail extends HTMLElement {
         swatch.type = 'button';
         swatch.className = 'color-swatch' + (pendingColor === c ? ' selected' : '');
         swatch.style.backgroundColor = c;
-        swatch.setAttribute('aria-label', `Color ${c}`);
+        const colorName = PRESET_COLOR_NAMES[PRESET_COLORS.indexOf(c)] ?? c;
+        swatch.setAttribute('aria-label', `Color ${colorName}`);
         swatch.setAttribute('aria-pressed', String(pendingColor === c));
+        swatch.title = colorName;
+        swatch.dataset['color'] = c;
         swatch.addEventListener('click', () => {
           pendingColor = c;
           palette.querySelectorAll<HTMLButtonElement>('.color-swatch').forEach(s => {
-            const active = s.getAttribute('aria-label') === `Color ${c}`;
+            const active = s.dataset['color'] === c;
             s.classList.toggle('selected', active);
             s.setAttribute('aria-pressed', String(active));
           });
@@ -1132,7 +1140,7 @@ export class DojoTaskDetail extends HTMLElement {
       colorInput.addEventListener('input', () => {
         pendingColor = colorInput.value;
         palette.querySelectorAll<HTMLButtonElement>('.color-swatch').forEach(s => {
-          const active = s.getAttribute('aria-label') === `Color ${pendingColor}`;
+          const active = s.dataset['color'] === pendingColor;
           s.classList.toggle('selected', active);
           s.setAttribute('aria-pressed', String(active));
         });


### PR DESCRIPTION
## Descripción

Implementa **US-11 — Editar etiqueta**: panel de administración de etiquetas accesible desde el header de la aplicación. El usuario puede editar el nombre o el color de cualquier etiqueta existente; los cambios se propagan automáticamente a todos los chips visibles en el tablero sin recargar la página.

> **Nota:** Esta rama incluye los cambios acumulados de `feat/10-crear-etiqueta` (US-09) y `feat/11-reutilizacion-etiquetas` (US-10).

## Cambios implementados

### Nuevo: `dojo-label-manager` (organismo)

Panel lateral (`min(360px, 100vw)`) que desliza desde la derecha (slide-in). Contiene:
- **Listado** de todas las etiquetas ordenadas alfabéticamente, con dot de color y nombre.
- **Formulario de edición inline** por etiqueta: campo de nombre (maxLength 30), paleta de 12 colores + `<input type="color">` personalizado.
- **Validaciones**: nombre vacío → error; nombre duplicado → propagado desde `updateLabel()` del repositorio.
- **Cierre**: botón ✕, clic en backdrop oscuro, tecla Escape.
- Despacha `dojo:label-updated` (bubbles+composed) con `{ label }` tras guardar con éxito.

### `dojo-app` (organismo raíz)

- Añade botón "🏷️ Gestionar etiquetas" en el header (antes del subtítulo).
- Importa y monta `<dojo-label-manager>` en el shadow root.
- Listener en el shadow root para `dojo:label-updated` → llama a `board.refreshLabel(label)`.

### `dojo-kanban-board` (organismo)

- Nuevo método público `refreshLabel(updatedLabel: Label)`:
  1. Actualiza `_labels[]` en caché.
  2. Itera `_tasksByColumn`; para cada tarea que tiene el `labelId` afectado, actualiza `card.taskLabels` → setter de `dojo-task-card` re-renderiza los chips.

## Arquitectura de comunicación

```
[Botón header] → labelMgr.show()
[dojo-label-manager] → updateLabel() → dojo:label-updated ↑
[dojo-app shadow root] → board.refreshLabel(label)
[dojo-kanban-board] → _labels[] + card.taskLabels por tarjeta afectada
[dojo-task-card setter] → _render() → chips actualizados
```

## Criterios de aceptación (US-11)

| Scenario | Estado |
|---|---|
| 1 — Acceder al panel desde el header | ✅ |
| 2 — Editar el nombre de una etiqueta | ✅ |
| 3 — Editar el color de una etiqueta | ✅ |
| 4 — Propagación automática a tarjetas visibles | ✅ |

## Seguridad

- `textContent` en todos los nodos dinámicos (sin riesgo XSS).
- Validación de nombre y color en `updateLabel()` del repositorio.
- Sin dependencias externas.
- TypeScript compila sin errores.

Closes #12