### PR TITLE
[US-16] Tarjeta de tarea en el tablero

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1325,7 +1325,6 @@ Usuario hace clic en "Gestionar etiquetas" (header)
 
 ---
 
-<<<<<<< HEAD
 ### Paso 15 — Implementación de Eliminar Etiqueta (US-12 / Issue #13)
 
 **Pull Request:** [#30 — [US-12] Eliminar etiqueta con limpieza atómica en IndexedDB](https://github.com/Code-Dojo-Labs/agent-app/pull/30)  
@@ -1717,3 +1716,106 @@ private _filterTasks(tasks: Task[]): Task[] {
 - Espaciado consistente con el resto del toolbar sin CSS adicional para la sección.
 - `display: contents` es standard (amplio soporte de navegadores modernos).
 - La alternativa (`display: flex` sobre el wrapper) crearía un flex-in-flex con gap diferente, requiriendo CSS adicional para alineación.
+
+---
+
+### Paso 19 — Tarjeta de tarea en el tablero (US-16 / Issue #17)
+
+#### Objetivo
+
+Cumplir todos los criterios de aceptación de US-16: chips de etiquetas en la parte superior de la tarjeta, fecha de creación en formato corto, acciones rápidas (drag + delete) solo en hover, y formato de fecha legible en el panel de detalle.
+
+#### Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `src/components/atoms/dojo-task-card/dojo-task-card.ts` | Chips reubicados, footer con fecha, acciones agrupadas en `.card-actions`, atributo `task-created-at` |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | `_renderTaskCards()` pasa `task.createdAt` como `task-created-at` |
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | `_formatDate()` reescrito con formato determinista |
+
+#### Detalle de la implementación
+
+**Reorden de contenido en la tarjeta:**
+
+El orden visual pasa de: `[delete] → [title] → [chips] → [footer]` a:
+
+```
+[card-actions: drag + delete] ← overlay, visible solo en hover
+[chip-row: etiqueta1, etiqueta2...]  ← solo si hay etiquetas
+[title: max 2 líneas + ellipsis]
+[footer: ⬆️ Alta  |  25 mar 2026]
+```
+
+**`task-created-at` observado:**
+
+```typescript
+static get observedAttributes(): string[] {
+  return ['task-id', 'task-title', 'task-priority', 'task-created-at'];
+}
+get createdAt(): string { return this.getAttribute('task-created-at') ?? ''; }
+```
+
+Pasado por el kanban board en `_renderTaskCards()`: `card.setAttribute('task-created-at', task.createdAt)`.
+
+**`_formatCardDate()` — formato determinista:**
+
+```typescript
+private static readonly MONTHS_ES = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+private static _formatCardDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getDate()} ${DojoTaskCard.MONTHS_ES[d.getMonth()]} ${d.getFullYear()}`;
+}
+```
+
+Produce exactamente `"25 mar 2026"` sin depender del locale del SO.
+
+**`.card-actions` en hover:**
+
+```css
+.card-actions { position: absolute; top: 0.375rem; right: 0.375rem;
+  display: flex; align-items: center; gap: 0.125rem; opacity: 0; }
+:host(:hover) .card-actions, :host(:focus-within) .card-actions { opacity: 1; }
+```
+
+**`_formatDate()` en detalle — "25 mar 2026, 10:43":**
+
+Reemplaza `toLocaleString('es-MX')` (producía "10:43 a. m.") por formato manual:
+
+```typescript
+const hh = String(d.getHours()).padStart(2, '0');
+const mm = String(d.getMinutes()).padStart(2, '0');
+return `${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}, ${hh}:${mm}`;
+```
+
+#### Criterios US-16 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| 1. Chips en parte superior (fondo color, texto blanco) | ✅ chip-row antes del título |
+| 2. Título máx. 2 líneas con ellipsis | ✅ `-webkit-line-clamp: 2` |
+| 3. Prioridad en parte inferior izquierda | ✅ `.footer-priority` |
+| 4. Fecha "25 mar 2026" en parte inferior derecha | ✅ `_formatCardDate()` + `.date-label` |
+| 5. Sin chips cuando no hay etiquetas | ✅ `if (this._labels.length > 0)` |
+| 6. Acciones en hover: drag + delete | ✅ `.card-actions` con opacity 0→1 |
+| 7. Clic en tarjeta abre detalle | ✅ `dojo:task-open` (existente) |
+| 8. Fecha en detalle "25 mar 2026, 10:43" | ✅ `_formatDate()` reescrito |
+
+#### ADR-23 — Formato de fecha determinista vs. `toLocaleString()`
+
+**Contexto:** US-16 especifica formatos exactos. `toLocaleString('es-MX')` produce variaciones entre OS/navegador ("a. m." vs "am", "." al final del mes en algunos navegadores).
+
+**Decisión:** Array `MONTHS_ES` estático + concatenación manual garantiza el formato exacto en todos los entornos.
+
+**Consecuencias:**
+- Comportamiento idéntico en Chrome, Firefox, Safari y cualquier locale del OS.
+- No hay internacionalización (aceptable para esta app monolingüe).
+
+#### ADR-24 — Agrupación de acciones en `.card-actions`
+
+**Contexto:** US-06 añadió `quick-delete-btn` absoluto independiente. US-16 requiere también un drag handle. Mantener dos elementos absolutos independientes complica el posicionamiento.
+
+**Decisión:** Un único `.card-actions` div agrupa ambas acciones. La transición `opacity: 0 → 1` se aplica una sola vez al contenedor.
+
+**Consecuencias:**
+- Una regla CSS gestiona la visibilidad de todas las acciones actuales y futuras.
+- El evento `dojo:task-delete-request` sigue siendo idéntico (sin breaking changes en la API pública).

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -35,7 +35,7 @@ export class DojoTaskCard extends HTMLElement {
   static readonly TAG = 'dojo-task-card';
 
   static get observedAttributes(): string[] {
-    return ['task-id', 'task-title', 'task-priority'];
+    return ['task-id', 'task-title', 'task-priority', 'task-created-at'];
   }
 
   private _shadow: ShadowRoot;
@@ -84,6 +84,7 @@ export class DojoTaskCard extends HTMLElement {
   get taskId(): string    { return this.getAttribute('task-id') ?? ''; }
   get taskTitle(): string { return this.getAttribute('task-title') ?? ''; }
   get priority(): string  { return this.getAttribute('task-priority') ?? 'medium'; }
+  get createdAt(): string { return this.getAttribute('task-created-at') ?? ''; }
 
   // ── Drag handlers ─────────────────────────────────────────────────────────
 
@@ -166,11 +167,24 @@ export class DojoTaskCard extends HTMLElement {
         outline-offset: 2px;
       }
 
-      /* Botón de eliminación rápida (US-06) */
-      .quick-delete-btn {
+      /* Acciones rápidas en hover (US-06, US-16) */
+      .card-actions {
         position: absolute;
         top: 0.375rem;
         right: 0.375rem;
+        display: flex;
+        align-items: center;
+        gap: 0.125rem;
+        opacity: 0;
+        transition: opacity 0.15s;
+        z-index: 1;
+      }
+      :host(:hover) .card-actions,
+      :host(:focus-within) .card-actions {
+        opacity: 1;
+      }
+      .quick-delete-btn,
+      .drag-handle-btn {
         background: transparent;
         border: none;
         cursor: pointer;
@@ -179,22 +193,26 @@ export class DojoTaskCard extends HTMLElement {
         font-size: 0.8125rem;
         color: var(--dojo-text-secondary);
         line-height: 1;
-        opacity: 0;
-        transition: opacity 0.15s, background 0.15s, color 0.15s;
-        z-index: 1;
-      }
-      :host(:hover) .quick-delete-btn,
-      :host(:focus-within) .quick-delete-btn {
-        opacity: 1;
+        font-family: inherit;
+        transition: background 0.15s, color 0.15s;
       }
       .quick-delete-btn:hover {
         background: #FEE2E2;
         color: #EF4444;
       }
-      .quick-delete-btn:focus-visible {
-        outline: 2px solid #EF4444;
+      .drag-handle-btn {
+        cursor: grab;
+      }
+      .drag-handle-btn:hover {
+        background: var(--dojo-bg);
+      }
+      .drag-handle-btn:active {
+        cursor: grabbing;
+      }
+      .quick-delete-btn:focus-visible,
+      .drag-handle-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
         outline-offset: 2px;
-        opacity: 1;
       }
 
       /* Indicador de posición de drop — línea en la parte superior */
@@ -235,8 +253,15 @@ export class DojoTaskCard extends HTMLElement {
         margin: 0 0 0.5rem 0;
       }
 
-      /* Footer: prioridad */
+      /* Footer: prioridad (izq) + fecha (der) */
       .footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.375rem;
+        margin-top: 0.25rem;
+      }
+      .footer-priority {
         display: flex;
         align-items: center;
         gap: 0.375rem;
@@ -253,6 +278,14 @@ export class DojoTaskCard extends HTMLElement {
         color: var(--dojo-text-muted, var(--dojo-text-secondary));
         text-transform: uppercase;
         letter-spacing: 0.03em;
+      }
+
+      /* Fecha de creación (US-16) */
+      .date-label {
+        font-size: 0.625rem;
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+        white-space: nowrap;
+        flex-shrink: 0;
       }
 
       /* Chips de etiquetas (US-10) */
@@ -279,27 +312,35 @@ export class DojoTaskCard extends HTMLElement {
     `;
     this._shadow.appendChild(style);
 
-    // Botón de eliminación rápida (US-06)
+    // ── Acciones rápidas en hover (US-06, US-16) ──────────────────────────
+    const cardActions = document.createElement('div');
+    cardActions.className = 'card-actions';
+
+    const dragHandleBtn = document.createElement('button');
+    dragHandleBtn.className = 'drag-handle-btn';
+    dragHandleBtn.type = 'button';
+    dragHandleBtn.setAttribute('aria-label', 'Arrastrar tarea');
+    dragHandleBtn.textContent = '⠿';
+    dragHandleBtn.addEventListener('click', (e: MouseEvent) => {
+      e.stopPropagation(); // evitar que abra el detalle al hacer clic en el handle
+    });
+    cardActions.appendChild(dragHandleBtn);
+
     const quickDeleteBtn = document.createElement('button');
     quickDeleteBtn.className = 'quick-delete-btn';
     quickDeleteBtn.setAttribute('aria-label', `Eliminar tarea: ${this.taskTitle}`);
     quickDeleteBtn.textContent = '🗑';
     quickDeleteBtn.addEventListener('click', (e: MouseEvent) => {
-      e.stopPropagation(); // Evitar que dispare dojo:task-open
+      e.stopPropagation();
       this.dispatchEvent(new CustomEvent('dojo:task-delete-request', {
         bubbles: true, composed: true,
         detail: { taskId: this.taskId, taskTitle: this.taskTitle },
       }));
     });
-    this._shadow.appendChild(quickDeleteBtn);
+    cardActions.appendChild(quickDeleteBtn);
+    this._shadow.appendChild(cardActions);
 
-    // Título
-    const titleEl = document.createElement('p');
-    titleEl.className = 'title';
-    titleEl.textContent = this.taskTitle; // textContent es seguro contra XSS
-    this._shadow.appendChild(titleEl);
-
-    // Chips de etiquetas (US-10)
+    // ── Chips de etiquetas — parte superior (US-10, US-16) ─────────────────
     if (this._labels.length > 0) {
       const HEX_COLOR_RE = /^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/;
       const chipRow = document.createElement('div');
@@ -311,10 +352,10 @@ export class DojoTaskCard extends HTMLElement {
         chip.className = 'task-label-chip';
         chip.setAttribute('role', 'listitem');
         chip.textContent = lbl.name;
-        chip.setAttribute('title', lbl.name); // Tooltip para nombres truncados (WCAG 2.1 SC 1.4.4)
+        chip.setAttribute('title', lbl.name);
         if (HEX_COLOR_RE.test(lbl.color)) {
           chip.style.backgroundColor = lbl.color;
-          chip.style.color = '#FFFFFF'; // US-13: texto siempre blanco (todos los colores cumplen ≥ 4.5:1 con #FFFFFF)
+          chip.style.color = '#FFFFFF';
         } else {
           chip.style.backgroundColor = 'var(--dojo-border)';
         }
@@ -323,10 +364,19 @@ export class DojoTaskCard extends HTMLElement {
       this._shadow.appendChild(chipRow);
     }
 
-    // Footer de prioridad
+    // ── Título ────────────────────────────────────────────────────────────
+    const titleEl = document.createElement('p');
+    titleEl.className = 'title';
+    titleEl.textContent = this.taskTitle;
+    this._shadow.appendChild(titleEl);
+
+    // ── Footer: prioridad (izq) + fecha de creación (der, US-16) ──────────
     const footer = document.createElement('div');
     footer.className = 'footer';
     footer.setAttribute('aria-label', `Prioridad: ${pConfig.label}`);
+
+    const footerPriority = document.createElement('div');
+    footerPriority.className = 'footer-priority';
 
     const iconEl = document.createElement('span');
     iconEl.className = 'priority-icon';
@@ -338,9 +388,34 @@ export class DojoTaskCard extends HTMLElement {
     label.setAttribute('aria-hidden', 'true');
     label.textContent = pConfig.label;
 
-    footer.appendChild(iconEl);
-    footer.appendChild(label);
+    footerPriority.appendChild(iconEl);
+    footerPriority.appendChild(label);
+    footer.appendChild(footerPriority);
+
+    const dateStr = DojoTaskCard._formatCardDate(this.createdAt);
+    if (dateStr) {
+      const dateEl = document.createElement('span');
+      dateEl.className = 'date-label';
+      dateEl.setAttribute('aria-label', `Creado el ${dateStr}`);
+      dateEl.textContent = dateStr;
+      footer.appendChild(dateEl);
+    }
+
     this._shadow.appendChild(footer);
+  }
+
+  /** Formatea una fecha ISO a "25 mar 2026" para uso en tarjetas. */
+  private static readonly MONTHS_ES = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+
+  private static _formatCardDate(iso: string): string {
+    if (!iso) return '';
+    try {
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) return '';
+      return `${d.getDate()} ${DojoTaskCard.MONTHS_ES[d.getMonth()]} ${d.getFullYear()}`;
+    } catch {
+      return '';
+    }
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -796,9 +796,10 @@ export class DojoKanbanBoard extends HTMLElement {
     const filtered = this._filterTasks(sorted);
     for (const task of filtered) {
       const card = document.createElement('dojo-task-card');
-      card.setAttribute('task-id',       task.id);
-      card.setAttribute('task-title',    task.title);
-      card.setAttribute('task-priority', task.priority);
+      card.setAttribute('task-id',         task.id);
+      card.setAttribute('task-title',      task.title);
+      card.setAttribute('task-priority',   task.priority);
+      card.setAttribute('task-created-at', task.createdAt);
       (card as TaskCardElement).taskLabels = this._getTaskLabels(task);
       colEl.appendChild(card);
     }

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -1459,10 +1459,15 @@ export class DojoTaskDetail extends HTMLElement {
 
   private _formatDate(iso: string): string {
     try {
-      return new Date(iso).toLocaleString('es-MX', {
-        day: 'numeric', month: 'short', year: 'numeric',
-        hour: '2-digit', minute: '2-digit',
-      });
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) return iso;
+      const months = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+      const day   = d.getDate();
+      const month = months[d.getMonth()];
+      const year  = d.getFullYear();
+      const hh    = String(d.getHours()).padStart(2, '0');
+      const mm    = String(d.getMinutes()).padStart(2, '0');
+      return `${day} ${month} ${year}, ${hh}:${mm}`;
     } catch {
       return iso;
     }


### PR DESCRIPTION
## Descripción

Implementación de la historia de usuario US-16: visualización de tarjetas de tarea con información relevante visible directamente en el tablero.

## Cambios realizados

### `src/components/atoms/dojo-task-card/dojo-task-card.ts`

- **Chips de etiquetas reubicados encima del título** (antes estaban debajo). Cumple el criterio "parte superior de la tarjeta".
- **Atributo `task-created-at`** añadido a `observedAttributes` con su getter `createdAt`.
- **Footer reestructurado**: prioridad (izquierda) + fecha de creación (derecha) con `justify-content: space-between`.
- **`.card-actions` en hover**: drag handle (`⠿`) e icono de eliminar (`🗑`) agrupados en un contenedor con `opacity: 0 → 1` al hacer hover. Elimina el `quick-delete-btn` absoluto previo y lo reemplaza por un grupo unificado.
- **`_formatCardDate()`**: helper estático determinista que produce exactamente `"25 mar 2026"` sin depender del locale del SO.

### `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts`

- `_renderTaskCards()` ahora pasa `task.createdAt` como atributo `task-created-at` a cada `<dojo-task-card>`.

### `src/components/organisms/dojo-task-detail/dojo-task-detail.ts`

- `_formatDate()` reescrito con formato determinista: `"25 mar 2026, 10:43"` (sin AM/PM, sin dependencia de locale del SO). Ya no usa `toLocaleString('es-MX')`.

## Criterios de aceptación cubiertos

- [x] Chips de etiquetas en la parte superior con fondo de color y texto blanco
- [x] Título máximo 2 líneas con ellipsis
- [x] Ícono y texto de prioridad en parte inferior izquierda
- [x] Fecha de creación "25 mar 2026" en parte inferior derecha
- [x] Sin chips cuando la tarea no tiene etiquetas
- [x] Acciones rápidas (drag + delete) solo visibles en hover
- [x] Clic en tarjeta abre el panel de detalle
- [x] Fecha en panel de detalle: "25 mar 2026, 10:43"

Cierra #17