### PR TITLE
feat(activity): implementar historial de actividad por tarea (US-20)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -33,6 +33,7 @@
    - [Paso 19 — Tarjeta de tarea en el tablero (US-16 / Issue #17)](#paso-19--tarjeta-de-tarea-en-el-tablero-us-16--issue-17)
    - [Paso 20 — Modo oscuro automático (US-18 / Issue #36)](#paso-20--modo-oscuro-automático-us-18--issue-36)
    - [Paso 21 — Exportación e importación de datos (US-19 / Issue #37)](#paso-21--exportación-e-importación-de-datos-us-19--issue-37)
+   - [Paso 22 — Historial de actividad por tarea (US-20 / Issue #38)](#paso-22--historial-de-actividad-por-tarea-us-20--issue-38)
 
 ---
 
@@ -2039,3 +2040,110 @@ Se implementó un diálogo inline en el Shadow DOM de `dojo-app` (no un componen
 - Integridad garantizada: nunca hay datos parcialmente importados.
 - No requiere rollback manual.
 - Limitación: archivos extremadamente grandes podrían alcanzar límites de memoria del navegador (aceptable para uso de tablero personal).
+
+---
+
+### Paso 22 — Historial de actividad por tarea (US-20 / Issue #38)
+
+> **PR:** [#54](https://github.com/Code-Dojo-Labs/agent-app/pull/54) — `feat/38-historial-actividad-tarea`
+> **Fecha:** 2026-03-28
+
+#### Resumen
+
+Se implementó un sistema de historial de actividad que registra automáticamente los cambios realizados en cada tarea (creación, cambio de estado, cambio de prioridad, adición/eliminación de etiquetas) y los presenta en una línea temporal dentro del panel de detalle.
+
+#### Arquitectura
+
+```
+src/types/models.ts                          ← Interfaz ActivityEvent + ActivityEventType
+src/db/database.ts                           ← Migración v1 → v2 (store activity)
+src/db/activity.repository.ts                ← CRUD de eventos de actividad (nuevo)
+src/db/export-import.ts                      ← Soporte de activity en export/import
+src/components/organisms/
+  ├── dojo-kanban-board/dojo-kanban-board.ts  ← Registro de eventos en handlers
+  └── dojo-task-detail/dojo-task-detail.ts    ← Sección UI de actividad
+```
+
+##### Modelo de datos
+
+```ts
+type ActivityEventType = 'created' | 'status_change' | 'priority_change' | 'label_added' | 'label_removed';
+
+interface ActivityEvent {
+  id: string;          // UUID v4
+  taskId: string;      // FK → Task.id
+  type: ActivityEventType;
+  payload: Record<string, unknown>;  // Datos específicos por tipo
+  createdAt: string;   // ISO 8601
+}
+```
+
+**Payloads por tipo:**
+
+| Tipo | Payload |
+|---|---|
+| `created` | `{}` |
+| `status_change` | `{ from: string, to: string }` (nombres de columna) |
+| `priority_change` | `{ from: string, to: string }` (valores de prioridad) |
+| `label_added` | `{ labelId: string, labelName: string }` |
+| `label_removed` | `{ labelId: string, labelName: string }` |
+
+##### Migración de IndexedDB
+
+Se incrementó `DB_VERSION` de 1 a 2. La migración `v1 → v2` crea el object store `activity` con keyPath `id` e índice `by-taskId` (no único). La estructura de migración incremental existente garantiza que usuarios con datos en v1 migran sin pérdida.
+
+##### Repositorio `activity.repository.ts`
+
+| Función | Descripción |
+|---|---|
+| `addActivityEvent(input)` | Crea un evento con UUID e ISO timestamp auto-generados |
+| `getActivitiesByTaskId(taskId)` | Devuelve eventos ordenados del más reciente al más antiguo |
+| `deleteActivitiesByTaskId(taskId)` | Elimina todos los eventos de una tarea (limpieza al borrar) |
+
+##### Puntos de integración en `dojo-kanban-board`
+
+Los eventos se registran en los handlers existentes sin modificar el flujo principal:
+
+- **`_handleCreateTask`** → `addActivityEvent({ type: 'created' })` tras `createTask()`
+- **`_handleTaskFieldUpdated`** → Detecta cambios comparando caché vs nuevos valores:
+  - `statusId` diferente → `status_change` con nombres de columna
+  - `priority` diferente → `priority_change` con valores anterior/nuevo
+  - `labelIds` diferente → diff de conjuntos para `label_added`/`label_removed`
+- **`_handleTaskDrop`** (drag & drop) → `status_change` al mover entre columnas
+- **`_handleTaskDeleteConfirm`** → `deleteActivitiesByTaskId()` para limpieza
+- **Eliminación de columna con tareas** → Limpieza de actividad por cada tarea
+
+##### Sección de actividad en `dojo-task-detail`
+
+La sección se carga de forma **asíncrona** tras construir el panel, evitando bloquear la apertura. Un guard de race condition verifica que el `taskId` aún coincida antes de renderizar.
+
+Cada evento se muestra en un grid de 3 columnas: ícono — descripción — fecha relativa. La lista tiene `max-height: 14rem` con scroll vertical para tareas con historial extenso.
+
+Las fechas se formatean con `Intl.RelativeTimeFormat('es', { numeric: 'auto' })` (ej. "hace 5 minutos", "ayer").
+
+##### Exportación/Importación
+
+`export-import.ts` se actualizó para incluir el campo opcional `activity` en `BoardExport`. La exportación detecta si el store `activity` existe (retrocompatibilidad con DB v1). La importación maneja archivos sin campo `activity` sin error.
+
+#### Criterios US-20 cubiertos
+
+| Scenario Gherkin | Estado |
+|---|---|
+| Registrar evento de creación de tarea | ✅ `addActivityEvent` en `_handleCreateTask` |
+| Registrar cambio de columna (estado) | ✅ Selector + drag & drop |
+| Registrar cambio de prioridad | ✅ Comparación old vs new en `_handleTaskFieldUpdated` |
+| Registrar adición de etiqueta | ✅ Diff de conjuntos `labelIds` |
+| Registrar eliminación de etiqueta | ✅ Diff de conjuntos `labelIds` |
+| Visualizar historial en panel de detalle | ✅ Sección asíncrona con lista cronológica inversa |
+| Tarea sin actividad registrada | ✅ Evento "Tarea creada" como mínimo |
+
+#### ADR-27 — Eventos de actividad como fire-and-forget
+
+**Contexto:** El registro de actividad es una funcionalidad secundaria; no debe impactar el rendimiento de las operaciones principales (crear, mover, editar tareas).
+
+**Decisión:** Las llamadas a `addActivityEvent()` no se esperan con `await` en los handlers del kanban board. Se ejecutan como fire-and-forget, permitiendo que la escritura en IndexedDB ocurra en segundo plano.
+
+**Consecuencias:**
+- La UI responde inmediatamente sin esperar la escritura del evento.
+- En caso de error, el evento se pierde silenciosamente (solo log en consola) sin afectar la operación principal.
+- La lectura de actividad al abrir el panel es síncrona respecto al usuario (espera resultado antes de renderizar).

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -32,6 +32,7 @@ import type { Column, Task, Label, Priority } from '../../../types/models.js';
 import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
 import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import { getAllLabels } from '../../../db/label.repository.js';
+import { addActivityEvent, deleteActivitiesByTaskId } from '../../../db/activity.repository.js';
 import '../../molecules/dojo-kanban-column/dojo-kanban-column.js';
 import '../../atoms/dojo-task-card/dojo-task-card.js';
 import '../../atoms/dojo-add-column-button/dojo-add-column-button.js';
@@ -960,6 +961,12 @@ export class DojoKanbanBoard extends HTMLElement {
         const newSourceTasks = sourceTasks.filter(t => t.id !== taskId);
 
         await updateTask(taskId, { statusId: targetColumnId });
+
+        // US-20: registrar cambio de estado por drag & drop
+        const fromName = this._columns.find(c => c.id === sourceColumnId)?.name ?? sourceColumnId;
+        const toName   = this._columns.find(c => c.id === targetColumnId)?.name ?? targetColumnId;
+        addActivityEvent({ taskId, type: 'status_change', payload: { from: fromName, to: toName } });
+
         await reorderTasks(targetColumnId, newTargetTasks.map(t => t.id));
         if (newSourceTasks.length > 0) {
           await reorderTasks(sourceColumnId, newSourceTasks.map(t => t.id));
@@ -1106,6 +1113,8 @@ export class DojoKanbanBoard extends HTMLElement {
       } else {
         // Eliminar todas las tareas de la columna
         await Promise.all(tasks.map(t => deleteTask(t.id)));
+        // US-20: limpiar historial de actividad de todas las tareas eliminadas
+        tasks.forEach(t => deleteActivitiesByTaskId(t.id));
       }
 
       await deleteColumn(columnId);
@@ -1175,6 +1184,10 @@ export class DojoKanbanBoard extends HTMLElement {
         order:     tasks.length,
         dueDate:   dueDate ?? null,
       });
+
+      // US-20: registrar evento de creación
+      addActivityEvent({ taskId: newTask.id, type: 'created', payload: {} });
+
       this._tasksByColumn.set(statusId, [...tasks, newTask]);
       this._refreshColumnCards(statusId);
       this._updateColumnCounts();
@@ -1209,12 +1222,14 @@ export class DojoKanbanBoard extends HTMLElement {
       changes: Partial<Task>;
     };
 
-    // Localizar columna origen desde el caché
+    // Localizar columna origen y tarea anterior desde el caché
     let sourceColumnId: string | null = null;
+    let oldTask: Task | undefined;
     for (const [colId, tasks] of this._tasksByColumn) {
-      if (tasks.some(t => t.id === taskId)) { sourceColumnId = colId; break; }
+      const found = tasks.find(t => t.id === taskId);
+      if (found) { sourceColumnId = colId; oldTask = found; break; }
     }
-    if (!sourceColumnId) return;
+    if (!sourceColumnId || !oldTask) return;
 
     // Guard: validar que el statusId destino existe (previene race condition — Fix #1)
     if (changes.statusId && !this._columns.some(c => c.id === changes.statusId)) {
@@ -1225,6 +1240,32 @@ export class DojoKanbanBoard extends HTMLElement {
     try {
       const updated = await updateTask(taskId, changes);
       const targetColumnId = updated.statusId;
+
+      // US-20: registrar eventos de actividad según los campos que cambiaron
+      if (changes.statusId && changes.statusId !== sourceColumnId) {
+        const fromName = this._columns.find(c => c.id === sourceColumnId)?.name ?? sourceColumnId;
+        const toName   = this._columns.find(c => c.id === changes.statusId)?.name ?? changes.statusId;
+        addActivityEvent({ taskId, type: 'status_change', payload: { from: fromName, to: toName } });
+      }
+      if (changes.priority !== undefined && changes.priority !== oldTask.priority) {
+        addActivityEvent({ taskId, type: 'priority_change', payload: { from: oldTask.priority, to: changes.priority } });
+      }
+      if (changes.labelIds !== undefined) {
+        const oldSet = new Set(oldTask.labelIds);
+        const newSet = new Set(changes.labelIds);
+        for (const id of changes.labelIds) {
+          if (!oldSet.has(id)) {
+            const lbl = this._labels.find(l => l.id === id);
+            addActivityEvent({ taskId, type: 'label_added', payload: { labelId: id, labelName: lbl?.name ?? id } });
+          }
+        }
+        for (const id of oldTask.labelIds) {
+          if (!newSet.has(id)) {
+            const lbl = this._labels.find(l => l.id === id);
+            addActivityEvent({ taskId, type: 'label_removed', payload: { labelId: id, labelName: lbl?.name ?? id } });
+          }
+        }
+      }
 
       if (changes.statusId && changes.statusId !== sourceColumnId) {
         // ── Cambio de columna (movimiento) ────────────────────────────────
@@ -1300,6 +1341,8 @@ export class DojoKanbanBoard extends HTMLElement {
 
     try {
       await deleteTask(taskId);
+      // US-20: limpiar historial de actividad de la tarea eliminada
+      deleteActivitiesByTaskId(taskId);
 
       // Actualizar caché
       const remaining = (this._tasksByColumn.get(columnId) ?? []).filter(t => t.id !== taskId);

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -26,8 +26,7 @@
  * --dojo-primary, --dojo-radius, --dojo-radius-sm, --dojo-shadow
  */
 
-import type { Task, Column, Label, Priority } from '../../../types/models.js';
-import type { ActivityEvent } from '../../../types/models.js';
+import type { Task, Column, Label, Priority, ActivityEvent } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import { createLabel } from '../../../db/label.repository.js';
@@ -41,6 +40,9 @@ const PRIORITIES: { value: Priority; label: string; icon: string }[] = [
   { value: 'high',   label: 'Alta',    icon: '⬆️' },
   { value: 'urgent', label: 'Urgente', icon: '🔥' },
 ];
+
+/** Instancia cacheada de Intl.RelativeTimeFormat para fechas de actividad (US-20). */
+const RTF_ES = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
 
 // ── Clase ──────────────────────────────────────────────────────────────────
 
@@ -1650,7 +1652,7 @@ export class DojoTaskDetail extends HTMLElement {
       const hrs  = Math.floor(mins / 60);
       const days = Math.floor(hrs / 24);
 
-      const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+      const rtf = RTF_ES;
       if (secs < 60)  return rtf.format(-secs, 'second');
       if (mins < 60)  return rtf.format(-mins, 'minute');
       if (hrs  < 24)  return rtf.format(-hrs,  'hour');

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -27,9 +27,11 @@
  */
 
 import type { Task, Column, Label, Priority } from '../../../types/models.js';
+import type { ActivityEvent } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import { createLabel } from '../../../db/label.repository.js';
+import { getActivitiesByTaskId } from '../../../db/activity.repository.js';
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
@@ -681,6 +683,44 @@ export class DojoTaskDetail extends HTMLElement {
       }
       .meta-key   { font-weight: 600; }
       .meta-value { color: var(--dojo-text-primary); }
+
+      /* ── Actividad (US-20) ── */
+      .activity-section {
+        border-top: 1px solid var(--dojo-border);
+        padding-top: 0.875rem;
+      }
+      .activity-heading {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--dojo-text-primary);
+        margin: 0 0 0.5rem;
+      }
+      .activity-empty {
+        font-size: 0.75rem;
+        color: var(--dojo-text-secondary);
+        margin: 0;
+      }
+      .activity-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        max-height: 14rem;
+        overflow-y: auto;
+      }
+      .activity-item {
+        display: grid;
+        grid-template-columns: 1.25rem 1fr auto;
+        gap: 0.375rem;
+        align-items: baseline;
+        font-size: 0.75rem;
+        color: var(--dojo-text-secondary);
+      }
+      .activity-icon { font-size: 0.75rem; }
+      .activity-desc { color: var(--dojo-text-primary); }
+      .activity-time { white-space: nowrap; font-size: 0.6875rem; }
     `;
     this._shadow.appendChild(style);
 
@@ -735,6 +775,12 @@ export class DojoTaskDetail extends HTMLElement {
     body.appendChild(this._buildDescriptionField(task));
     body.appendChild(this._buildLabelsField(task));
     body.appendChild(this._buildMetadata(task));
+
+    // US-20: Sección de actividad (se carga de forma asíncrona)
+    const activityContainer = document.createElement('div');
+    activityContainer.className = 'activity-section';
+    body.appendChild(activityContainer);
+    this._loadActivitySection(task.id, activityContainer);
 
     panel.appendChild(body);
 
@@ -1496,6 +1542,123 @@ export class DojoTaskDetail extends HTMLElement {
     section.appendChild(lbl);
     section.appendChild(row);
     return section;
+  }
+
+  // ── Sección de actividad (US-20) ──────────────────────────────────────────
+
+  private async _loadActivitySection(taskId: string, container: HTMLElement): Promise<void> {
+    try {
+      const events = await getActivitiesByTaskId(taskId);
+      // Verificar que el panel sigue mostrando la misma tarea (race condition)
+      if (this._task?.id !== taskId) return;
+      this._renderActivityEvents(events, container);
+    } catch (err) {
+      console.error('[dojo-task-detail] Error al cargar actividad:', err);
+    }
+  }
+
+  private _renderActivityEvents(events: ActivityEvent[], container: HTMLElement): void {
+    container.innerHTML = '';
+
+    const heading = document.createElement('h3');
+    heading.className = 'activity-heading';
+    heading.textContent = 'Actividad';
+    container.appendChild(heading);
+
+    if (events.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'activity-empty';
+      empty.textContent = 'Sin actividad registrada.';
+      container.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'activity-list';
+    list.setAttribute('role', 'list');
+
+    for (const evt of events) {
+      const li = document.createElement('li');
+      li.className = 'activity-item';
+
+      const icon = document.createElement('span');
+      icon.className = 'activity-icon';
+      icon.textContent = this._activityIcon(evt.type);
+      icon.setAttribute('aria-hidden', 'true');
+
+      const desc = document.createElement('span');
+      desc.className = 'activity-desc';
+      desc.textContent = this._activityDescription(evt);
+
+      const time = document.createElement('time');
+      time.className = 'activity-time';
+      time.setAttribute('datetime', evt.createdAt);
+      time.textContent = this._formatRelativeTime(evt.createdAt);
+
+      li.appendChild(icon);
+      li.appendChild(desc);
+      li.appendChild(time);
+      list.appendChild(li);
+    }
+
+    container.appendChild(list);
+  }
+
+  private _activityIcon(type: string): string {
+    switch (type) {
+      case 'created':         return '✨';
+      case 'status_change':   return '📋';
+      case 'priority_change': return '⚡';
+      case 'label_added':     return '🏷️';
+      case 'label_removed':   return '🗑️';
+      default:                return '📝';
+    }
+  }
+
+  private _activityDescription(evt: ActivityEvent): string {
+    const p = evt.payload;
+    switch (evt.type) {
+      case 'created':
+        return 'Tarea creada';
+      case 'status_change':
+        return `Movida de "${p.from}" a "${p.to}"`;
+      case 'priority_change':
+        return `Prioridad cambiada de "${this._priorityLabel(p.from as string)}" a "${this._priorityLabel(p.to as string)}"`;
+      case 'label_added':
+        return `Etiqueta "${p.labelName}" añadida`;
+      case 'label_removed':
+        return `Etiqueta "${p.labelName}" eliminada`;
+      default:
+        return 'Cambio registrado';
+    }
+  }
+
+  private _priorityLabel(value: string): string {
+    const map: Record<string, string> = {
+      low: 'Baja', medium: 'Media', high: 'Alta', urgent: 'Urgente',
+    };
+    return map[value] ?? value;
+  }
+
+  private _formatRelativeTime(iso: string): string {
+    try {
+      const date = new Date(iso);
+      const now  = Date.now();
+      const diff = now - date.getTime();
+      const secs = Math.floor(diff / 1000);
+      const mins = Math.floor(secs / 60);
+      const hrs  = Math.floor(mins / 60);
+      const days = Math.floor(hrs / 24);
+
+      const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+      if (secs < 60)  return rtf.format(-secs, 'second');
+      if (mins < 60)  return rtf.format(-mins, 'minute');
+      if (hrs  < 24)  return rtf.format(-hrs,  'hour');
+      if (days < 30)  return rtf.format(-days, 'day');
+      return this._formatDate(iso);
+    } catch {
+      return iso;
+    }
   }
 
   private _buildMetadata(task: Task): HTMLElement {

--- a/src/db/activity.repository.ts
+++ b/src/db/activity.repository.ts
@@ -1,0 +1,68 @@
+/**
+ * activity.repository.ts — CRUD de eventos de actividad sobre IndexedDB.
+ *
+ * Registra y consulta el historial de cambios de cada tarea (US-20).
+ * Los eventos se almacenan en el object store `activity` con índice `by-taskId`.
+ */
+
+import { idbRequest, idbTransaction, getStore, openDatabase } from './database.js';
+import { generateUUID } from '../utils/uuid.js';
+import type { ActivityEvent, ActivityEventType } from '../types/models.js';
+
+// ── Tipos internos ─────────────────────────────────────────────────────────
+
+type CreateActivityInput = {
+  taskId:  string;
+  type:    ActivityEventType;
+  payload: Record<string, unknown>;
+};
+
+// ── Implementación ─────────────────────────────────────────────────────────
+
+/**
+ * Registra un nuevo evento de actividad asociado a una tarea.
+ * Asigna `id` y `createdAt` automáticamente.
+ */
+export async function addActivityEvent(input: CreateActivityInput): Promise<ActivityEvent> {
+  const event: ActivityEvent = {
+    id:        generateUUID(),
+    taskId:    input.taskId,
+    type:      input.type,
+    payload:   input.payload,
+    createdAt: new Date().toISOString(),
+  };
+
+  const { store, tx } = await getStore('activity', 'readwrite');
+  store.add(event);
+  await idbTransaction(tx);
+  return event;
+}
+
+/**
+ * Devuelve todos los eventos de actividad de una tarea,
+ * ordenados del más reciente al más antiguo.
+ */
+export async function getActivitiesByTaskId(taskId: string): Promise<ActivityEvent[]> {
+  const { store } = await getStore('activity');
+  const index     = store.index('by-taskId');
+  const events    = await idbRequest<ActivityEvent[]>(index.getAll(taskId));
+  return events.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/**
+ * Elimina todos los eventos de actividad asociados a una tarea.
+ * Útil al eliminar la tarea para no dejar registros huérfanos.
+ */
+export async function deleteActivitiesByTaskId(taskId: string): Promise<void> {
+  const db    = await openDatabase();
+  const tx    = db.transaction('activity', 'readwrite');
+  const store = tx.objectStore('activity');
+  const index = store.index('by-taskId');
+  const keys  = await idbRequest<IDBValidKey[]>(index.getAllKeys(taskId));
+
+  for (const key of keys) {
+    store.delete(key);
+  }
+
+  await idbTransaction(tx);
+}

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -5,13 +5,14 @@
  * Toda la asincronía basada en eventos (IDBRequest) se encapsula en Promesas.
  *
  * Object Stores:
- *   - tasks   : keyPath = 'id'  | índices: by-status, by-priority, by-created
- *   - columns : keyPath = 'id'
- *   - labels  : keyPath = 'id'  | índice: by-name (unique)
+ *   - tasks    : keyPath = 'id'  | índices: by-status, by-priority, by-created
+ *   - columns  : keyPath = 'id'
+ *   - labels   : keyPath = 'id'  | índice: by-name (unique)
+ *   - activity : keyPath = 'id'  | índice: by-taskId (US-20)
  */
 
 const DB_NAME    = 'kanban-app-db';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 /** Instancia singleton de la base de datos (se inicializa una sola vez). */
 let _db: IDBDatabase | null = null;
@@ -88,7 +89,13 @@ export function openDatabase(): Promise<IDBDatabase> {
       }
 
       // ── Migraciones futuras ─────────────────────────────────────────
-      // if (oldVersion < 2) { ... }
+      // v1 → v2: object store de actividad (US-20)
+      if (oldVersion < 2) {
+        const activityStore = db.createObjectStore('activity', { keyPath: 'id' });
+        activityStore.createIndex('by-taskId', 'taskId', { unique: false });
+      }
+
+      // if (oldVersion < 3) { ... }
     };
   });
 

--- a/src/db/export-import.ts
+++ b/src/db/export-import.ts
@@ -11,7 +11,7 @@
  */
 
 import { openDatabase, idbRequest, idbTransaction } from './database.js';
-import type { Column, Task, Label } from '../types/models.js';
+import type { Column, Task, Label, ActivityEvent } from '../types/models.js';
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
@@ -28,6 +28,7 @@ export interface BoardExport {
   columns: Column[];
   tasks: Task[];
   labels: Label[];
+  activity?: ActivityEvent[];
 }
 
 /** Resultado de la validación de un archivo importado. */
@@ -52,10 +53,18 @@ type ValidateResult = ValidationResult | ValidationError;
  */
 export async function exportBoardData(): Promise<BoardExport> {
   const db = await openDatabase();
-  const tx = db.transaction(['columns', 'tasks', 'labels'], 'readonly');
-  const columns = await idbRequest<Column[]>(tx.objectStore('columns').getAll());
-  const tasks   = await idbRequest<Task[]>(tx.objectStore('tasks').getAll());
-  const labels  = await idbRequest<Label[]>(tx.objectStore('labels').getAll());
+  const storeNames = ['columns', 'tasks', 'labels'] as const;
+  // Incluir activity si el store existe (DB v2+)
+  const allNames = db.objectStoreNames;
+  const hasActivity = allNames.contains('activity');
+  const txStores = hasActivity ? [...storeNames, 'activity'] : [...storeNames];
+  const tx = db.transaction(txStores, 'readonly');
+  const columns  = await idbRequest<Column[]>(tx.objectStore('columns').getAll());
+  const tasks    = await idbRequest<Task[]>(tx.objectStore('tasks').getAll());
+  const labels   = await idbRequest<Label[]>(tx.objectStore('labels').getAll());
+  const activity = hasActivity
+    ? await idbRequest<ActivityEvent[]>(tx.objectStore('activity').getAll())
+    : [];
 
   return {
     version:    CURRENT_VERSION,
@@ -63,6 +72,7 @@ export async function exportBoardData(): Promise<BoardExport> {
     columns:    columns.sort((a, b) => a.order - b.order),
     tasks,
     labels:     labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })),
+    activity:   activity.sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
   };
 }
 
@@ -171,7 +181,12 @@ export function validateImportData(raw: unknown): ValidateResult {
  */
 export async function importBoardData(data: BoardExport): Promise<void> {
   const db = await openDatabase();
-  const tx = db.transaction(['columns', 'tasks', 'labels'], 'readwrite');
+  const allNames = db.objectStoreNames;
+  const hasActivity = allNames.contains('activity');
+  const storeNames = hasActivity
+    ? ['columns', 'tasks', 'labels', 'activity']
+    : ['columns', 'tasks', 'labels'];
+  const tx = db.transaction(storeNames, 'readwrite');
 
   const colStore   = tx.objectStore('columns');
   const taskStore  = tx.objectStore('tasks');
@@ -186,6 +201,15 @@ export async function importBoardData(data: BoardExport): Promise<void> {
   for (const col of data.columns)   colStore.add(col);
   for (const task of data.tasks)    taskStore.add(task);
   for (const label of data.labels)  labelStore.add(label);
+
+  // 3. Importar actividad si existe en el archivo y el store está disponible
+  if (hasActivity) {
+    const activityStore = tx.objectStore('activity');
+    activityStore.clear();
+    if (data.activity) {
+      for (const evt of data.activity) activityStore.add(evt);
+    }
+  }
 
   await idbTransaction(tx);
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -87,3 +87,27 @@ export const DEFAULT_LABELS: Omit<Label, 'id'>[] = [
   { name: 'Testing',         color: '#0E7490' },
   { name: 'Infraestructura', color: '#374151' },
 ];
+
+// ── ActivityEvent (US-20) ──────────────────────────────────────────────────
+
+/** Tipos de evento registrados en el historial de actividad. */
+export type ActivityEventType =
+  | 'created'
+  | 'status_change'
+  | 'priority_change'
+  | 'label_added'
+  | 'label_removed';
+
+/** Registro de un evento de actividad asociado a una tarea. */
+export interface ActivityEvent {
+  /** UUID v4. */
+  id: string;
+  /** FK → Task.id. */
+  taskId: string;
+  /** Tipo de evento. */
+  type: ActivityEventType;
+  /** Datos adicionales del evento (varían según el tipo). */
+  payload: Record<string, unknown>;
+  /** Fecha del evento en formato ISO 8601. */
+  createdAt: string;
+}


### PR DESCRIPTION
## Descripción

Implementa el historial de actividad por tarea según la **US-20** — permite consultar un registro cronológico de los cambios realizados en cada tarea, brindando trazabilidad completa.

## Cambios realizados

### Modelo de datos

- Nueva interfaz `ActivityEvent` con campos: `id`, `taskId`, `type`, `payload`, `createdAt`

- Nuevo tipo `ActivityEventType`: `created`, `status_change`, `priority_change`, `label_added`, `label_removed`

### Base de datos

- Migración de IndexedDB **v1 → v2**: nuevo object store `activity` con índice `by-taskId`

- Nuevo repositorio `activity.repository.ts` con operaciones: `addActivityEvent`, `getActivitiesByTaskId`, `deleteActivitiesByTaskId`

### Registro de eventos

- **Creación de tarea** → evento `created`

- **Cambio de estado** (selector o drag & drop) → evento `status_change` con `from`/`to`

- **Cambio de prioridad** → evento `priority_change` con `from`/`to`

- **Adición/eliminación de etiqueta** → eventos `label_added`/`label_removed` con nombre de etiqueta

- **Limpieza** al eliminar tareas o columnas con tareas

### Interfaz de usuario

- Sección \"Actividad\" en el panel de detalle (`dojo-task-detail`)

- Lista cronológica inversa (más reciente primero)

- Íconos por tipo de evento, descripciones legibles en español

- Fechas relativas con `Intl.RelativeTimeFormat('es')`

- Scroll con `max-height: 14rem` para listas extensas

### Exportación/Importación

- Actualizado `export-import.ts` para incluir eventos de actividad

- Retrocompatible con archivos exportados sin campo `activity`

## Archivos modificados

- `src/types/models.ts` — Nueva interfaz y tipo

- `src/db/database.ts` — Migración v2

- `src/db/activity.repository.ts` — **Nuevo** — CRUD de actividad

- `src/db/export-import.ts` — Soporte de activity en export/import

- `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` — Registro de eventos

- `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` — UI de actividad

Closes #38