### PR TITLE
feat(subtasks): add subtask checklist with progress tracking (US-21)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -34,6 +34,7 @@
    - [Paso 20 — Modo oscuro automático (US-18 / Issue #36)](#paso-20--modo-oscuro-automático-us-18--issue-36)
    - [Paso 21 — Exportación e importación de datos (US-19 / Issue #37)](#paso-21--exportación-e-importación-de-datos-us-19--issue-37)
    - [Paso 22 — Historial de actividad por tarea (US-20 / Issue #38)](#paso-22--historial-de-actividad-por-tarea-us-20--issue-38)
+   - [Paso 23 — Subtareas / Checklist (US-21 / Issue #39)](#paso-23--subtareas--checklist-us-21--issue-39)
 
 ---
 
@@ -2147,3 +2148,64 @@ Las fechas se formatean con `Intl.RelativeTimeFormat('es', { numeric: 'auto' })`
 - La UI responde inmediatamente sin esperar la escritura del evento.
 - En caso de error, el evento se pierde silenciosamente (solo log en consola) sin afectar la operación principal.
 - La lectura de actividad al abrir el panel es síncrona respecto al usuario (espera resultado antes de renderizar).
+
+### Paso 23 — Subtareas / Checklist (US-21 / Issue #39)
+
+| Campo | Valor |
+|---|---|
+| **Issue** | #39 |
+| **User Story** | US-21 — Subtareas (Checklist) |
+| **Branch** | `feat/39-subtareas-checklist` |
+| **PR** | #55 |
+
+#### Problema
+
+Las tareas del tablero no tenían forma de descomponerse en pasos más pequeños. Los usuarios necesitan poder crear listas de verificación dentro de cada tarea, marcar subtareas como completadas y ver el progreso tanto en el detalle como en la tarjeta del tablero.
+
+#### Decisión de diseño
+
+Las subtareas se almacenan como un array embebido (`subtasks: Subtask[]`) directamente en el objeto `Task`, sin crear un nuevo object store en IndexedDB. Esto simplifica la persistencia: `updateTask()` ya maneja la serialización completa del objeto, por lo que no se requirieron cambios en la capa de base de datos ni migración de versión.
+
+#### Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `src/types/models.ts` | Nueva interfaz `Subtask { id, text, completed }` + campo opcional `subtasks?: Subtask[]` en `Task` |
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Sección completa de subtareas: heading, barra de progreso, checklist interactivo, input para añadir |
+| `src/components/atoms/dojo-task-card/dojo-task-card.ts` | Método `setSubtaskProgress(done, total)` + indicador visual de progreso en miniatura |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | Pasa datos de subtareas a tarjetas en render + actualización inline sin re-render completo |
+
+#### Receta: Sección de subtareas en el detalle de tarea
+
+1. **Modelo** — Se define `Subtask` como tipo con `id: string`, `text: string`, `completed: boolean`. El campo `subtasks` es opcional en `Task` para retrocompatibilidad con tareas existentes.
+
+2. **`_buildSubtasksField(task)`** — Construye un contenedor `.subtasks-section` con:
+   - Heading "Subtareas"
+   - Texto de progreso "X / Y completadas" (solo si `total > 0`)
+   - Barra de progreso visual (`.subtasks-progress-bar` + `.subtasks-progress-fill`)
+   - Lista `<ul>` con un `<li>` por subtarea: checkbox + texto + botón eliminar
+   - Fila de input + botón "+ Añadir" para crear subtareas
+
+3. **Interacciones** — Cada acción (toggle checkbox, eliminar, añadir) actualiza el array de subtareas y llama `this._save({ subtasks: [...] })`, que despacha `dojo:task-field-updated`. La sección se reconstruye in-place con `_rebuildSubtasksSection()` usando `replaceWith()`.
+
+4. **Tarjeta** — `DojoTaskCard` expone `setSubtaskProgress(done, total)` que renderiza una barra de progreso miniatura con texto "X / Y" cuando hay subtareas. Si `total === 0`, no se muestra nada.
+
+5. **Tablero** — `_renderTaskCards()` calcula `done`/`total` de cada tarea y llama `setSubtaskProgress()`. En `_handleTaskFieldUpdated()`, si `changes.subtasks` está presente, actualiza la tarjeta inline sin refrescar toda la columna.
+
+#### Accesibilidad (WCAG 2.1)
+
+- `aria-label` descriptivos en checkboxes, botones de eliminar e input
+- Rol `list` en el contenedor de subtareas
+- Foco automático en el input tras añadir una subtarea (`requestAnimationFrame`)
+
+#### ADR-28 — Subtareas embebidas en Task (sin store separado)
+
+**Contexto:** Se necesita almacenar subtareas asociadas a cada tarea. Las opciones eran: (1) store separado `subtasks` con referencia por `taskId`, o (2) array embebido en el objeto `Task`.
+
+**Decisión:** Embeber `subtasks: Subtask[]` directamente en el objeto `Task`.
+
+**Consecuencias:**
+- Sin migración de base de datos (se mantiene versión 2).
+- `updateTask()` persiste subtareas automáticamente al serializar el objeto completo.
+- Exportación/importación funciona sin cambios (el campo es opcional y se incluye automáticamente).
+- Limitación teórica: no se pueden consultar subtareas independientemente por índice. En la práctica, el volumen de subtareas por tarea es bajo (~10-20) y no justifica la complejidad adicional.

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -50,6 +50,19 @@ export class DojoTaskCard extends HTMLElement {
     if (this.isConnected) this._render();
   }
 
+  /** Progreso de subtareas (US-21): [completadas, total] */
+  private _subtasksDone  = 0;
+  private _subtasksTotal = 0;
+
+  get subtasksDone(): number  { return this._subtasksDone; }
+  get subtasksTotal(): number { return this._subtasksTotal; }
+
+  setSubtaskProgress(done: number, total: number): void {
+    this._subtasksDone  = done;
+    this._subtasksTotal = total;
+    if (this.isConnected) this._render();
+  }
+
   constructor() {
     super();
     this._shadow = this.attachShadow({ mode: 'open' });
@@ -329,6 +342,34 @@ export class DojoTaskCard extends HTMLElement {
         color: var(--dojo-text-muted, var(--dojo-text-secondary));
       }
 
+      /* Progreso de subtareas (US-21) */
+      .subtask-progress {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        margin-top: 0.25rem;
+        margin-bottom: 0.25rem;
+      }
+      .subtask-progress-text {
+        font-size: 0.625rem;
+        color: var(--dojo-text-muted, var(--dojo-text-secondary));
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      .subtask-progress-bar {
+        flex: 1;
+        height: 4px;
+        background: var(--dojo-border);
+        border-radius: 2px;
+        overflow: hidden;
+      }
+      .subtask-progress-fill {
+        height: 100%;
+        background: var(--dojo-primary, #1D4ED8);
+        border-radius: 2px;
+        transition: width 0.2s;
+      }
+
       /* Chips de etiquetas (US-10) */
       .chip-row {
         display: flex;
@@ -407,6 +448,27 @@ export class DojoTaskCard extends HTMLElement {
         chipRow.appendChild(chip);
       }
       this._shadow.appendChild(chipRow);
+    }
+
+    // ── Progreso de subtareas (US-21) ───────────────────────────────────
+    if (this._subtasksTotal > 0) {
+      const progressRow = document.createElement('div');
+      progressRow.className = 'subtask-progress';
+
+      const pText = document.createElement('span');
+      pText.className = 'subtask-progress-text';
+      pText.textContent = `${this._subtasksDone} / ${this._subtasksTotal}`;
+      progressRow.appendChild(pText);
+
+      const pBar = document.createElement('div');
+      pBar.className = 'subtask-progress-bar';
+      const pFill = document.createElement('div');
+      pFill.className = 'subtask-progress-fill';
+      pFill.style.width = `${Math.round((this._subtasksDone / this._subtasksTotal) * 100)}%`;
+      pBar.appendChild(pFill);
+      progressRow.appendChild(pBar);
+
+      this._shadow.appendChild(progressRow);
     }
 
     // ── Título ────────────────────────────────────────────────────────────

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -58,7 +58,8 @@ export class DojoTaskCard extends HTMLElement {
   get subtasksTotal(): number { return this._subtasksTotal; }
 
   setSubtaskProgress(done: number, total: number): void {
-    this._subtasksDone  = done;
+    if (!Number.isFinite(done) || !Number.isFinite(total) || total < 0) return;
+    this._subtasksDone  = Math.max(0, Math.min(done, total));
     this._subtasksTotal = total;
     if (this.isConnected) this._render();
   }
@@ -462,6 +463,11 @@ export class DojoTaskCard extends HTMLElement {
 
       const pBar = document.createElement('div');
       pBar.className = 'subtask-progress-bar';
+      pBar.setAttribute('role', 'progressbar');
+      pBar.setAttribute('aria-valuenow', String(this._subtasksDone));
+      pBar.setAttribute('aria-valuemin', '0');
+      pBar.setAttribute('aria-valuemax', String(this._subtasksTotal));
+      pBar.setAttribute('aria-label', `Progreso: ${this._subtasksDone} de ${this._subtasksTotal} subtareas`);
       const pFill = document.createElement('div');
       pFill.className = 'subtask-progress-fill';
       pFill.style.width = `${Math.round((this._subtasksDone / this._subtasksTotal) * 100)}%`;

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -55,6 +55,7 @@ interface ActiveFilter {
 /** Contrato de la propiedad taskLabels expuesta por dojo-task-card (US-10). */
 interface TaskCardElement extends HTMLElement {
   taskLabels: Label[];
+  setSubtaskProgress(done: number, total: number): void;
 }
 
 // ── Clase ──────────────────────────────────────────────────────────────────
@@ -838,6 +839,13 @@ export class DojoKanbanBoard extends HTMLElement {
       card.setAttribute('task-created-at', task.createdAt);
       if (task.dueDate) card.setAttribute('task-due-date', task.dueDate);
       (card as TaskCardElement).taskLabels = this._getTaskLabels(task);
+      const subs = task.subtasks ?? [];
+      if (subs.length > 0) {
+        (card as TaskCardElement).setSubtaskProgress(
+          subs.filter(s => s.completed).length,
+          subs.length
+        );
+      }
       colEl.appendChild(card);
     }
   }
@@ -1291,7 +1299,7 @@ export class DojoKanbanBoard extends HTMLElement {
         } else if (changes.labelIds !== undefined && this._activeFilter.labelIds?.length) {
           // Etiquetas cambiaron y hay filtro activo — puede que la tarjeta deba desaparecer
           this._refreshColumnCards(sourceColumnId);
-        } else if (changes.title !== undefined || changes.priority !== undefined || changes.labelIds !== undefined || changes.dueDate !== undefined) {
+        } else if (changes.title !== undefined || changes.priority !== undefined || changes.labelIds !== undefined || changes.dueDate !== undefined || changes.subtasks !== undefined) {
           const colEl = this._shadow.querySelector(
             `dojo-kanban-column[column-id="${CSS.escape(sourceColumnId)}"]`
           );
@@ -1307,6 +1315,13 @@ export class DojoKanbanBoard extends HTMLElement {
                 } else {
                   cardEl.removeAttribute('task-due-date');
                 }
+              }
+              if (changes.subtasks !== undefined) {
+                const subs = updated.subtasks ?? [];
+                (cardEl as TaskCardElement).setSubtaskProgress(
+                  subs.filter(s => s.completed).length,
+                  subs.length
+                );
               }
             }
           }

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -26,11 +26,12 @@
  * --dojo-primary, --dojo-radius, --dojo-radius-sm, --dojo-shadow
  */
 
-import type { Task, Column, Label, Priority, ActivityEvent } from '../../../types/models.js';
+import type { Task, Column, Label, Priority, ActivityEvent, Subtask } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import { createLabel } from '../../../db/label.repository.js';
 import { getActivitiesByTaskId } from '../../../db/activity.repository.js';
+import { generateUUID } from '../../../utils/uuid.js';
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
@@ -723,6 +724,128 @@ export class DojoTaskDetail extends HTMLElement {
       .activity-icon { font-size: 0.75rem; }
       .activity-desc { color: var(--dojo-text-primary); }
       .activity-time { white-space: nowrap; font-size: 0.6875rem; }
+
+      /* ── Subtareas / checklist (US-21) ── */
+      .subtasks-section {
+        border-top: 1px solid var(--dojo-border);
+        padding-top: 0.875rem;
+      }
+      .subtasks-heading {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        color: var(--dojo-text-primary);
+        margin: 0 0 0.25rem;
+      }
+      .subtasks-progress-text {
+        font-size: 0.6875rem;
+        color: var(--dojo-text-secondary);
+        margin: 0 0 0.5rem;
+      }
+      .subtasks-progress-bar {
+        width: 100%;
+        height: 4px;
+        background: var(--dojo-border);
+        border-radius: 2px;
+        overflow: hidden;
+        margin-bottom: 0.5rem;
+      }
+      .subtasks-progress-fill {
+        height: 100%;
+        background: var(--dojo-primary, #1D4ED8);
+        border-radius: 2px;
+        transition: width 0.2s ease;
+      }
+      .subtasks-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .subtask-item {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.8125rem;
+        color: var(--dojo-text-primary);
+        padding: 0.25rem 0;
+      }
+      .subtask-item input[type="checkbox"] {
+        flex-shrink: 0;
+        cursor: pointer;
+        accent-color: var(--dojo-primary, #1D4ED8);
+      }
+      .subtask-text {
+        flex: 1;
+        line-height: 1.4;
+        word-break: break-word;
+      }
+      .subtask-text.completed {
+        text-decoration: line-through;
+        color: var(--dojo-text-secondary);
+      }
+      .subtask-delete-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.125rem 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.6875rem;
+        color: var(--dojo-text-secondary);
+        opacity: 0;
+        transition: opacity 0.15s, color 0.15s;
+      }
+      .subtask-item:hover .subtask-delete-btn,
+      .subtask-item:focus-within .subtask-delete-btn {
+        opacity: 1;
+      }
+      .subtask-delete-btn:hover {
+        color: #EF4444;
+      }
+      .subtask-delete-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+        opacity: 1;
+      }
+      .subtask-add-row {
+        display: flex;
+        gap: 0.375rem;
+        margin-top: 0.375rem;
+      }
+      .subtask-add-input {
+        flex: 1;
+        font-size: 0.8125rem;
+        font-family: inherit;
+        padding: 0.375rem 0.5rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        outline: none;
+      }
+      .subtask-add-input:focus {
+        border-color: var(--dojo-primary, #1D4ED8);
+        box-shadow: 0 0 0 2px rgba(29,78,216,.15);
+      }
+      .subtask-add-btn {
+        font-size: 0.75rem;
+        font-family: inherit;
+        padding: 0.375rem 0.625rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: var(--dojo-primary, #1D4ED8);
+        color: #FFFFFF;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .subtask-add-btn:hover {
+        opacity: 0.9;
+      }
+      .subtask-add-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -776,6 +899,7 @@ export class DojoTaskDetail extends HTMLElement {
     body.appendChild(this._buildDueDateField(task));
     body.appendChild(this._buildDescriptionField(task));
     body.appendChild(this._buildLabelsField(task));
+    body.appendChild(this._buildSubtasksField(task));
     body.appendChild(this._buildMetadata(task));
 
     // US-20: Sección de actividad (se carga de forma asíncrona)
@@ -1544,6 +1668,141 @@ export class DojoTaskDetail extends HTMLElement {
     section.appendChild(lbl);
     section.appendChild(row);
     return section;
+  }
+
+  // ── Sección de subtareas / checklist (US-21) ──────────────────────────────
+
+  private _buildSubtasksField(task: Task): HTMLElement {
+    const section = document.createElement('div');
+    section.className = 'subtasks-section';
+
+    const heading = document.createElement('h3');
+    heading.className = 'subtasks-heading';
+    heading.textContent = 'Subtareas';
+    section.appendChild(heading);
+
+    const subtasks = task.subtasks ?? [];
+    const total     = subtasks.length;
+    const completed = subtasks.filter(s => s.completed).length;
+
+    // Progreso (solo si hay subtareas)
+    if (total > 0) {
+      const progressText = document.createElement('p');
+      progressText.className = 'subtasks-progress-text';
+      progressText.textContent = `${completed} / ${total} completadas`;
+      section.appendChild(progressText);
+
+      const progressBar = document.createElement('div');
+      progressBar.className = 'subtasks-progress-bar';
+      const progressFill = document.createElement('div');
+      progressFill.className = 'subtasks-progress-fill';
+      progressFill.style.width = `${Math.round((completed / total) * 100)}%`;
+      progressBar.appendChild(progressFill);
+      section.appendChild(progressBar);
+    }
+
+    // Lista de subtareas
+    const list = document.createElement('ul');
+    list.className = 'subtasks-list';
+    list.setAttribute('role', 'list');
+
+    for (const sub of subtasks) {
+      list.appendChild(this._buildSubtaskItem(sub, subtasks));
+    }
+
+    section.appendChild(list);
+
+    // Fila para añadir nueva subtarea
+    const addRow = document.createElement('div');
+    addRow.className = 'subtask-add-row';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'subtask-add-input';
+    input.placeholder = 'Nueva subtarea…';
+    input.maxLength = 200;
+    input.setAttribute('aria-label', 'Texto de nueva subtarea');
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'subtask-add-btn';
+    addBtn.textContent = '+ Añadir';
+
+    const addSubtask = (): void => {
+      const text = input.value.trim();
+      if (!text || !this._task) return;
+      const newSub: Subtask = { id: generateUUID(), text, completed: false };
+      const updated = [...(this._task.subtasks ?? []), newSub];
+      this._save({ subtasks: updated });
+      this._rebuildSubtasksSection(section);
+      // Enfocar el input tras la reconstrucción
+      requestAnimationFrame(() => {
+        section.querySelector<HTMLInputElement>('.subtask-add-input')?.focus();
+      });
+    };
+
+    addBtn.addEventListener('click', addSubtask);
+    input.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        addSubtask();
+      }
+    });
+
+    addRow.appendChild(input);
+    addRow.appendChild(addBtn);
+    section.appendChild(addRow);
+
+    return section;
+  }
+
+  private _buildSubtaskItem(sub: Subtask, allSubtasks: Subtask[]): HTMLElement {
+    const li = document.createElement('li');
+    li.className = 'subtask-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = sub.completed;
+    checkbox.setAttribute('aria-label', `Marcar "${sub.text}" como ${sub.completed ? 'pendiente' : 'completada'}`);
+    checkbox.addEventListener('change', () => {
+      if (!this._task) return;
+      const updated = (this._task.subtasks ?? []).map(s =>
+        s.id === sub.id ? { ...s, completed: checkbox.checked } : s
+      );
+      this._save({ subtasks: updated });
+      // Reconstruir la sección para actualizar progreso
+      const section = li.closest('.subtasks-section') as HTMLElement | null;
+      if (section) this._rebuildSubtasksSection(section);
+    });
+
+    const textEl = document.createElement('span');
+    textEl.className = `subtask-text${sub.completed ? ' completed' : ''}`;
+    textEl.textContent = sub.text;
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'subtask-delete-btn';
+    deleteBtn.textContent = '✕';
+    deleteBtn.setAttribute('aria-label', `Eliminar subtarea: ${sub.text}`);
+    deleteBtn.addEventListener('click', () => {
+      if (!this._task) return;
+      const updated = (this._task.subtasks ?? []).filter(s => s.id !== sub.id);
+      this._save({ subtasks: updated });
+      const section = li.closest('.subtasks-section') as HTMLElement | null;
+      if (section) this._rebuildSubtasksSection(section);
+    });
+
+    li.appendChild(checkbox);
+    li.appendChild(textEl);
+    li.appendChild(deleteBtn);
+    return li;
+  }
+
+  /** Reconstruye la sección de subtareas in-place para reflejar progreso actualizado. */
+  private _rebuildSubtasksSection(oldSection: HTMLElement): void {
+    if (!this._task) return;
+    const newSection = this._buildSubtasksField(this._task);
+    oldSection.replaceWith(newSection);
   }
 
   // ── Sección de actividad (US-20) ──────────────────────────────────────────

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -1694,6 +1694,11 @@ export class DojoTaskDetail extends HTMLElement {
 
       const progressBar = document.createElement('div');
       progressBar.className = 'subtasks-progress-bar';
+      progressBar.setAttribute('role', 'progressbar');
+      progressBar.setAttribute('aria-valuenow', String(completed));
+      progressBar.setAttribute('aria-valuemin', '0');
+      progressBar.setAttribute('aria-valuemax', String(total));
+      progressBar.setAttribute('aria-label', `Progreso de subtareas: ${completed} de ${total}`);
       const progressFill = document.createElement('div');
       progressFill.className = 'subtasks-progress-fill';
       progressFill.style.width = `${Math.round((completed / total) * 100)}%`;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -9,6 +9,18 @@
 
 export type Priority = 'low' | 'medium' | 'high' | 'urgent';
 
+// ── Subtask (US-21) ────────────────────────────────────────────────────────
+
+/** Elemento de checklist embebido en una tarea. */
+export interface Subtask {
+  /** UUID v4. */
+  id: string;
+  /** Texto descriptivo de la subtarea. */
+  text: string;
+  /** Si la subtarea está completada. */
+  completed: boolean;
+}
+
 // ── Task ───────────────────────────────────────────────────────────────────
 
 /** Representa una tarjeta del tablero Kanban. */
@@ -31,6 +43,8 @@ export interface Task {
   updatedAt: string;
   /** Fecha de vencimiento en formato ISO 8601. Null/undefined = sin vencimiento (US-17). */
   dueDate?: string | null;
+  /** Lista de subtareas (checklist). Puede estar vacía (US-21). */
+  subtasks?: Subtask[];
   /** Posición dentro de la columna (para ordenamiento manual). */
   order: number;
 }


### PR DESCRIPTION
# US-21 — Subtareas (Checklist)

## Resumen

Implementa el sistema de subtareas / checklist para tareas del tablero Kanban.

## Cambios realizados 

### Modelo de datos (`src/types/models.ts`)
- Nueva interfaz `Subtask` con campos `id`, `text` y `completed`
- Campo opcional `subtasks?: Subtask[]` añadido a la interfaz `Task`
- Sin cambios en la base de datos (subtareas embebidas en el objeto Task)

### Detalle de tarea (`dojo-task-detail.ts`)
- Sección completa de subtareas con: by
  - Heading \"Subtareas\"
  - Barra de progreso con texto \"X / Y completadas\"
  - Lista checklist con checkbox, texto y botón eliminar por subtarea
  - Input para añadir nuevas subtareas (Enter o botón \"+ Añadir\")
- Checkbox toggle actualiza estado `completed` y persiste automáticamente
- Eliminación de subtareas con confirmación visual
- Reconstrucción reactiva de la sección tras cada cambio

### Tarjeta de tarea (`dojo-task-card.ts`)
- Nuevo método `setSubtaskProgress(done, total)` como propiedad pública
- Indicador visual de progreso: texto \"X / Y\" + barra de progreso
- Solo visible cuando la tarea tiene subtareas (>0)

### Tablero Kanban (`dojo-kanban-board.ts`)
- Pasa datos de progreso de subtareas a las tarjetas en `_renderTaskCards()`
- Actualización inline del progreso cuando cambian las subtareas (sin re-render completo)
- Interfaz `TaskCardElement` extendida con `setSubtaskProgress`

## Accesibilidad (WCAG 2.1)
- `aria-label` en checkboxes, botones de eliminar e input de nueva subtarea
- Rol `list` en la lista de subtareas
- Foco automático en input tras añadir subtarea

## Testing manual
1. Abrir detalle de una tarea → aparece sección \"Subtareas\" vacía con input
2. Escribir texto y pulsar Enter → nueva subtarea aparece con checkbox
3. Marcar/desmarcar checkboxes → progreso se actualiza
4. Eliminar subtarea → desaparece de la lista y progreso se recalcula
5. En el tablero, la tarjeta muestra barra de progreso miniatura

Closes #39