### PR TITLE
feat(export-import): exportación e importación de datos del tablero (US-19)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -32,6 +32,7 @@
    - [Paso 18 — Búsqueda y filtrado de tareas (US-15 / Issue #16)](#paso-18--búsqueda-y-filtrado-de-tareas-us-15--issue-16)
    - [Paso 19 — Tarjeta de tarea en el tablero (US-16 / Issue #17)](#paso-19--tarjeta-de-tarea-en-el-tablero-us-16--issue-17)
    - [Paso 20 — Modo oscuro automático (US-18 / Issue #36)](#paso-20--modo-oscuro-automático-us-18--issue-36)
+   - [Paso 21 — Exportación e importación de datos (US-19 / Issue #37)](#paso-21--exportación-e-importación-de-datos-us-19--issue-37)
 
 ---
 
@@ -1933,3 +1934,108 @@ Para evitar el destello de tema incorrecto antes de que carguen los módulos ES,
 - Sin conflictos de especificidad CSS.
 - Funcionalidad de override manual sin necesidad de `[data-theme="light"]` adicional.
 - Requiere JavaScript habilitado (aceptable para esta SPA).
+
+---
+
+### Paso 21 — Exportación e importación de datos (US-19 / Issue #37)
+
+> **PR:** [#53](https://github.com/Code-Dojo-Labs/agent-app/pull/53) — `feat/37-exportacion-importacion-datos`
+> **Fecha:** 2026-03-28
+
+#### Resumen
+
+Se implementó la funcionalidad de exportación e importación completa del tablero en formato JSON versionado, permitiendo copias de seguridad y transferencia de datos entre navegadores o dispositivos.
+
+#### Arquitectura
+
+```
+src/db/export-import.ts          ← Servicio de exportación/importación (nuevo)
+src/components/organisms/
+  └── dojo-app/dojo-app.ts       ← UI: botones, diálogo de confirmación, toasts
+```
+
+##### Servicio `export-import.ts`
+
+El servicio encapsula toda la lógica de serialización, validación e importación atómica:
+
+| Función | Responsabilidad |
+|---|---|
+| `exportBoardData()` | Lee columns, tasks y labels en una sola transacción `readonly` atómica |
+| `downloadBoardExport(data)` | Genera un `Blob` JSON y dispara la descarga con nombre `dojo-kanban-export-{timestamp}.json` |
+| `readImportFile(file)` | Lee un `File` del navegador y lo parsea como JSON |
+| `validateImportData(raw)` | Valida estructura, versión, y tipos de cada entidad (Column, Task, Label) |
+| `importBoardData(data)` | Reemplaza los datos en una sola transacción `readwrite` atómica (clear + add) |
+
+##### Formato de exportación (v1)
+
+```json
+{
+  "version": 1,
+  "exportedAt": "2026-03-28T12:00:00.000Z",
+  "columns": [ { "id": "...", "name": "...", "icon": "...", "order": 0 } ],
+  "tasks": [ { "id": "...", "title": "...", ... } ],
+  "labels": [ { "id": "...", "name": "...", "color": "#..." } ]
+}
+```
+
+El campo `version` permite migraciones futuras sin romper archivos antiguos. La constante `SUPPORTED_VERSIONS` controla qué versiones son aceptadas al importar.
+
+##### Validación de importación
+
+La función `validateImportData()` comprueba:
+1. Estructura raíz: `version` (number), `exportedAt` (string), `columns`/`tasks`/`labels` (arrays).
+2. Versión soportada: solo `SUPPORTED_VERSIONS` (actualmente `{1}`).
+3. Integridad de cada entidad: campos obligatorios con tipos correctos (`_isValidColumn`, `_isValidTask`, `_isValidLabel`).
+
+Si la validación falla, se devuelve un mensaje descriptivo al usuario sin intentar la importación.
+
+##### Atomicidad de la importación
+
+```typescript
+const tx = db.transaction(['columns', 'tasks', 'labels'], 'readwrite');
+colStore.clear();
+taskStore.clear();
+labelStore.clear();
+for (const col of data.columns)   colStore.add(col);
+for (const task of data.tasks)    taskStore.add(task);
+for (const label of data.labels)  labelStore.add(label);
+await idbTransaction(tx);
+```
+
+Al usar una única transacción `readwrite`, si algún paso falla (store corrupto, datos inválidos), IndexedDB revierte **todos** los cambios automáticamente. Los datos del usuario nunca quedan en estado parcial.
+
+##### Flujo de UI
+
+1. **Exportar:** click en 📤 → `exportBoardData()` → `downloadBoardExport()` → descarga automática + toast de éxito.
+2. **Importar:** click en 📥 → `<input type="file">` oculto → selección de archivo → `readImportFile()` → `validateImportData()` → diálogo de confirmación → `importBoardData()` → recarga del tablero + toast de éxito.
+
+##### Diálogo de confirmación
+
+Se implementó un diálogo inline en el Shadow DOM de `dojo-app` (no un componente separado) con:
+- `role="alertdialog"` + `aria-labelledby` + `aria-describedby` para accesibilidad.
+- Focus automático al botón "Cancelar" (acción segura por defecto).
+- Cierre al hacer clic en el backdrop.
+- Botón "Importar y reemplazar" en rojo (`--dojo-danger`) para señalar la acción destructiva.
+
+#### Criterios US-19 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| Exportar datos del tablero completo | ✅ `exportBoardData()` lee los 3 stores |
+| Formato del archivo exportado (version, exportedAt, columns, tasks, labels) | ✅ Estructura validada |
+| Importar datos reemplazando los existentes | ✅ Transacción atómica clear + add |
+| Cancelar importación antes de reemplazar datos | ✅ Diálogo con botón Cancelar |
+| Importar un archivo con formato inválido | ✅ `validateImportData()` devuelve error descriptivo |
+| Importar un archivo con versión no soportada | ✅ Validación de `SUPPORTED_VERSIONS` |
+| Exportar tablero vacío | ✅ Devuelve JSON válido con arrays vacíos |
+
+#### ADR-26 — Transacción atómica para import/export
+
+**Contexto:** La importación reemplaza todos los datos del tablero. Un fallo a mitad de la operación podría dejar la base de datos en estado inconsistente (tareas sin columnas, etiquetas huérfanas).
+
+**Decisión:** Usar una única transacción `readwrite` que abarca los tres object stores (`columns`, `tasks`, `labels`). Si cualquier operación falla, IndexedDB aborta y revierte la transacción completa.
+
+**Consecuencias:**
+- Integridad garantizada: nunca hay datos parcialmente importados.
+- No requiere rollback manual.
+- Limitación: archivos extremadamente grandes podrían alcanzar límites de memoria del navegador (aceptable para uso de tablero personal).

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -29,6 +29,36 @@ export class DojoApp extends HTMLElement {
   static readonly TAG = 'dojo-app';
 
   private _shadow: ShadowRoot;
+  /** Datos pendientes de importación (tras validación, previo a confirmación). */
+  private _pendingImport: import('../../../db/export-import.js').BoardExport | null = null;
+  private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Referencia estable para poder eliminar el listener de teclado del diálogo de importación. */
+  private _onImportKeydown = (e: KeyboardEvent): void => {
+    if (!this.hasAttribute('import-confirm')) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this._hideImportConfirm();
+      return;
+    }
+    // Focus trap: mantener Tab dentro del diálogo (WCAG 2.1 SC 2.1.2)
+    if (e.key === 'Tab') {
+      const focusable = Array.from(
+        this._shadow.querySelectorAll<HTMLElement>('.import-dialog button:not([disabled])')
+      ).filter(el => el.offsetParent !== null);
+      if (focusable.length < 2) return;
+      const first  = focusable[0];
+      const last   = focusable[focusable.length - 1];
+      const active = this._shadow.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
 
   constructor() {
     super();
@@ -39,6 +69,10 @@ export class DojoApp extends HTMLElement {
     // Guarda de idempotencia: evita re-render al mover el elemento en el DOM
     if (this._shadow.childElementCount > 0) return;
     this._render();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('keydown', this._onImportKeydown);
   }
 
   private _render(): void {
@@ -401,9 +435,6 @@ export class DojoApp extends HTMLElement {
 
   // ── Export/Import (US-19) ────────────────────────────────────────────────
 
-  /** Datos pendientes de importación (tras validación, previo a confirmación). */
-  private _pendingImport: import('../../../db/export-import.js').BoardExport | null = null;
-
   private async _handleExport(): Promise<void> {
     try {
       const data = await exportBoardData();
@@ -440,6 +471,8 @@ export class DojoApp extends HTMLElement {
     this.setAttribute('import-confirm', '');
     const dialog = this._shadow.querySelector<HTMLElement>('.import-dialog');
     dialog?.setAttribute('aria-hidden', 'false');
+    document.removeEventListener('keydown', this._onImportKeydown);
+    document.addEventListener('keydown', this._onImportKeydown);
     requestAnimationFrame(() => {
       this._shadow.querySelector<HTMLElement>('.import-cancel-btn')?.focus();
     });
@@ -447,6 +480,7 @@ export class DojoApp extends HTMLElement {
 
   private _hideImportConfirm(): void {
     this.removeAttribute('import-confirm');
+    document.removeEventListener('keydown', this._onImportKeydown);
     const dialog = this._shadow.querySelector<HTMLElement>('.import-dialog');
     dialog?.setAttribute('aria-hidden', 'true');
     this._pendingImport = null;
@@ -467,8 +501,6 @@ export class DojoApp extends HTMLElement {
       this._showToast(msg, true);
     }
   }
-
-  private _toastTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _showToast(message: string, isError = false): void {
     const toast = this._shadow.querySelector<HTMLElement>('.toast');

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -17,6 +17,13 @@ import '../dojo-label-manager/dojo-label-manager.js';
 import '../../atoms/dojo-theme-toggle/dojo-theme-toggle.js';
 
 import type { Label } from '../../../types/models.js';
+import {
+  exportBoardData,
+  downloadBoardExport,
+  readImportFile,
+  validateImportData,
+  importBoardData,
+} from '../../../db/export-import.js';
 
 export class DojoApp extends HTMLElement {
   static readonly TAG = 'dojo-app';
@@ -81,8 +88,8 @@ export class DojoApp extends HTMLElement {
         flex-shrink: 0;
       }
 
-      /* Botón Gestionar etiquetas */
-      .manage-labels-btn {
+      /* Botones del header (gestionar etiquetas, exportar, importar) */
+      .header-btn {
         display: inline-flex;
         align-items: center;
         gap: 0.375rem;
@@ -95,17 +102,140 @@ export class DojoApp extends HTMLElement {
         font-family: inherit;
         cursor: pointer;
         transition: background 0.15s, color 0.15s, border-color 0.15s;
-        margin-left: auto;
         white-space: nowrap;
       }
-      .manage-labels-btn:hover {
+      .header-btn:hover {
         background: var(--dojo-bg);
         color: var(--dojo-text-primary);
         border-color: var(--dojo-primary, #1D4ED8);
       }
-      .manage-labels-btn:focus-visible {
+      .header-btn:focus-visible {
         outline: 2px solid var(--dojo-primary, #1D4ED8);
         outline-offset: 2px;
+      }
+      .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-left: auto;
+      }
+      .import-input { display: none; }
+
+      /* ── Diálogo de confirmación de importación ───────────────── */
+      .import-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+        z-index: 300;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease;
+      }
+      :host([import-confirm]) .import-backdrop {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .import-dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -56%);
+        z-index: 301;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+        padding: 1.5rem;
+        width: 400px;
+        max-width: calc(100vw - 2rem);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease, transform 0.18s ease;
+      }
+      :host([import-confirm]) .import-dialog {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translate(-50%, -50%);
+      }
+      .import-dialog-icon {
+        font-size: 2rem;
+        text-align: center;
+        margin-bottom: 0.75rem;
+        line-height: 1;
+      }
+      .import-dialog-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        text-align: center;
+        margin: 0 0 0.5rem;
+      }
+      .import-dialog-body {
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        text-align: center;
+        margin: 0 0 1.25rem;
+        line-height: 1.5;
+      }
+      .import-dialog-actions {
+        display: flex;
+        gap: 0.625rem;
+        justify-content: flex-end;
+      }
+      .import-cancel-btn,
+      .import-confirm-btn {
+        padding: 0.4375rem 1rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s;
+      }
+      .import-cancel-btn {
+        background: transparent;
+        border: 1px solid var(--dojo-border);
+        color: var(--dojo-text-primary);
+      }
+      .import-cancel-btn:hover { background: var(--dojo-bg); }
+      .import-confirm-btn {
+        background: var(--dojo-danger, #DC2626);
+        border: 1px solid transparent;
+        color: #fff;
+        font-weight: 600;
+      }
+      .import-confirm-btn:hover { opacity: 0.9; }
+      .import-cancel-btn:focus-visible,
+      .import-confirm-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* ── Toast de notificación ─────────────────────────────── */
+      .toast {
+        position: fixed;
+        bottom: 1.5rem;
+        left: 50%;
+        transform: translateX(-50%) translateY(120%);
+        z-index: 400;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        box-shadow: var(--dojo-shadow-md, 0 4px 6px rgba(0,0,0,.07));
+        padding: 0.75rem 1.25rem;
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.25s ease, opacity 0.25s ease;
+      }
+      .toast.visible {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateX(-50%) translateY(0);
+      }
+      .toast.error {
+        border-color: var(--dojo-danger, #DC2626);
+        color: var(--dojo-danger, #DC2626);
       }
 
       /* ── Área del tablero (ocupa el espacio restante) ─────────────── */
@@ -139,7 +269,7 @@ export class DojoApp extends HTMLElement {
     subtitle.textContent = 'Zero Dependencies';
 
     const manageLabelBtn = document.createElement('button');
-    manageLabelBtn.className = 'manage-labels-btn';
+    manageLabelBtn.className = 'header-btn';
     manageLabelBtn.type = 'button';
     manageLabelBtn.setAttribute('aria-label', 'Gestionar etiquetas');
     const btnIcon = document.createElement('span');
@@ -153,11 +283,56 @@ export class DojoApp extends HTMLElement {
       (labelMgr as any).show();
     });
 
+    // ── Botón Exportar (US-19) ──────────────────────────────────────────────
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'header-btn';
+    exportBtn.type = 'button';
+    exportBtn.setAttribute('aria-label', 'Exportar datos del tablero');
+    const exportIcon = document.createElement('span');
+    exportIcon.setAttribute('aria-hidden', 'true');
+    exportIcon.textContent = '📤';
+    const exportText = document.createElement('span');
+    exportText.textContent = 'Exportar';
+    exportBtn.appendChild(exportIcon);
+    exportBtn.appendChild(exportText);
+    exportBtn.addEventListener('click', () => this._handleExport());
+
+    // ── Botón Importar (US-19) ──────────────────────────────────────────────
+    const importBtn = document.createElement('button');
+    importBtn.className = 'header-btn';
+    importBtn.type = 'button';
+    importBtn.setAttribute('aria-label', 'Importar datos al tablero');
+    const importIcon = document.createElement('span');
+    importIcon.setAttribute('aria-hidden', 'true');
+    importIcon.textContent = '📥';
+    const importText = document.createElement('span');
+    importText.textContent = 'Importar';
+    importBtn.appendChild(importIcon);
+    importBtn.appendChild(importText);
+
+    const importInput = document.createElement('input');
+    importInput.type = 'file';
+    importInput.accept = '.json,application/json';
+    importInput.className = 'import-input';
+    importInput.addEventListener('change', () => this._handleImportFile(importInput));
+    importBtn.addEventListener('click', () => {
+      importInput.value = '';
+      importInput.click();
+    });
+
     const themeToggle = document.createElement('dojo-theme-toggle');
+
+    // Grupo de acciones del header
+    const headerActions = document.createElement('div');
+    headerActions.className = 'header-actions';
+    headerActions.appendChild(manageLabelBtn);
+    headerActions.appendChild(exportBtn);
+    headerActions.appendChild(importBtn);
+    headerActions.appendChild(importInput);
 
     appHeader.appendChild(logo);
     appHeader.appendChild(title);
-    appHeader.appendChild(manageLabelBtn);
+    appHeader.appendChild(headerActions);
     appHeader.appendChild(themeToggle);
     this._shadow.appendChild(appHeader);
 
@@ -185,6 +360,129 @@ export class DojoApp extends HTMLElement {
       const { labelId } = (e as CustomEvent).detail as { labelId: string };
       (board as any).removeLabel?.(labelId);
     });
+
+    // ── Diálogo de confirmación de importación (US-19) ──────────────────────
+    const importBackdrop = document.createElement('div');
+    importBackdrop.className = 'import-backdrop';
+    importBackdrop.addEventListener('click', () => this._hideImportConfirm());
+
+    const importDialog = document.createElement('div');
+    importDialog.className = 'import-dialog';
+    importDialog.setAttribute('role', 'alertdialog');
+    importDialog.setAttribute('aria-labelledby', 'import-dialog-title');
+    importDialog.setAttribute('aria-describedby', 'import-dialog-body');
+    importDialog.setAttribute('aria-hidden', 'true');
+    importDialog.innerHTML = `
+      <div class="import-dialog-icon" aria-hidden="true">⚠️</div>
+      <h2 class="import-dialog-title" id="import-dialog-title">Importar datos</h2>
+      <p class="import-dialog-body" id="import-dialog-body">
+        Los datos actuales del tablero serán <strong>reemplazados</strong> por los del archivo importado. Esta acción no se puede deshacer.
+      </p>
+      <div class="import-dialog-actions">
+        <button class="import-cancel-btn" type="button">Cancelar</button>
+        <button class="import-confirm-btn" type="button">Importar y reemplazar</button>
+      </div>
+    `;
+    importDialog.querySelector('.import-cancel-btn')!
+      .addEventListener('click', () => this._hideImportConfirm());
+    importDialog.querySelector('.import-confirm-btn')!
+      .addEventListener('click', () => this._confirmImport(board));
+
+    this._shadow.appendChild(importBackdrop);
+    this._shadow.appendChild(importDialog);
+
+    // ── Toast de notificación (US-19) ────────────────────────────────────────
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    this._shadow.appendChild(toast);
+  }
+
+  // ── Export/Import (US-19) ────────────────────────────────────────────────
+
+  /** Datos pendientes de importación (tras validación, previo a confirmación). */
+  private _pendingImport: import('../../../db/export-import.js').BoardExport | null = null;
+
+  private async _handleExport(): Promise<void> {
+    try {
+      const data = await exportBoardData();
+      downloadBoardExport(data);
+      this._showToast('Datos exportados correctamente.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error al exportar';
+      this._showToast(msg, true);
+    }
+  }
+
+  private async _handleImportFile(input: HTMLInputElement): Promise<void> {
+    const file = input.files?.[0];
+    if (!file) return;
+
+    try {
+      const raw    = await readImportFile(file);
+      const result = validateImportData(raw);
+
+      if (!result.ok) {
+        this._showToast(result.message, true);
+        return;
+      }
+
+      this._pendingImport = result.data;
+      this._showImportConfirm();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error al leer el archivo';
+      this._showToast(msg, true);
+    }
+  }
+
+  private _showImportConfirm(): void {
+    this.setAttribute('import-confirm', '');
+    const dialog = this._shadow.querySelector<HTMLElement>('.import-dialog');
+    dialog?.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLElement>('.import-cancel-btn')?.focus();
+    });
+  }
+
+  private _hideImportConfirm(): void {
+    this.removeAttribute('import-confirm');
+    const dialog = this._shadow.querySelector<HTMLElement>('.import-dialog');
+    dialog?.setAttribute('aria-hidden', 'true');
+    this._pendingImport = null;
+  }
+
+  private async _confirmImport(board: HTMLElement): Promise<void> {
+    if (!this._pendingImport) return;
+
+    try {
+      await importBoardData(this._pendingImport);
+      this._hideImportConfirm();
+      // Recargar el tablero completo para reflejar los nuevos datos
+      (board as any)._loadBoard?.();
+      this._showToast('Datos importados correctamente.');
+    } catch (err) {
+      this._hideImportConfirm();
+      const msg = err instanceof Error ? err.message : 'Error al importar';
+      this._showToast(msg, true);
+    }
+  }
+
+  private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private _showToast(message: string, isError = false): void {
+    const toast = this._shadow.querySelector<HTMLElement>('.toast');
+    if (!toast) return;
+
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+
+    toast.textContent = message;
+    toast.classList.toggle('error', isError);
+    toast.classList.add('visible');
+
+    this._toastTimer = setTimeout(() => {
+      toast.classList.remove('visible');
+    }, 3500);
   }
 }
 

--- a/src/db/export-import.ts
+++ b/src/db/export-import.ts
@@ -1,0 +1,236 @@
+/**
+ * export-import.ts — Exportación e importación de datos del tablero.
+ *
+ * Permite generar una snapshot completa del tablero en formato JSON
+ * (columnas, tareas, etiquetas) y restaurarla reemplazando los datos actuales.
+ *
+ * El formato incluye un campo `version` para soportar migraciones futuras
+ * y un campo `exportedAt` con la fecha de exportación en ISO 8601.
+ *
+ * US-19: Exportación e importación de datos.
+ */
+
+import { openDatabase, idbRequest, idbTransaction } from './database.js';
+import type { Column, Task, Label } from '../types/models.js';
+
+// ── Tipos ──────────────────────────────────────────────────────────────────
+
+/** Versión actual del formato de exportación. */
+const CURRENT_VERSION = 1;
+
+/** Versiones soportadas para importación. */
+const SUPPORTED_VERSIONS = new Set([1]);
+
+/** Estructura del archivo exportado. */
+export interface BoardExport {
+  version: number;
+  exportedAt: string;
+  columns: Column[];
+  tasks: Task[];
+  labels: Label[];
+}
+
+/** Resultado de la validación de un archivo importado. */
+interface ValidationResult {
+  ok: true;
+  data: BoardExport;
+}
+
+interface ValidationError {
+  ok: false;
+  message: string;
+}
+
+type ValidateResult = ValidationResult | ValidationError;
+
+// ── Exportación ────────────────────────────────────────────────────────────
+
+/**
+ * Genera una snapshot completa del tablero en formato `BoardExport`.
+ * Lee los tres object stores (columns, tasks, labels) en una sola transacción
+ * readonly para garantizar consistencia.
+ */
+export async function exportBoardData(): Promise<BoardExport> {
+  const db = await openDatabase();
+  const tx = db.transaction(['columns', 'tasks', 'labels'], 'readonly');
+  const columns = await idbRequest<Column[]>(tx.objectStore('columns').getAll());
+  const tasks   = await idbRequest<Task[]>(tx.objectStore('tasks').getAll());
+  const labels  = await idbRequest<Label[]>(tx.objectStore('labels').getAll());
+
+  return {
+    version:    CURRENT_VERSION,
+    exportedAt: new Date().toISOString(),
+    columns:    columns.sort((a, b) => a.order - b.order),
+    tasks,
+    labels:     labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })),
+  };
+}
+
+/**
+ * Descarga la snapshot como un archivo `.json` usando un link temporal.
+ */
+export function downloadBoardExport(data: BoardExport): void {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url  = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href     = url;
+  a.download = `dojo-kanban-export-${_fileTimestamp()}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ── Importación ────────────────────────────────────────────────────────────
+
+/**
+ * Lee un `File` seleccionado por el usuario y lo parsea como JSON.
+ * Devuelve el contenido parseado o lanza un error descriptivo.
+ */
+export async function readImportFile(file: File): Promise<unknown> {
+  const text = await file.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error('El archivo seleccionado no contiene JSON válido.');
+  }
+}
+
+/**
+ * Valida que un objeto desconocido tenga la estructura esperada de `BoardExport`.
+ * Verifica: version, exportedAt, columns, tasks, labels.
+ */
+export function validateImportData(raw: unknown): ValidateResult {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, message: 'El archivo no tiene la estructura esperada.' };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // version
+  if (typeof obj.version !== 'number') {
+    return { ok: false, message: 'El archivo no contiene un campo "version" válido.' };
+  }
+  if (!SUPPORTED_VERSIONS.has(obj.version)) {
+    return { ok: false, message: `La versión ${obj.version} no es compatible. Versiones soportadas: ${[...SUPPORTED_VERSIONS].join(', ')}.` };
+  }
+
+  // exportedAt
+  if (typeof obj.exportedAt !== 'string') {
+    return { ok: false, message: 'El archivo no contiene un campo "exportedAt" válido.' };
+  }
+
+  // columns
+  if (!Array.isArray(obj.columns)) {
+    return { ok: false, message: 'El archivo no contiene la colección "columns".' };
+  }
+  for (const col of obj.columns) {
+    if (!_isValidColumn(col)) {
+      return { ok: false, message: 'Una o más columnas tienen un formato inválido.' };
+    }
+  }
+
+  // tasks
+  if (!Array.isArray(obj.tasks)) {
+    return { ok: false, message: 'El archivo no contiene la colección "tasks".' };
+  }
+  for (const task of obj.tasks) {
+    if (!_isValidTask(task)) {
+      return { ok: false, message: 'Una o más tareas tienen un formato inválido.' };
+    }
+  }
+
+  // labels
+  if (!Array.isArray(obj.labels)) {
+    return { ok: false, message: 'El archivo no contiene la colección "labels".' };
+  }
+  for (const label of obj.labels) {
+    if (!_isValidLabel(label)) {
+      return { ok: false, message: 'Una o más etiquetas tienen un formato inválido.' };
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      version:    obj.version as number,
+      exportedAt: obj.exportedAt as string,
+      columns:    obj.columns as Column[],
+      tasks:      obj.tasks as Task[],
+      labels:     obj.labels as Label[],
+    },
+  };
+}
+
+/**
+ * Reemplaza todos los datos del tablero con los datos importados.
+ * Opera en una única transacción readwrite atómica: si algún paso falla,
+ * IndexedDB revierte los cambios automáticamente.
+ */
+export async function importBoardData(data: BoardExport): Promise<void> {
+  const db = await openDatabase();
+  const tx = db.transaction(['columns', 'tasks', 'labels'], 'readwrite');
+
+  const colStore   = tx.objectStore('columns');
+  const taskStore  = tx.objectStore('tasks');
+  const labelStore = tx.objectStore('labels');
+
+  // 1. Limpiar stores existentes
+  colStore.clear();
+  taskStore.clear();
+  labelStore.clear();
+
+  // 2. Insertar datos importados
+  for (const col of data.columns)   colStore.add(col);
+  for (const task of data.tasks)    taskStore.add(task);
+  for (const label of data.labels)  labelStore.add(label);
+
+  await idbTransaction(tx);
+}
+
+// ── Helpers privados ───────────────────────────────────────────────────────
+
+function _fileTimestamp(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+function _isValidColumn(obj: unknown): obj is Column {
+  if (obj === null || typeof obj !== 'object') return false;
+  const c = obj as Record<string, unknown>;
+  return (
+    typeof c.id    === 'string' &&
+    typeof c.name  === 'string' &&
+    typeof c.icon  === 'string' &&
+    typeof c.order === 'number'
+  );
+}
+
+function _isValidTask(obj: unknown): obj is Task {
+  if (obj === null || typeof obj !== 'object') return false;
+  const t = obj as Record<string, unknown>;
+  return (
+    typeof t.id          === 'string' &&
+    typeof t.title       === 'string' &&
+    typeof t.description === 'string' &&
+    typeof t.statusId    === 'string' &&
+    typeof t.priority    === 'string' &&
+    Array.isArray(t.labelIds) &&
+    typeof t.createdAt   === 'string' &&
+    typeof t.updatedAt   === 'string' &&
+    typeof t.order       === 'number'
+  );
+}
+
+function _isValidLabel(obj: unknown): obj is Label {
+  if (obj === null || typeof obj !== 'object') return false;
+  const l = obj as Record<string, unknown>;
+  return (
+    typeof l.id    === 'string' &&
+    typeof l.name  === 'string' &&
+    typeof l.color === 'string'
+  );
+}


### PR DESCRIPTION
## Resumen

Implementa la funcionalidad de exportación e importación de datos del tablero en formato JSON, según los criterios de aceptación de la US-19.

## Cambios realizados

### Nuevo archivo: `src/db/export-import.ts`
- **`exportBoardData()`** — Lee columnas, tareas y etiquetas en una sola transacción readonly atómica.
- **`downloadBoardExport(data)`** — Genera y descarga el archivo JSON con timestamp en el nombre.
- **`readImportFile(file)`** — Lee un archivo seleccionado por el usuario y lo parsea como JSON.
- **`validateImportData(raw)`** — Valida estructura, versión (`v1`), tipos de datos de columnas, tareas y etiquetas.
- **`importBoardData(data)`** — Reemplaza todos los datos en una transacción readwrite atómica (clear + add).

### Modificado: `src/components/organisms/dojo-app/dojo-app.ts`
- Botones **Exportar** (📤) e **Importar** (📥) en el header de la aplicación.
- Diálogo de confirmación antes de importar (advierte que los datos serán reemplazados).
- Notificaciones toast para éxito y error.
- Recarga automática del tablero tras importación exitosa.

## Formato de exportación (v1)

```json
{
  "version": 1,
  "exportedAt": "2026-03-28T...",
  "columns": [...],
  "tasks": [...],
  "labels": [...]
}
```

## Escenarios cubiertos

- ✅ Exportar datos del tablero completo
- ✅ Formato versionado con `version` y `exportedAt`
- ✅ Importar datos reemplazando los existentes (con confirmación)
- ✅ Cancelar importación sin modificar datos
- ✅ Importar archivo con formato inválido → error
- ✅ Importar archivo con versión no soportada → error
- ✅ Exportar tablero vacío → JSON válido con colecciones vacías

## Constraints respetados

- Zero Dependencies (solo Web APIs nativas: IndexedDB, Blob, URL.createObjectURL)
- Shadow DOM encapsulado
- CSS Custom Properties para theming
- A11Y: `role="alertdialog"`, `aria-live="polite"`, focus management

Closes #37