### PR TITLE
[US-12] Eliminar etiqueta con limpieza atómica en IndexedDB

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,7 +1,7 @@
 # COOKBOOK — ToDo List con Web Components
 
 > **Versión:** 1.0.0  
-> **Última actualización:** 2026-03-25  
+> **Última actualización:** 2026-03-26  
 > **Mantenido por:** Agente `documentalista`
 
 ---
@@ -26,6 +26,7 @@
    - [Paso 12 — Implementación de Crear Etiqueta (US-09 / Issue #10)](#paso-12--implementación-de-crear-etiqueta-us-09--issue-10)
    - [Paso 13 — Implementación de Reutilización de Etiquetas (US-10 / Issue #11)](#paso-13--implementación-de-reutilización-de-etiquetas-us-10--issue-11)
    - [Paso 14 — Implementación de Editar Etiqueta (US-11 / Issue #12)](#paso-14--implementación-de-editar-etiqueta-us-11--issue-12)
+   - [Paso 15 — Implementación de Eliminar Etiqueta (US-12 / Issue #13)](#paso-15--implementación-de-eliminar-etiqueta-us-12--issue-13)
 
 ---
 
@@ -1319,4 +1320,119 @@ Usuario hace clic en "Gestionar etiquetas" (header)
 | B: Panel dentro del board | El botón estaría en la barra de filtros, el panel en el shadow del board | Descartada |
 
 **Justificación:** El issue especifica "botón en el header de la aplicación". El header está en `dojo-app`. Para evitar que el organismo board asuma responsabilidades de gestión global, el panel de etiquetas se monta en el shadow de `dojo-app`, que actúa como coordinador de nivel de aplicación.
+
+---
+
+### Paso 15 — Implementación de Eliminar Etiqueta (US-12 / Issue #13)
+
+**Pull Request:** [#30 — [US-12] Eliminar etiqueta con limpieza atómica en IndexedDB](https://github.com/Code-Dojo-Labs/agent-app/pull/30)  
+**Rama:** `feat/13-eliminar-etiqueta`  
+**Fecha:** 2026-03-26
+
+#### Resumen
+
+Cubre la historia de usuario US-12: el usuario puede eliminar etiquetas desde el panel de gestión. La eliminación muestra primero un panel de confirmación inline que indica cuántas tareas se verán afectadas, y al confirmar realiza la limpieza de forma atómica en IndexedDB.
+
+#### Archivos modificados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `src/db/label.repository.ts` | Modificado — nueva función atómica `deleteLabel`, nueva función `countTasksByLabelId` |
+| `src/components/organisms/dojo-label-manager/dojo-label-manager.ts` | Modificado — botón eliminar + confirmación inline + evento `dojo:label-deleted` |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | Modificado — nuevo método `removeLabel()` |
+| `src/components/organisms/dojo-app/dojo-app.ts` | Modificado — escucha `dojo:label-deleted` y delega a `board.removeLabel()` |
+
+#### ADR-15: Transacción atómica multi-store para eliminación
+
+**Problema:** Al eliminar una etiqueta, el sistema debe mantener la integridad referencial entre el store `labels` y el campo `labelIds` del store `tasks`. Una solución naive (dos transacciones separadas) expone una ventana de inconsistencia si falla la segunda.
+
+**Decisión:** Usar una única transacción `readwrite` que abarque ambos stores simultáneamente:
+
+```typescript
+const tx = db.transaction(['labels', 'tasks'], 'readwrite');
+const labelStore = tx.objectStore('labels');
+const taskStore  = tx.objectStore('tasks');
+labelStore.delete(id);
+// ... limpiar labelIds en todas las tareas afectadas ...
+await idbTransaction(tx); // confirma o hace rollback de AMBOS stores
+```
+
+**Consecuencia:** Si la transacción falla, ninguno de los dos stores se modifica. La integridad es garantizada por el motor de IndexedDB.
+
+#### ADR-16: Confirmación inline en lugar de diálogo modal separado
+
+**Problema:** El criterio de aceptación requiere un "diálogo de confirmación". Existen dos opciones:
+- Reutilizar/extender `dojo-delete-confirm-dialog` (específico de tareas).
+- Implementar una confirmación inline dentro de `dojo-label-manager`.
+
+**Decisión:** Confirmación inline en el panel lateral, siguiendo el mismo patrón del formulario de edición ya establecido.
+
+**Justificación:** `dojo-delete-confirm-dialog` está acoplado semánticamente a tareas (`dojo:task-delete-confirm`). Extenderlo añadiría complejidad innecesaria. El patrón de "reemplazar fila con formulario" ya existe y resulta coherente con la UX del panel.
+
+#### Flujo de eliminación
+
+```
+Usuario clic 🗑️
+    │
+    ▼
+countTasksByLabelId() → async (carga el nº de tareas afectadas)
+    │
+    ▼
+Panel de confirmación inline (muestra aviso si hay tareas afectadas)
+    │
+    ├─ "Cancelar" → resetea _deletingId, reconstruye lista
+    │
+    └─ "Eliminar"
+           │
+           ▼
+       deleteLabel() [transacción atómica multi-store]
+           │
+           ▼
+       Actualizar _labels local → _buildContent()
+           │
+           ▼
+       CustomEvent dojo:label-deleted { labelId }
+           │
+           ▼
+       dojo-app → board.removeLabel(labelId)
+           │
+           ▼
+       Actualizar _labels + _tasksByColumn en caché
+       Refrescar chips DOM de tarjetas afectadas
+```
+
+#### API pública actualizada de `dojo-label-manager`
+
+| Evento despachado | Detalle | Descripción |
+|---|---|---|
+| `dojo:label-updated` | `{ label }` | Etiqueta editada |
+| `dojo:label-deleted` | `{ labelId }` | (**nuevo**) Etiqueta eliminada confirmada |
+
+#### `removeLabel()` en `dojo-kanban-board`
+
+Método que complementa al ya existente `refreshLabel()`:
+
+```typescript
+removeLabel(deletedLabelId: string): void {
+  this._labels = this._labels.filter(l => l.id !== deletedLabelId);
+  for (const [columnId, tasks] of this._tasksByColumn) {
+    for (const task of tasks) {
+      if ((task.labelIds ?? []).includes(deletedLabelId)) {
+        task.labelIds = task.labelIds.filter(lid => lid !== deletedLabelId);
+        // refrescar chip en el DOM...
+      }
+    }
+  }
+}
+```
+
+#### Criterios US-12 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| 1. Eliminar una etiqueta sin tareas asignadas | ✅ Confirmación sin aviso → eliminación directa |
+| 2. Diálogo muestra tareas afectadas | ✅ `countTasksByLabelId()` → aviso visual amarillo |
+| 3. Confirmar eliminación con tareas asignadas (limpieza atómica) | ✅ Transacción multi-store garantiza consistencia |
+| 4. Cancelar la eliminación | ✅ Botón "Cancelar" restaura la fila original |
+| 5. Chips desaparecen del tablero sin recarga | ✅ `board.removeLabel()` actualiza DOM reactivamente |
 

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -170,6 +170,12 @@ export class DojoApp extends HTMLElement {
       const { label } = (e as CustomEvent).detail as { label: Label };
       (board as any).refreshLabel?.(label);
     });
+
+    // Cuando se elimina una etiqueta, propagar al tablero para eliminar sus chips (US-12)
+    this._shadow.addEventListener('dojo:label-deleted', (e: Event) => {
+      const { labelId } = (e as CustomEvent).detail as { labelId: string };
+      (board as any).removeLabel?.(labelId);
+    });
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -112,6 +112,30 @@ export class DojoKanbanBoard extends HTMLElement {
     }
   }
 
+  /**
+   * Elimina una etiqueta del caché local y actualiza los chips de todas
+   * las tarjetas que la tenían asignada. Llamado por dojo-app tras recibir
+   * el evento `dojo:label-deleted` desde dojo-label-manager (US-12).
+   */
+  removeLabel(deletedLabelId: string): void {
+    this._labels = this._labels.filter(l => l.id !== deletedLabelId);
+    for (const [columnId, tasks] of this._tasksByColumn) {
+      for (const task of tasks) {
+        if ((task.labelIds ?? []).includes(deletedLabelId)) {
+          // Actualizar el caché local de tareas
+          task.labelIds = task.labelIds.filter(lid => lid !== deletedLabelId);
+          const colEl = this._shadow.querySelector(
+            `dojo-kanban-column[column-id="${CSS.escape(columnId)}"]`
+          );
+          if (colEl) {
+            const cardEl = colEl.querySelector(`dojo-task-card[task-id="${CSS.escape(task.id)}"]`);
+            if (cardEl) (cardEl as any).taskLabels = this._getTaskLabels(task);
+          }
+        }
+      }
+    }
+  }
+
   // ── Render inicial (estructura vacía con loading) ─────────────────────────
 
   private _render(): void {

--- a/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
+++ b/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
@@ -28,7 +28,7 @@
  */
 
 import type { Label } from '../../../types/models.js';
-import { getAllLabels, updateLabel } from '../../../db/label.repository.js';
+import { getAllLabels, updateLabel, deleteLabel, countTasksByLabelId } from '../../../db/label.repository.js';
 
 // ── Paleta de colores (idéntica a dojo-task-detail) ────────────────────────
 const PRESET_COLORS = [
@@ -53,6 +53,8 @@ export class DojoLabelManager extends HTMLElement {
   private _shadow: ShadowRoot;
   private _labels: Label[] = [];
   private _editingId: string | null = null;
+  private _deletingId: string | null = null;
+  private _deletingAffectedCount: number = 0;
 
   constructor() {
     super();
@@ -86,7 +88,8 @@ export class DojoLabelManager extends HTMLElement {
   async show(): Promise<void> {
     this._labels = await getAllLabels();
     this._labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }));
-    this._editingId = null;
+    this._editingId  = null;
+    this._deletingId = null;
     this.setAttribute('open', '');
     this._buildContent();
     requestAnimationFrame(() => {
@@ -96,7 +99,8 @@ export class DojoLabelManager extends HTMLElement {
 
   hide(): void {
     this.removeAttribute('open');
-    this._editingId = null;
+    this._editingId  = null;
+    this._deletingId = null;
   }
 
   // ── Render base ──────────────────────────────────────────────────────────
@@ -235,6 +239,86 @@ export class DojoLabelManager extends HTMLElement {
       .edit-btn:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
       .edit-btn:focus-visible {
         outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Botón eliminar */
+      .delete-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        flex-shrink: 0;
+        line-height: 1;
+        transition: background 0.15s, color 0.15s;
+      }
+      .delete-btn:hover { background: #FEE2E2; color: #B91C1C; }
+      .delete-btn:focus-visible {
+        outline: 2px solid #EF4444;
+        outline-offset: 2px;
+      }
+
+      /* Panel de confirmación de eliminación inline */
+      .delete-confirm {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.5rem 0;
+      }
+      .delete-confirm-msg {
+        font-size: 0.8125rem;
+        color: var(--dojo-text-primary);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .delete-confirm-warning {
+        font-size: 0.75rem;
+        color: #B45309;
+        margin: 0;
+        background: #FEF3C7;
+        border: 1px solid #F59E0B;
+        border-radius: var(--dojo-radius-sm, 4px);
+        padding: 0.3rem 0.5rem;
+      }
+      .delete-confirm-actions {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: flex-end;
+        padding-top: 0.25rem;
+      }
+      .delete-btn-cancel {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        border: 1px solid var(--dojo-border);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        transition: background 0.15s;
+      }
+      .delete-btn-cancel:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .delete-btn-confirm {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        background: #EF4444;
+        border: 1px solid #EF4444;
+        color: #fff;
+        font-weight: 600;
+        transition: opacity 0.15s;
+      }
+      .delete-btn-confirm:hover { opacity: 0.88; }
+      .delete-btn-confirm:disabled { opacity: 0.55; cursor: not-allowed; }
+      .delete-btn-cancel:focus-visible,
+      .delete-btn-confirm:focus-visible {
+        outline: 2px solid #EF4444;
         outline-offset: 2px;
       }
 
@@ -444,6 +528,8 @@ export class DojoLabelManager extends HTMLElement {
 
     if (this._editingId === label.id) {
       item.appendChild(this._buildEditForm(label));
+    } else if (this._deletingId === label.id) {
+      item.appendChild(this._buildDeleteConfirm(label));
     } else {
       const dot = document.createElement('span');
       dot.className = 'label-dot';
@@ -461,19 +547,98 @@ export class DojoLabelManager extends HTMLElement {
       editBtn.textContent = '✏️';
       editBtn.setAttribute('aria-label', `Editar etiqueta "${label.name}"`);
       editBtn.addEventListener('click', () => {
-        this._editingId = label.id;
+        this._editingId  = label.id;
+        this._deletingId = null;
         this._buildContent();
         requestAnimationFrame(() => {
           this._shadow.querySelector<HTMLInputElement>('.edit-name-input')?.focus();
         });
       });
 
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'delete-btn';
+      deleteBtn.type = 'button';
+      deleteBtn.textContent = '🗑️';
+      deleteBtn.setAttribute('aria-label', `Eliminar etiqueta "${label.name}"`);
+      deleteBtn.addEventListener('click', async () => {
+        this._editingId  = null;
+        this._deletingId = label.id;
+        this._deletingAffectedCount = await countTasksByLabelId(label.id);
+        this._buildContent();
+        requestAnimationFrame(() => {
+          this._shadow.querySelector<HTMLButtonElement>('.delete-btn-cancel')?.focus();
+        });
+      });
+
       item.appendChild(dot);
       item.appendChild(nameEl);
       item.appendChild(editBtn);
+      item.appendChild(deleteBtn);
     }
 
     return item;
+  }
+
+  private _buildDeleteConfirm(label: Label): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'delete-confirm';
+
+    const msg = document.createElement('p');
+    msg.className = 'delete-confirm-msg';
+    msg.textContent = `¿Eliminar la etiqueta "${label.name}"?`;
+    container.appendChild(msg);
+
+    if (this._deletingAffectedCount > 0) {
+      const warning = document.createElement('p');
+      warning.className = 'delete-confirm-warning';
+      warning.setAttribute('role', 'alert');
+      warning.textContent =
+        `Esta etiqueta está asignada a ${this._deletingAffectedCount} ` +
+        `${this._deletingAffectedCount === 1 ? 'tarea' : 'tareas'}.`;
+      container.appendChild(warning);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'delete-confirm-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'delete-btn-cancel';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => {
+      this._deletingId = null;
+      this._buildContent();
+    });
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = 'delete-btn-confirm';
+    confirmBtn.textContent = 'Eliminar';
+    confirmBtn.addEventListener('click', async () => {
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = '…';
+      try {
+        await deleteLabel(label.id);
+        const deletedId = label.id;
+        this._labels = this._labels.filter(l => l.id !== deletedId);
+        this._deletingId = null;
+        this._buildContent();
+        this.dispatchEvent(new CustomEvent('dojo:label-deleted', {
+          bubbles: true, composed: true,
+          detail: { labelId: deletedId },
+        }));
+      } catch (err) {
+        console.error('[dojo-label-manager] Error al eliminar etiqueta:', err);
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = 'Eliminar';
+      }
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    container.appendChild(actions);
+
+    return container;
   }
 
   private _buildEditForm(label: Label): HTMLElement {

--- a/src/db/label.repository.ts
+++ b/src/db/label.repository.ts
@@ -6,9 +6,9 @@
  * en esta capa antes de escribir en IndexedDB.
  */
 
-import { idbRequest, idbTransaction, getStore } from './database.js';
+import { idbRequest, idbTransaction, getStore, openDatabase } from './database.js';
 import { generateUUID } from '../utils/uuid.js';
-import type { Label } from '../types/models.js';
+import type { Label, Task } from '../types/models.js';
 
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
@@ -78,9 +78,40 @@ export async function updateLabel(id: string, changes: UpdateLabelInput): Promis
   return updated;
 }
 
-/** Elimina una etiqueta por su ID. No lanza error si no existe. */
+/** Devuelve el número de tareas que tienen asignada una etiqueta. */
+export async function countTasksByLabelId(labelId: string): Promise<number> {
+  const db    = await openDatabase();
+  const tx    = db.transaction('tasks', 'readonly');
+  const store = tx.objectStore('tasks');
+  const tasks = await idbRequest<Task[]>(store.getAll());
+  return tasks.filter(t => (t.labelIds ?? []).includes(labelId)).length;
+}
+
+/**
+ * Elimina una etiqueta y limpia su referencia en todas las tareas asociadas.
+ * La operación es atómica: usa una transacción que abarca los stores
+ * "labels" y "tasks" para evitar inconsistencias.
+ */
 export async function deleteLabel(id: string): Promise<void> {
-  const { store, tx } = await getStore('labels', 'readwrite');
-  store.delete(id);
+  const db         = await openDatabase();
+  const tx         = db.transaction(['labels', 'tasks'], 'readwrite');
+  const labelStore = tx.objectStore('labels');
+  const taskStore  = tx.objectStore('tasks');
+
+  // Eliminar la etiqueta
+  labelStore.delete(id);
+
+  // Quitar el ID de la etiqueta de todas las tareas que la referenciaban
+  const allTasks = await idbRequest<Task[]>(taskStore.getAll());
+  for (const task of allTasks) {
+    if ((task.labelIds ?? []).includes(id)) {
+      taskStore.put({
+        ...task,
+        labelIds:  task.labelIds.filter(lid => lid !== id),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+  }
+
   await idbTransaction(tx);
 }


### PR DESCRIPTION
## Descripción

Implementa la historia de usuario **US-12 — Eliminar etiqueta** ([#13](https://github.com/Code-Dojo-Labs/agent-app/issues/13)).

Permite al usuario eliminar etiquetas desde el panel de gestión con un flujo de confirmación que muestra el impacto sobre las tareas existentes.

---

## Cambios realizados

### `src/db/label.repository.ts`
- **Nueva función `countTasksByLabelId(labelId)`**: consulta cuántas tareas tienen asignada una etiqueta antes de confirmar la eliminación.
- **Reemplazo de `deleteLabel(id)`**: la versión anterior solo eliminaba del store `labels`. La nueva implementación usa una **transacción atómica multi-store** (`labels` + `tasks`) para:
  - Eliminar la etiqueta del object store `labels`.
  - Limpiar el `labelId` del array `labelIds` de todas las tareas afectadas en la misma transacción.

### `src/components/organisms/dojo-label-manager/dojo-label-manager.ts`
- Agrega estado `_deletingId` y `_deletingAffectedCount`.
- Botón 🗑️ en cada fila de etiqueta (accesible con `aria-label`).
- Panel de confirmación inline `_buildDeleteConfirm()` con:
  - Mensaje descriptivo con el nombre de la etiqueta.
  - Aviso visual (amarillo) indicando cuántas tareas se verán afectadas.
  - Botones "Cancelar" y "Eliminar" con gestión de estado de carga.
- Despacha el evento `dojo:label-deleted` con `{ labelId }` al confirmar.

### `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts`
- **Nuevo método `removeLabel(deletedLabelId)`**: actualiza el caché local de `_labels` y `_tasksByColumn`, y refresca los chips de todas las tarjetas afectadas en el DOM.

### `src/components/organisms/dojo-app/dojo-app.ts`
- Escucha el evento `dojo:label-deleted` y llama a `board.removeLabel(labelId)` para propagar el cambio visualmente sin necesidad de recargar la página.

---

## Criterios de aceptación cubiertos

| Escenario | Estado |
|---|---|
| Eliminar etiqueta sin tareas asignadas | ✅ |
| Diálogo muestra tareas afectadas | ✅ |
| Confirmar eliminación con tareas asignadas (limpieza atómica) | ✅ |
| Cancelar eliminación sin cambios | ✅ |
| Chips desaparecen del tablero sin recarga | ✅ |

---

Closes #13