### PR TITLE
[US-13] Colores de etiquetas con validación de contraste WCAG AA

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -27,6 +27,7 @@
    - [Paso 13 — Implementación de Reutilización de Etiquetas (US-10 / Issue #11)](#paso-13--implementación-de-reutilización-de-etiquetas-us-10--issue-11)
    - [Paso 14 — Implementación de Editar Etiqueta (US-11 / Issue #12)](#paso-14--implementación-de-editar-etiqueta-us-11--issue-12)
    - [Paso 15 — Implementación de Eliminar Etiqueta (US-12 / Issue #13)](#paso-15--implementación-de-eliminar-etiqueta-us-12--issue-13)
+   - [Paso 16 — Implementación de Colores WCAG y Validación de Contraste (US-13 / Issue #14)](#paso-16--implementación-de-colores-wcag-y-validación-de-contraste-us-13--issue-14)
 
 ---
 
@@ -1436,3 +1437,99 @@ removeLabel(deletedLabelId: string): void {
 | 4. Cancelar la eliminación | ✅ Botón "Cancelar" restaura la fila original |
 | 5. Chips desaparecen del tablero sin recarga | ✅ `board.removeLabel()` actualiza DOM reactivamente |
 
+---
+
+### Paso 16 — Implementación de Colores WCAG y Validación de Contraste (US-13 / Issue #14)
+
+**Pull Request:** [#31 — [US-13] Colores de etiquetas con validación de contraste WCAG AA](https://github.com/Code-Dojo-Labs/agent-app/pull/31)  
+**Rama:** `feat/14-colores-etiquetas-contraste-wcag`  
+**Fecha:** 2026-03-26
+
+#### Resumen
+
+Cubre la historia de usuario US-13: la paleta de colores de etiquetas se actualiza a 10 tonos que cumplen WCAG AA (≥ 4.5:1 con texto blanco), y se implementa validación dinámica para colores personalizados que bloquea el guardado y sugiere una alternativa accesible.
+
+#### Archivos modificados
+
+| Archivo | Tipo de cambio |
+|---|---|
+| `src/utils/contrast.ts` | Modificado — nueva función `suggestAccessibleColor()` |
+| `src/components/organisms/dojo-label-manager/dojo-label-manager.ts` | Modificado — paleta WCAG, validación en color custom |
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Modificado — misma paleta y validación WCAG en creación |
+| `src/components/atoms/dojo-task-card/dojo-task-card.ts` | Modificado — texto chips siempre `#FFFFFF` |
+
+#### ADR-17: Paleta de 10 colores obligatorios vs. paleta libre de 12 colores
+
+**Problema:** El código anterior tenía 12 colores brillantes (`#EF4444`, `#F97316`…) que no necesariamente cumplían WCAG AA con texto blanco. El issue especifica exactamente 10 colores oscuros ya validados.
+
+**Decisión:** Reemplazar ambas paletas (`dojo-label-manager` y `dojo-task-detail`) con los mismos 10 colores del spec.
+
+**Consecuencia:** Las etiquetas creadas antes de este cambio que usen colores de la paleta antigua seguirán mostrándose con su color original. Solo los nuevos colores seleccionados pasarán por la validación.
+
+#### ADR-18: `suggestAccessibleColor` — algoritmo de oscurecimiento por factor
+
+**Algoritmo:**
+```typescript
+// Reducir los canales RGB un 10% por iteración hasta cumplir 4.5:1 con #FFFFFF
+for (let factor = 0.90; factor >= 0; factor -= 0.05) {
+  const adjusted = scale(originalRGB, factor);
+  if (meetsWcagAA('#FFFFFF', adjusted)) return adjusted;
+}
+```
+
+**Alternativas consideradas:**
+- Conversión a HSL y reducción de Lightness: más precisa perceptualmente, pero más compleja y sin librería externa no trivial.
+- Tabla de equivalencias manual: no escalable.
+
+**Justificación:** El escalado lineal de RGB es suficientemente preciso para el rango de colores requerido y mantiene el código dentro del principio Zero Dependencies.
+
+#### Flujo de validación WCAG en color personalizado
+
+```
+Usuario abre <input type="color"> y selecciona un color
+    │
+    ▼
+meetsWcagAA('#FFFFFF', color)?
+    │
+    ├─ Sí → contrastWarning oculto, botón Guardar activo
+    │
+    └─ No → suggestAccessibleColor(color) → X_hex
+           │
+           ▼
+        Advertencia visual amarilla:
+        "El color no tiene suficiente contraste…"
+        [swatch X_hex] [Usar versión accesible (X_hex)]
+        Botón Guardar: disabled
+           │
+           └─ Usuario clic "Usar versión accesible"
+                  │
+                  ▼
+              pendingColor = X_hex
+              Actualizar swatch + colorInput
+              Re-validar → pasa → ocultar warning, botón activo
+```
+
+#### Paleta de colores actualizada
+
+| Nombre | Hex | Contraste con #FFFFFF |
+|---|---|---|
+| Rojo | `#B91C1C` | ≥ 4.5:1 ✅ |
+| Naranja | `#C2410C` | ≥ 4.5:1 ✅ |
+| Ámbar | `#B45309` | ≥ 4.5:1 ✅ |
+| Verde | `#15803D` | ≥ 4.5:1 ✅ |
+| Azul | `#1D4ED8` | ≥ 4.5:1 ✅ |
+| Índigo | `#4338CA` | ≥ 4.5:1 ✅ |
+| Violeta | `#6D28D9` | ≥ 4.5:1 ✅ |
+| Rosa | `#BE185D` | ≥ 4.5:1 ✅ |
+| Cian | `#0E7490` | ≥ 4.5:1 ✅ |
+| Gris | `#374151` | ≥ 4.5:1 ✅ |
+
+#### Criterios US-13 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| 1. Seleccionar color de paleta predefinida | ✅ 10 colores sin validación adicional (ya cumplen) |
+| 2. Color personalizado con contraste válido → guardar | ✅ Sin interferencia |
+| 3. Color personalizado con contraste insuficiente → advertencia + sugerencia | ✅ |
+| 4. Texto siempre blanco en chips | ✅ `#FFFFFF` fijo en `dojo-task-card` |
+| 5. Sin dependencias externas de gestión de colores | ✅ Solo `contrast.ts` nativo |

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -29,7 +29,7 @@
  */
 
 import type { Label } from '../../../types/models.js';
-import { pickTextColor } from '../../../utils/contrast.js';
+// US-13: texto de chips siempre #FFFFFF (todos los colores de paleta cumplen ≥ 4.5:1 con blanco)
 
 export class DojoTaskCard extends HTMLElement {
   static readonly TAG = 'dojo-task-card';
@@ -314,7 +314,7 @@ export class DojoTaskCard extends HTMLElement {
         chip.setAttribute('title', lbl.name); // Tooltip para nombres truncados (WCAG 2.1 SC 1.4.4)
         if (HEX_COLOR_RE.test(lbl.color)) {
           chip.style.backgroundColor = lbl.color;
-          try { chip.style.color = pickTextColor(lbl.color); } catch { chip.style.color = '#fff'; }
+          chip.style.color = '#FFFFFF'; // US-13: texto siempre blanco (todos los colores cumplen ≥ 4.5:1 con #FFFFFF)
         } else {
           chip.style.backgroundColor = 'var(--dojo-border)';
         }

--- a/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
+++ b/src/components/organisms/dojo-label-manager/dojo-label-manager.ts
@@ -29,18 +29,19 @@
 
 import type { Label } from '../../../types/models.js';
 import { getAllLabels, updateLabel, deleteLabel, countTasksByLabelId } from '../../../db/label.repository.js';
+import { meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 
-// ── Paleta de colores (idéntica a dojo-task-detail) ────────────────────────
+// ── Paleta de colores WCAG AA (contraste ≥ 4.5:1 con #FFFFFF) — US-13 ─────
 const PRESET_COLORS = [
-  '#EF4444', '#F97316', '#F59E0B', '#EAB308',
-  '#22C55E', '#10B981', '#3B82F6', '#6366F1',
-  '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16',
+  '#B91C1C', '#C2410C', '#B45309', '#15803D',
+  '#1D4ED8', '#4338CA', '#6D28D9', '#BE185D',
+  '#0E7490', '#374151',
 ] as const;
 
 const PRESET_COLOR_NAMES = [
-  'Rojo', 'Naranja', 'Ámbar', 'Amarillo',
-  'Verde', 'Esmeralda', 'Azul', 'Índigo',
-  'Violeta', 'Rosa', 'Cian', 'Lima',
+  'Rojo', 'Naranja', 'Ámbar', 'Verde',
+  'Azul', 'Índigo', 'Violeta', 'Rosa',
+  'Cian', 'Gris',
 ] as const;
 
 // ── Clase ──────────────────────────────────────────────────────────────────
@@ -405,6 +406,45 @@ export class DojoLabelManager extends HTMLElement {
         margin: 0;
       }
 
+      /* Advertencia de contraste WCAG (US-13) */
+      .edit-contrast-warning {
+        font-size: 0.75rem;
+        color: #92400E;
+        margin: 0;
+        background: #FEF3C7;
+        border: 1px solid #F59E0B;
+        border-radius: var(--dojo-radius-sm, 4px);
+        padding: 0.3rem 0.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .edit-contrast-suggestion {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.75rem;
+      }
+      .edit-contrast-swatch {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border-radius: 3px;
+        flex-shrink: 0;
+        border: 1px solid rgba(0,0,0,0.2);
+      }
+      .edit-contrast-apply {
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 0.75rem;
+        color: var(--dojo-primary, #1D4ED8);
+        padding: 0;
+        font-family: inherit;
+        text-decoration: underline;
+      }
+      .edit-contrast-apply:hover { opacity: 0.75; }
+
       /* Acciones del formulario */
       .edit-actions {
         display: flex;
@@ -701,6 +741,8 @@ export class DojoLabelManager extends HTMLElement {
       palette.querySelectorAll('.color-swatch').forEach(s => {
         s.classList.toggle('selected', (s as HTMLElement).dataset['color'] === pendingColor);
       });
+      // Validación de contraste WCAG 2.1 (US-13)
+      updateContrastWarning(pendingColor);
     });
 
     form.appendChild(palette);
@@ -713,6 +755,56 @@ export class DojoLabelManager extends HTMLElement {
     customRow.appendChild(customLabel);
     customRow.appendChild(colorInput);
     form.appendChild(customRow);
+
+    // Advertencia de contraste WCAG (US-13)
+    const contrastWarning = document.createElement('div');
+    contrastWarning.className = 'edit-contrast-warning';
+    contrastWarning.setAttribute('role', 'alert');
+    contrastWarning.style.display = 'none';
+    form.appendChild(contrastWarning);
+
+    // Helper para mostrar/ocultar la advertencia y bloquear el guardado
+    const updateContrastWarning = (color: string): void => {
+      const isPreset = (PRESET_COLORS as readonly string[]).includes(color);
+      if (isPreset || meetsWcagAA('#FFFFFF', color)) {
+        contrastWarning.style.display = 'none';
+        saveBtn.disabled = false;
+        return;
+      }
+      // Calcular sugerencia
+      const suggested = suggestAccessibleColor(color, '#FFFFFF');
+      contrastWarning.innerHTML = '';
+      const msg = document.createElement('span');
+      msg.textContent = 'El color no tiene suficiente contraste con texto blanco (mínimo 4.5:1 WCAG AA).';
+      contrastWarning.appendChild(msg);
+
+      const suggestionRow = document.createElement('span');
+      suggestionRow.className = 'edit-contrast-suggestion';
+      const swatch = document.createElement('span');
+      swatch.className = 'edit-contrast-swatch';
+      swatch.style.backgroundColor = suggested;
+      swatch.setAttribute('aria-hidden', 'true');
+      const applyBtn = document.createElement('button');
+      applyBtn.className = 'edit-contrast-apply';
+      applyBtn.type = 'button';
+      applyBtn.textContent = `Usar versión accesible (${suggested})`;
+      applyBtn.addEventListener('click', () => {
+        pendingColor = suggested;
+        colorInput.value = suggested;
+        palette.querySelectorAll('.color-swatch').forEach(s => {
+          s.classList.toggle('selected', (s as HTMLElement).dataset['color'] === suggested);
+        });
+        updateContrastWarning(suggested);
+      });
+      suggestionRow.appendChild(swatch);
+      suggestionRow.appendChild(applyBtn);
+      contrastWarning.appendChild(suggestionRow);
+      contrastWarning.style.display = '';
+      saveBtn.disabled = true;
+    };
+
+    // Ejecutar validación inicial (por si el color actual no cumple WCAG)
+    updateContrastWarning(pendingColor);
 
     // Mensaje de error
     const errorEl = document.createElement('p');

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -28,7 +28,7 @@
 
 import type { Task, Column, Label, Priority } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
-import { pickTextColor } from '../../../utils/contrast.js';
+import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import { createLabel } from '../../../db/label.repository.js';
 
 // ── Constantes ─────────────────────────────────────────────────────────────
@@ -580,6 +580,17 @@ export class DojoTaskDetail extends HTMLElement {
         font-size: 0.75rem;
         color: #EF4444;
       }
+      .label-contrast-warning {
+        font-size: 0.75rem;
+        color: #92400E;
+        background: #FEF3C7;
+        border: 1px solid #F59E0B;
+        border-radius: var(--dojo-radius-sm, 4px);
+        padding: 0.3rem 0.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
       .label-create-actions {
         display: flex;
         gap: 0.375rem;
@@ -973,15 +984,16 @@ export class DojoTaskDetail extends HTMLElement {
   }
 
   private _buildLabelsField(task: Task): HTMLElement {
+    // Paleta WCAG AA (contraste ≥ 4.5:1 con #FFFFFF) — US-13
     const PRESET_COLORS = [
-      '#EF4444', '#F97316', '#F59E0B', '#EAB308',
-      '#22C55E', '#10B981', '#3B82F6', '#6366F1',
-      '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16',
+      '#B91C1C', '#C2410C', '#B45309', '#15803D',
+      '#1D4ED8', '#4338CA', '#6D28D9', '#BE185D',
+      '#0E7490', '#374151',
     ];
     const PRESET_COLOR_NAMES = [
-      'Rojo', 'Naranja', 'Ámbar', 'Amarillo',
-      'Verde', 'Esmeralda', 'Azul', 'Índigo',
-      'Violeta', 'Rosa', 'Cian', 'Lima',
+      'Rojo', 'Naranja', 'Ámbar', 'Verde',
+      'Azul', 'Índigo', 'Violeta', 'Rosa',
+      'Cian', 'Gris',
     ];
 
     const section = document.createElement('div');
@@ -1155,10 +1167,19 @@ export class DojoTaskDetail extends HTMLElement {
           s.classList.toggle('selected', active);
           s.setAttribute('aria-pressed', String(active));
         });
+        // Validación WCAG 2.1 (US-13): contraste con texto blanco
+        updateContrastWarning(pendingColor);
       });
       customRow.appendChild(customLbl);
       customRow.appendChild(colorInput);
       form.appendChild(customRow);
+
+      // Advertencia de contraste WCAG (US-13)
+      const contrastWarning = document.createElement('div');
+      contrastWarning.className = 'label-contrast-warning';
+      contrastWarning.setAttribute('role', 'alert');
+      contrastWarning.style.display = 'none';
+      form.appendChild(contrastWarning);
 
       const errorEl = document.createElement('span');
       errorEl.className = 'label-error';
@@ -1182,6 +1203,45 @@ export class DojoTaskDetail extends HTMLElement {
           picker.querySelector<HTMLInputElement>('.labels-search')?.focus()
         );
       });
+
+      // Helper para validar y mostrar advertencia de contraste (US-13)
+      const updateContrastWarning = (color: string): void => {
+        const isPreset = PRESET_COLORS.includes(color as typeof PRESET_COLORS[number]);
+        if (isPreset || meetsWcagAA('#FFFFFF', color)) {
+          contrastWarning.style.display = 'none';
+          confirmBtn.disabled = false;
+          return;
+        }
+        const suggested = suggestAccessibleColor(color, '#FFFFFF');
+        contrastWarning.innerHTML = '';
+        const msg = document.createElement('span');
+        msg.textContent = 'El color no tiene suficiente contraste con texto blanco (mínimo 4.5:1 WCAG AA).';
+        contrastWarning.appendChild(msg);
+        const row = document.createElement('span');
+        row.style.cssText = 'display:inline-flex;align-items:center;gap:0.375rem;font-size:0.75rem;';
+        const sw = document.createElement('span');
+        sw.style.cssText = `display:inline-block;width:14px;height:14px;border-radius:3px;background:${suggested};border:1px solid rgba(0,0,0,.2);flex-shrink:0;`;
+        sw.setAttribute('aria-hidden', 'true');
+        const applyBtn = document.createElement('button');
+        applyBtn.type = 'button';
+        applyBtn.style.cssText = 'background:none;border:none;cursor:pointer;font-size:.75rem;color:var(--dojo-primary,#1D4ED8);padding:0;font-family:inherit;text-decoration:underline;';
+        applyBtn.textContent = `Usar versión accesible (${suggested})`;
+        applyBtn.addEventListener('click', () => {
+          pendingColor = suggested;
+          colorInput.value = suggested;
+          palette.querySelectorAll<HTMLButtonElement>('.color-swatch').forEach(s => {
+            const active = s.dataset['color'] === suggested;
+            s.classList.toggle('selected', active);
+            s.setAttribute('aria-pressed', String(active));
+          });
+          updateContrastWarning(suggested);
+        });
+        row.appendChild(sw);
+        row.appendChild(applyBtn);
+        contrastWarning.appendChild(row);
+        contrastWarning.style.display = '';
+        confirmBtn.disabled = true;
+      };
 
       const confirmBtn = document.createElement('button');
       confirmBtn.type = 'button';

--- a/src/utils/contrast.ts
+++ b/src/utils/contrast.ts
@@ -105,3 +105,34 @@ export function pickTextColor(background: string): '#FFFFFF' | '#000000' {
 export function isLabelColorAccessible(bgColor: string): boolean {
   return meetsWcagAA('#FFFFFF', bgColor) || meetsWcagAA('#000000', bgColor);
 }
+
+/**
+ * Sugiere una versión más oscura de `bgColor` que cumpla contraste ≥ 4.5:1 con `foreground`.
+ * Si el color ya cumple el requisito, lo devuelve sin cambios.
+ * El ajuste reduce progresivamente la luminosidad escalando los componentes RGB hacia negro.
+ *
+ * @param bgColor    - Color de fondo en formato hex que puede no pasar el ratio.
+ * @param foreground - Color de texto a evaluar (por defecto "#FFFFFF").
+ * @returns El color original si ya es accesible, o el ajuste más oscuro que lo cumpla.
+ */
+export function suggestAccessibleColor(bgColor: string, foreground: string = '#FFFFFF'): string {
+  if (meetsWcagAA(foreground, bgColor)) return bgColor;
+
+  try {
+    const [r, g, b] = hexToRgb(bgColor);
+    for (let factor = 0.90; factor >= 0; factor -= 0.05) {
+      const nr = Math.round(r * factor);
+      const ng = Math.round(g * factor);
+      const nb = Math.round(b * factor);
+      const adjusted =
+        '#' +
+        nr.toString(16).padStart(2, '0') +
+        ng.toString(16).padStart(2, '0') +
+        nb.toString(16).padStart(2, '0');
+      if (meetsWcagAA(foreground, adjusted)) return adjusted;
+    }
+  } catch {
+    // Si el hex es inválido, devolver el original
+  }
+  return bgColor;
+}


### PR DESCRIPTION
## Descripción

Implementa la historia de usuario **US-13 — Colores de etiquetas con validación de contraste WCAG** ([#14](https://github.com/Code-Dojo-Labs/agent-app/issues/14)).

Actualiza la paleta de colores de etiquetas a 10 tonos que grantizancontraste ≥ 4.5:1 con texto blanco, e implementa validación dinámica para colores personalizados.

---

## Cambios realizados

### `src/utils/contrast.ts`
- **Nueva función `suggestAccessibleColor(bgColor, foreground?)`**: calcula iterativamente la versión más oscura de un color que cumpla contraste ≥ 4.5:1 con el color de texto (por defecto `#FFFFFF`). Usa exclusivamente Web APIs nativas sin dependencias externas.

### `src/components/organisms/dojo-label-manager/dojo-label-manager.ts`
- **Paleta actualizada**: 10 colores WCAG AA conforme al spec de US-13 (`#B91C1C`, `#C2410C`, `#B45309`, `#15803D`, `#1D4ED8`, `#4338CA`, `#6D28D9`, `#BE185D`, `#0E7490`, `#374151`).
- **Importa** `meetsWcagAA` y `suggestAccessibleColor` de `contrast.ts`.
- **Validación WCAG en color personalizado**: al cambiar el `<input type="color">`, si el contraste < 4.5:1 con `#FFFFFF` → muestra advertencia amarilla con sugerencia de color accesible y deshabilita el botón "Guardar". Al aplicar la sugerencia, el botón se reactiva.

### `src/components/organisms/dojo-task-detail/dojo-task-detail.ts`
- Misma paleta de 10 colores WCAG AA.
- Misma lógica de validación en el formulario inline de creación de etiqueta (`buildCreateForm`).
- CSS `.label-contrast-warning` añadido a los estilos del componente.

### `src/components/atoms/dojo-task-card/dojo-task-card.ts`
- **Texto de chips siempre `#FFFFFF`**: eliminado `pickTextColor()` dinámico. Todos los colores de la paleta cumplen ≥ 4.5:1 con blanco, por lo que el texto siempre puede ser blanco.

---

## Criterios de aceptación cubiertos

| Scenario Gherkin | Estado |
|---|---|
| Seleccionar un color de la paleta predefinida (10 colores WCAG AA) | ✅ |
| Seleccionar color personalizado con contraste válido → guardar | ✅ |
| Seleccionar color personalizado con contraste insuficiente → advertencia + sugerencia | ✅ |
| Texto siempre blanco en chips | ✅ |
| Validación implementada sin dependencias externas | ✅ |

---

Closes #14