### PR TITLE
feat(tasks): add due dates and visual alerts

### DIFF
--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -29,13 +29,14 @@
  */
 
 import type { Label } from '../../../types/models.js';
+import { getDueStatus, formatRelativeDate, type DueStatus } from '../../../utils/date.js';
 // US-13: texto de chips siempre #FFFFFF (todos los colores de paleta cumplen ≥ 4.5:1 con blanco)
 
 export class DojoTaskCard extends HTMLElement {
   static readonly TAG = 'dojo-task-card';
 
   static get observedAttributes(): string[] {
-    return ['task-id', 'task-title', 'task-priority', 'task-created-at'];
+    return ['task-id', 'task-title', 'task-priority', 'task-created-at', 'task-due-date'];
   }
 
   private _shadow: ShadowRoot;
@@ -85,6 +86,7 @@ export class DojoTaskCard extends HTMLElement {
   get taskTitle(): string { return this.getAttribute('task-title') ?? ''; }
   get priority(): string  { return this.getAttribute('task-priority') ?? 'medium'; }
   get createdAt(): string { return this.getAttribute('task-created-at') ?? ''; }
+  get dueDate(): string   { return this.getAttribute('task-due-date') ?? ''; }
 
   // ── Drag handlers ─────────────────────────────────────────────────────────
 
@@ -127,9 +129,19 @@ export class DojoTaskCard extends HTMLElement {
 
   // ── Render ────────────────────────────────────────────────────────────────
 
+  /** Mapeo estado → clase CSS para borde de alerta de vencimiento (US-17). */
+  private static readonly DUE_STATUS_CLASS: Record<DueStatus, string> = {
+    overdue:    'due-overdue',
+    'due-soon': 'due-soon',
+    normal:     '',
+    none:       '',
+  };
+
   private _render(): void {
     const p       = this.priority as keyof typeof DojoTaskCard.PRIORITY_CONFIG;
     const pConfig = DojoTaskCard.PRIORITY_CONFIG[p] ?? DojoTaskCard.PRIORITY_CONFIG.medium;
+    const dueStatus = getDueStatus(this.dueDate || null);
+    const dueCls    = DojoTaskCard.DUE_STATUS_CLASS[dueStatus];
 
     this._shadow.innerHTML = '';
 
@@ -288,6 +300,35 @@ export class DojoTaskCard extends HTMLElement {
         flex-shrink: 0;
       }
 
+      /* ── Alertas de vencimiento (US-17) ── */
+      :host(.due-overdue) {
+        border-color: var(--dojo-due-overdue, #EF4444);
+        border-width: 2px;
+      }
+      :host(.due-soon) {
+        border-color: var(--dojo-due-soon, #F59E0B);
+        border-width: 2px;
+      }
+      .due-date-label {
+        font-size: 0.625rem;
+        white-space: nowrap;
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2rem;
+      }
+      .due-date-label.due-overdue {
+        color: var(--dojo-due-overdue, #EF4444);
+        font-weight: 600;
+      }
+      .due-date-label.due-soon {
+        color: var(--dojo-due-soon, #F59E0B);
+        font-weight: 600;
+      }
+      .due-date-label.due-normal {
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+      }
+
       /* Chips de etiquetas (US-10) */
       .chip-row {
         display: flex;
@@ -311,6 +352,10 @@ export class DojoTaskCard extends HTMLElement {
       }
     `;
     this._shadow.appendChild(style);
+
+    // ── Clase de alerta de vencimiento en el host (US-17) ─────────────────
+    this.classList.remove('due-overdue', 'due-soon');
+    if (dueCls) this.classList.add(dueCls);
 
     // ── Acciones rápidas en hover (US-06, US-16) ──────────────────────────
     const cardActions = document.createElement('div');
@@ -399,6 +444,19 @@ export class DojoTaskCard extends HTMLElement {
       dateEl.setAttribute('aria-label', `Creado el ${dateStr}`);
       dateEl.textContent = dateStr;
       footer.appendChild(dateEl);
+    }
+
+    // ── Fecha de vencimiento relativa (US-17) ─────────────────────────────
+    const dueRelative = formatRelativeDate(this.dueDate || null);
+    if (dueRelative) {
+      const dueEl = document.createElement('span');
+      const statusCls = dueStatus === 'overdue' ? 'due-overdue'
+                      : dueStatus === 'due-soon' ? 'due-soon'
+                      : 'due-normal';
+      dueEl.className = `due-date-label ${statusCls}`;
+      dueEl.setAttribute('aria-label', `Vence ${dueRelative}`);
+      dueEl.textContent = `📅 ${dueRelative}`;
+      footer.appendChild(dueEl);
     }
 
     this._shadow.appendChild(footer);

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -454,7 +454,10 @@ export class DojoTaskCard extends HTMLElement {
                       : dueStatus === 'due-soon' ? 'due-soon'
                       : 'due-normal';
       dueEl.className = `due-date-label ${statusCls}`;
-      dueEl.setAttribute('aria-label', `Vence ${dueRelative}`);
+      const ariaLabel = dueStatus === 'overdue'
+        ? `Venció ${dueRelative}`
+        : `Vence ${dueRelative}`;
+      dueEl.setAttribute('aria-label', ariaLabel);
       dueEl.textContent = `📅 ${dueRelative}`;
       footer.appendChild(dueEl);
     }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -800,6 +800,7 @@ export class DojoKanbanBoard extends HTMLElement {
       card.setAttribute('task-title',      task.title);
       card.setAttribute('task-priority',   task.priority);
       card.setAttribute('task-created-at', task.createdAt);
+      if (task.dueDate) card.setAttribute('task-due-date', task.dueDate);
       (card as TaskCardElement).taskLabels = this._getTaskLabels(task);
       colEl.appendChild(card);
     }
@@ -1116,11 +1117,12 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private async _handleCreateTask(e: CustomEvent): Promise<void> {
-    const { statusId, title, description, priority } = e.detail as {
+    const { statusId, title, description, priority, dueDate } = e.detail as {
       statusId:    string;
       title:       string;
       description: string;
       priority:    string;
+      dueDate?:    string | null;
     };
     // Validar que la columna exista (puede haberse eliminado mientras el diálogo estaba abierto)
     if (!this._columns.some(c => c.id === statusId)) {
@@ -1136,6 +1138,7 @@ export class DojoKanbanBoard extends HTMLElement {
         priority:  priority as Task['priority'],
         labelIds:  [],
         order:     tasks.length,
+        dueDate:   dueDate ?? null,
       });
       this._tasksByColumn.set(statusId, [...tasks, newTask]);
       this._refreshColumnCards(statusId);
@@ -1212,7 +1215,7 @@ export class DojoKanbanBoard extends HTMLElement {
         } else if (changes.labelIds !== undefined && this._activeFilter.labelIds?.length) {
           // Etiquetas cambiaron y hay filtro activo — puede que la tarjeta deba desaparecer
           this._refreshColumnCards(sourceColumnId);
-        } else if (changes.title !== undefined || changes.priority !== undefined || changes.labelIds !== undefined) {
+        } else if (changes.title !== undefined || changes.priority !== undefined || changes.labelIds !== undefined || changes.dueDate !== undefined) {
           const colEl = this._shadow.querySelector(
             `dojo-kanban-column[column-id="${CSS.escape(sourceColumnId)}"]`
           );
@@ -1222,6 +1225,13 @@ export class DojoKanbanBoard extends HTMLElement {
               if (changes.title    !== undefined) cardEl.setAttribute('task-title',    updated.title);
               if (changes.priority !== undefined) cardEl.setAttribute('task-priority', updated.priority);
               if (changes.labelIds !== undefined) (cardEl as TaskCardElement).taskLabels = this._getTaskLabels(updated);
+              if (changes.dueDate !== undefined) {
+                if (updated.dueDate) {
+                  cardEl.setAttribute('task-due-date', updated.dueDate);
+                } else {
+                  cardEl.removeAttribute('task-due-date');
+                }
+              }
             }
           }
         }

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -42,10 +42,13 @@ import '../../organisms/dojo-delete-confirm-dialog/dojo-delete-confirm-dialog.js
 
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
+type SortMode = 'order' | 'due-date';
+
 interface ActiveFilter {
   priorities?: Priority[];
   labelIds?: string[];
   searchText?: string;
+  sortBy?: SortMode;
 }
 
 /** Contrato de la propiedad taskLabels expuesta por dojo-task-card (US-10). */
@@ -458,6 +461,30 @@ export class DojoKanbanBoard extends HTMLElement {
     this._filterSearchInput = searchInput;
     content.appendChild(searchInput);
 
+    // ── Selector de ordenamiento (US-17) ──────────────────────────────────
+    const sortLabel = document.createElement('label');
+    sortLabel.className = 'filter-label';
+    sortLabel.textContent = 'Orden:';
+    sortLabel.setAttribute('for', 'sort-select');
+    content.appendChild(sortLabel);
+
+    const sortSelect = document.createElement('select');
+    sortSelect.id = 'sort-select';
+    sortSelect.className = 'filter-search';
+    sortSelect.setAttribute('aria-label', 'Ordenar tareas');
+    const optOrder = document.createElement('option');
+    optOrder.value = 'order';
+    optOrder.textContent = 'Manual';
+    const optDue = document.createElement('option');
+    optDue.value = 'due-date';
+    optDue.textContent = 'Fecha de vencimiento';
+    sortSelect.appendChild(optOrder);
+    sortSelect.appendChild(optDue);
+    sortSelect.addEventListener('change', () => {
+      this.activeFilter = { ...this._activeFilter, sortBy: sortSelect.value as SortMode };
+    });
+    content.appendChild(sortSelect);
+
     // ── Separador ─────────────────────────────────────────────────────────
     const sep1 = document.createElement('div');
     sep1.className = 'filter-sep';
@@ -792,7 +819,15 @@ export class DojoKanbanBoard extends HTMLElement {
    * Las tarjetas se proyectan en el default slot del componente.
    */
   private _renderTaskCards(colEl: Element, tasks: Task[]): void {
-    const sorted   = [...tasks].sort((a, b) => a.order - b.order);
+    const sortMode = this._activeFilter.sortBy ?? 'order';
+    const sorted = [...tasks].sort((a, b) => {
+      if (sortMode === 'due-date') {
+        const aDate = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+        const bDate = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+        if (aDate !== bDate) return aDate - bDate;
+      }
+      return a.order - b.order;
+    });
     const filtered = this._filterTasks(sorted);
     for (const task of filtered) {
       const card = document.createElement('dojo-task-card');

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -1447,20 +1447,36 @@ export class DojoTaskDetail extends HTMLElement {
     input.className = 'field-select';
     input.type      = 'date';
     input.setAttribute('aria-label', 'Fecha de vencimiento');
-    // Convertir ISO a formato YYYY-MM-DD para el input
+    // Convertir ISO a formato YYYY-MM-DD para el input usando hora local
     if (task.dueDate) {
       try {
         const d = new Date(task.dueDate);
         if (!isNaN(d.getTime())) {
-          input.value = d.toISOString().slice(0, 10);
+          const year  = d.getFullYear();
+          const month = String(d.getMonth() + 1).padStart(2, '0');
+          const day   = String(d.getDate()).padStart(2, '0');
+          input.value = `${year}-${month}-${day}`;
         }
       } catch { /* ignorar fecha inválida */ }
     }
 
     input.addEventListener('change', () => {
-      const isoValue = input.value
-        ? new Date(input.value + 'T23:59:59').toISOString()
-        : null;
+      let isoValue: string | null = null;
+      if (input.value) {
+        const parts = input.value.split('-');
+        if (parts.length === 3) {
+          const [yearStr, monthStr, dayStr] = parts;
+          const year  = Number(yearStr);
+          const month = Number(monthStr);
+          const day   = Number(dayStr);
+          if (!Number.isNaN(year) && !Number.isNaN(month) && !Number.isNaN(day)) {
+            const d = new Date(year, month - 1, day, 23, 59, 59, 999);
+            if (!isNaN(d.getTime())) {
+              isoValue = d.toISOString();
+            }
+          }
+        }
+      }
       this._save({ dueDate: isoValue });
     });
 

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -731,6 +731,7 @@ export class DojoTaskDetail extends HTMLElement {
 
     body.appendChild(this._buildTitleField(task));
     body.appendChild(this._buildStatusPriorityRow(task));
+    body.appendChild(this._buildDueDateField(task));
     body.appendChild(this._buildDescriptionField(task));
     body.appendChild(this._buildLabelsField(task));
     body.appendChild(this._buildMetadata(task));
@@ -1423,6 +1424,61 @@ export class DojoTaskDetail extends HTMLElement {
     section.appendChild(sectionLbl);
     section.appendChild(chips);
     section.appendChild(picker);
+    return section;
+  }
+
+  /** Campo de fecha de vencimiento con auto-save (US-17). */
+  private _buildDueDateField(task: Task): HTMLElement {
+    const section = document.createElement('div');
+    section.className = 'section';
+
+    const lbl = document.createElement('label');
+    lbl.className = 'section-lbl';
+    lbl.setAttribute('for', 'detail-due-date');
+    lbl.textContent = 'Fecha de vencimiento';
+
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '0.5rem';
+
+    const input = document.createElement('input');
+    input.id        = 'detail-due-date';
+    input.className = 'field-select';
+    input.type      = 'date';
+    input.setAttribute('aria-label', 'Fecha de vencimiento');
+    // Convertir ISO a formato YYYY-MM-DD para el input
+    if (task.dueDate) {
+      try {
+        const d = new Date(task.dueDate);
+        if (!isNaN(d.getTime())) {
+          input.value = d.toISOString().slice(0, 10);
+        }
+      } catch { /* ignorar fecha inválida */ }
+    }
+
+    input.addEventListener('change', () => {
+      const isoValue = input.value
+        ? new Date(input.value + 'T23:59:59').toISOString()
+        : null;
+      this._save({ dueDate: isoValue });
+    });
+
+    const clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.className = 'close-btn';
+    clearBtn.setAttribute('aria-label', 'Eliminar fecha de vencimiento');
+    clearBtn.textContent = '✕';
+    clearBtn.style.flexShrink = '0';
+    clearBtn.addEventListener('click', () => {
+      input.value = '';
+      this._save({ dueDate: null });
+    });
+
+    row.appendChild(input);
+    row.appendChild(clearBtn);
+    section.appendChild(lbl);
+    section.appendChild(row);
     return section;
   }
 

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -363,6 +363,23 @@ export class DojoTaskDialog extends HTMLElement {
     priField.appendChild(priSelect);
     dialog.appendChild(priField);
 
+    // ── Campo: Fecha de vencimiento (opcional, US-17) ─────────────────────
+    const dueField = document.createElement('div');
+    dueField.className = 'field';
+
+    const dueLabel = document.createElement('label');
+    dueLabel.setAttribute('for', 'task-due-date-input');
+    dueLabel.textContent = 'Fecha de vencimiento (opcional)';
+
+    const dueInput = document.createElement('input');
+    dueInput.id   = 'task-due-date-input';
+    dueInput.type = 'date';
+    dueInput.setAttribute('aria-label', 'Fecha de vencimiento');
+
+    dueField.appendChild(dueLabel);
+    dueField.appendChild(dueInput);
+    dialog.appendChild(dueField);
+
     // ── Acciones ───────────────────────────────────────────────────────────
     const actions = document.createElement('div');
     actions.className = 'actions';
@@ -394,6 +411,7 @@ export class DojoTaskDialog extends HTMLElement {
           title,
           description: descInput.value.trim(),
           priority:    priSelect.value as Priority,
+          dueDate:     dueInput.value ? new Date(dueInput.value + 'T23:59:59').toISOString() : null,
         },
       }));
       this._close();

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -411,7 +411,15 @@ export class DojoTaskDialog extends HTMLElement {
           title,
           description: descInput.value.trim(),
           priority:    priSelect.value as Priority,
-          dueDate:     dueInput.value ? new Date(dueInput.value + 'T23:59:59').toISOString() : null,
+          dueDate:     (() => {
+            if (!dueInput.value) return null;
+            const parts = dueInput.value.split('-');
+            if (parts.length !== 3) return null;
+            const [y, m, d] = parts.map(Number);
+            if (Number.isNaN(y) || Number.isNaN(m) || Number.isNaN(d)) return null;
+            const date = new Date(y, m - 1, d, 23, 59, 59, 999);
+            return isNaN(date.getTime()) ? null : date.toISOString();
+          })(),
         },
       }));
       this._close();

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -29,6 +29,8 @@ export interface Task {
   createdAt: string;
   /** Fecha de última modificación en formato ISO 8601. */
   updatedAt: string;
+  /** Fecha de vencimiento en formato ISO 8601. Null/undefined = sin vencimiento (US-17). */
+  dueDate?: string | null;
   /** Posición dentro de la columna (para ordenamiento manual). */
   order: number;
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,73 @@
+/**
+ * date.ts — Utilidades de fecha de vencimiento (US-17)
+ *
+ * Calcula el estado de vencimiento y genera texto relativo
+ * usando `Intl.RelativeTimeFormat`. Zero dependencies.
+ */
+
+// ── Tipos ──────────────────────────────────────────────────────────────────
+
+export type DueStatus = 'overdue' | 'due-soon' | 'normal' | 'none';
+
+// ── Constantes ─────────────────────────────────────────────────────────────
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR   = 3_600_000;
+const MS_PER_DAY    = 86_400_000;
+const DUE_SOON_MS   = 48 * MS_PER_HOUR; // 48 horas
+
+// ── Formatter singleton ────────────────────────────────────────────────────
+
+let _rtf: Intl.RelativeTimeFormat | null = null;
+
+function getFormatter(): Intl.RelativeTimeFormat {
+  if (!_rtf) _rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+  return _rtf;
+}
+
+// ── API pública ────────────────────────────────────────────────────────────
+
+/**
+ * Determina el estado de vencimiento de una tarea.
+ * - `'overdue'`   → ya venció
+ * - `'due-soon'`  → vence dentro de 48 h
+ * - `'normal'`    → vence en más de 48 h
+ * - `'none'`      → sin fecha asignada
+ */
+export function getDueStatus(dueDate?: string | null): DueStatus {
+  if (!dueDate) return 'none';
+  const diff = new Date(dueDate).getTime() - Date.now();
+  if (isNaN(diff)) return 'none';
+  if (diff < 0) return 'overdue';
+  if (diff <= DUE_SOON_MS) return 'due-soon';
+  return 'normal';
+}
+
+/**
+ * Devuelve una cadena relativa legible: "mañana", "en 3 días", "hace 2 días", etc.
+ * Retorna cadena vacía si la fecha es inválida o no se proporciona.
+ */
+export function formatRelativeDate(iso?: string | null): string {
+  if (!iso) return '';
+  const target = new Date(iso).getTime();
+  if (isNaN(target)) return '';
+
+  const diff = target - Date.now();
+  const absDiff = Math.abs(diff);
+  const rtf = getFormatter();
+
+  if (absDiff < MS_PER_MINUTE) return 'ahora';
+
+  if (absDiff < MS_PER_HOUR) {
+    const mins = Math.round(diff / MS_PER_MINUTE);
+    return rtf.format(mins, 'minute');
+  }
+
+  if (absDiff < MS_PER_DAY) {
+    const hours = Math.round(diff / MS_PER_HOUR);
+    return rtf.format(hours, 'hour');
+  }
+
+  const days = Math.round(diff / MS_PER_DAY);
+  return rtf.format(days, 'day');
+}


### PR DESCRIPTION
## Resumen

Implementa fechas de vencimiento y alertas visuales en las tarjetas del tablero Kanban según la historia de usuario US-17.

## Cambios realizados

### Modelo de datos
- **`src/types/models.ts`** — Añadido campo opcional `dueDate?: string | null` a la interfaz `Task`

### Nueva utilidad
- **`src/utils/date.ts`** — Funciones `getDueStatus()` y `formatRelativeDate()` usando `Intl.RelativeTimeFormat` nativo (zero dependencies)

### Componentes actualizados

| Componente | Cambio |
|---|---|
| `dojo-task-card` | Nuevo atributo `task-due-date`, borde rojo (vencida) / ámbar (≤48h), fecha relativa en footer |
| `dojo-task-dialog` | Campo `<input type="date">` opcional en formulario de creación |
| `dojo-task-detail` | Campo de fecha editable con auto-save + botón para eliminar fecha |
| `dojo-kanban-board` | Pasa `task-due-date` a cards, incluye `dueDate` en flujo de creación, actualiza atributo al editar |

## Criterios de aceptación cubiertos

- ✅ Asignar fecha de vencimiento al crear una tarea
- ✅ Asignar/modificar fecha al editar una tarea
- ✅ Mostrar fecha en formato relativo ("en 2 días", "mañana", "ayer")
- ✅ Borde rojo para tareas vencidas
- ✅ Borde ámbar para tareas próximas a vencer (48h)
- ✅ Sin fecha = sin indicador ni borde de alerta
- ✅ Eliminar fecha de vencimiento desde el panel de detalle

## Notas técnicas

- No requiere migración de IndexedDB (campo opcional en objetos existentes)
- Compilación TypeScript limpia (`tsc --noEmit` sin errores)
- Respeta las constraints del proyecto: zero dependencies, Shadow DOM, CSS Custom Properties

Closes #35