### PR TITLE
feat(boards): implement multiple boards support (US-22)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -2209,3 +2209,91 @@ Las subtareas se almacenan como un array embebido (`subtasks: Subtask[]`) direct
 - `updateTask()` persiste subtareas automáticamente al serializar el objeto completo.
 - Exportación/importación funciona sin cambios (el campo es opcional y se incluye automáticamente).
 - Limitación teórica: no se pueden consultar subtareas independientemente por índice. En la práctica, el volumen de subtareas por tarea es bajo (~10-20) y no justifica la complejidad adicional.
+
+---
+
+## Paso 24 — Múltiples tableros (US-22)
+
+> **Issue:** #40 · **PR:** #56 · **Rama:** `feat/40-multiples-tableros`
+
+### Problema
+
+La aplicación soportaba un único tablero implícito. Todas las columnas y tareas vivían en un espacio global sin particionamiento.
+
+### Solución
+
+#### Modelo de datos
+
+Se añade la interfaz `Board` (`id`, `name`, `emoji?`, `createdAt`) en `models.ts`. Se agrega `boardId: string` a las interfaces `Task` y `Column`. Las etiquetas permanecen globales (compartidas entre tableros).
+
+#### Migración de base de datos (v2 → v3)
+
+En `database.ts`, el bloque `if (oldVersion < 3)`:
+
+1. Crea el object store `boards` (keyPath = `id`).
+2. Genera un tablero por defecto con `crypto.randomUUID()` (sincrónico en `onupgradeneeded`).
+3. Crea el índice `by-board` en los stores `columns` y `tasks`.
+4. Itera registros existentes con `openCursor()` y asigna `boardId` al tablero por defecto.
+
+```
+boards store  → keyPath: 'id'
+columns store → nuevo índice: 'by-board' sobre 'boardId'
+tasks store   → nuevo índice: 'by-board' sobre 'boardId'
+```
+
+#### Repositorio de tableros (`board.repository.ts`)
+
+CRUD completo: `getAllBoards`, `getBoardById`, `createBoard`, `updateBoard`, `deleteBoard`. Tipos `CreateBoardInput` y `UpdateBoardInput` derivados con `Omit<>`.
+
+#### Repositorios actualizados
+
+- **`column.repository.ts`**: `getColumnsByBoard(boardId)` usa índice `by-board`. `seedDefaultColumns(boardId)` acepta parámetro. `deleteColumnsByBoard(boardId)` para limpieza en cascada.
+- **`task.repository.ts`**: `deleteTasksByBoard(boardId)` para eliminación en cascada al borrar un tablero.
+
+#### Componente `dojo-board-selector` (Organismo)
+
+Grid responsiva (`grid-template-columns: repeat(auto-fill, minmax(220px, 1fr))`) que muestra tarjetas con emoji, nombre y fecha. Funcionalidades:
+
+- **Crear tablero**: Formulario inline (nombre + emoji). Al crear, llama `createBoard()` + `seedDefaultColumns(boardId)`.
+- **Renombrar tablero**: Formulario inline con valores precargados. Llama `updateBoard()`.
+- **Eliminar tablero**: Diálogo de confirmación. Ejecuta `deleteTasksByBoard` → `deleteColumnsByBoard` → `deleteBoard`. Previene eliminar el último tablero.
+- Evento `dojo:board-selected` con `{ boardId }` al hacer click.
+
+#### Componente `dojo-kanban-board` actualizado
+
+- Nuevo atributo observado `board-id` (via `observedAttributes` + `attributeChangedCallback`).
+- `_loadBoard()` usa `getColumnsByBoard(this._boardId)` en lugar de `getAllColumns()`.
+- `createColumn()` y `createTask()` incluyen `boardId` del tablero activo.
+- No carga datos si `boardId` está vacío (espera a que se establezca).
+
+#### Orquestación en `dojo-app`
+
+- Importa `dojo-board-selector` y `getAllBoards`.
+- Estado `_activeBoardId`: si vacío → vista selector, si presente → vista tablero.
+- Atributo `view="board"` en el host controla visibilidad via CSS (header actions, botón "← Tableros").
+- `_autoSelectSingleBoard()`: si solo hay un tablero, navega directamente (UX optimizada).
+- `_navigateToBoard(boardId)`: oculta selector, muestra kanban con `board-id` attribute.
+- `_showBoardSelector()`: oculta kanban, muestra selector con `refresh()`.
+
+#### Export/Import actualizado
+
+`BoardExport` incluye campo opcional `boards?: Board[]`. La exportación lee el store `boards`. La importación es retrocompatible: si los datos importados no incluyen `boards`, crea un tablero por defecto y asigna `boardId` a columnas y tareas importadas.
+
+### Accesibilidad (WCAG 2.1)
+
+- Grid con `role="list"`, tarjetas con `role="listitem"` y `tabindex="0"`
+- `aria-label` descriptivos en tarjetas, botones de acción y formularios
+- Navegación con teclado (Enter/Space para seleccionar, Escape para cancelar)
+- Diálogo de eliminación con `role="alertdialog"` y `aria-labelledby`
+- Botones de acción visibles en hover/focus-within
+
+### ADR-29 — boardId en Task y Column (no solo en Column)
+
+**Contexto:** Dado que las tareas pertenecen a columnas y las columnas a tableros, `boardId` en `Task` es técnicamente redundante. Sin embargo, se necesitan operaciones de eliminación en cascada eficientes al borrar un tablero.
+
+**Decisión:** Añadir `boardId` directamente en `Task` además de en `Column`.
+
+**Consecuencias:**
+- `deleteTasksByBoard(boardId)` opera con un solo índice lookup en lugar de resolver columnas primero.
+- Ligera desnormalización compensada por simplicidad operacional.
+- El índice `by-board` en tasks permite consultas directas sin joins.

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -14,9 +14,11 @@
 
 import '../dojo-kanban-board/dojo-kanban-board.js';
 import '../dojo-label-manager/dojo-label-manager.js';
+import '../dojo-board-selector/dojo-board-selector.js';
 import '../../atoms/dojo-theme-toggle/dojo-theme-toggle.js';
 
 import type { Label } from '../../../types/models.js';
+import { getAllBoards } from '../../../db/board.repository.js';
 import {
   exportBoardData,
   downloadBoardExport,
@@ -32,6 +34,8 @@ export class DojoApp extends HTMLElement {
   /** Datos pendientes de importación (tras validación, previo a confirmación). */
   private _pendingImport: import('../../../db/export-import.js').BoardExport | null = null;
   private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+  /** ID del tablero activo. Si es vacío, se muestra el selector de tableros (US-22). */
+  private _activeBoardId = '';
 
   /** Referencia estable para poder eliminar el listener de teclado del diálogo de importación. */
   private _onImportKeydown = (e: KeyboardEvent): void => {
@@ -69,6 +73,7 @@ export class DojoApp extends HTMLElement {
     // Guarda de idempotencia: evita re-render al mover el elemento en el DOM
     if (this._shadow.childElementCount > 0) return;
     this._render();
+    this._autoSelectSingleBoard();
   }
 
   disconnectedCallback(): void {
@@ -281,6 +286,38 @@ export class DojoApp extends HTMLElement {
       dojo-kanban-board {
         height: 100%;
       }
+      dojo-board-selector {
+        height: 100%;
+      }
+
+      /* Botón "Volver a tableros" */
+      .back-btn {
+        display: none;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.3125rem 0.625rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s, border-color 0.15s;
+        white-space: nowrap;
+      }
+      .back-btn:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .back-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+      :host([view="board"]) .back-btn { display: inline-flex; }
+      :host([view="board"]) .header-actions { display: flex; }
+      :host(:not([view="board"])) .header-actions { display: none; }
     `;
     this._shadow.appendChild(style);
 
@@ -366,6 +403,22 @@ export class DojoApp extends HTMLElement {
 
     appHeader.appendChild(logo);
     appHeader.appendChild(title);
+
+    // Botón "Volver a tableros" (US-22) — visible solo en vista de tablero
+    const backBtn = document.createElement('button');
+    backBtn.className = 'back-btn';
+    backBtn.type = 'button';
+    backBtn.setAttribute('aria-label', 'Volver a la lista de tableros');
+    const backIcon = document.createElement('span');
+    backIcon.setAttribute('aria-hidden', 'true');
+    backIcon.textContent = '←';
+    const backText = document.createElement('span');
+    backText.textContent = 'Tableros';
+    backBtn.appendChild(backIcon);
+    backBtn.appendChild(backText);
+    backBtn.addEventListener('click', () => this._showBoardSelector());
+    appHeader.appendChild(backBtn);
+
     appHeader.appendChild(headerActions);
     appHeader.appendChild(themeToggle);
     this._shadow.appendChild(appHeader);
@@ -375,9 +428,21 @@ export class DojoApp extends HTMLElement {
     boardArea.className = 'board-area';
     boardArea.setAttribute('role', 'main');
 
+    // Selector de tableros (vista por defecto — US-22)
+    const boardSelector = document.createElement('dojo-board-selector');
+    boardArea.appendChild(boardSelector);
+
+    // Tablero Kanban (se muestra al seleccionar un tablero)
     const board = document.createElement('dojo-kanban-board');
+    board.style.display = 'none';
     boardArea.appendChild(board);
     this._shadow.appendChild(boardArea);
+
+    // Escuchar selección de tablero (US-22)
+    this._shadow.addEventListener('dojo:board-selected', (e: Event) => {
+      const { boardId } = (e as CustomEvent).detail as { boardId: string };
+      this._navigateToBoard(boardId);
+    });
 
     // ── Panel de gestión de etiquetas (US-11) ───────────────────────────────────────
     const labelMgr = document.createElement('dojo-label-manager');
@@ -431,6 +496,49 @@ export class DojoApp extends HTMLElement {
     toast.setAttribute('role', 'status');
     toast.setAttribute('aria-live', 'polite');
     this._shadow.appendChild(toast);
+  }
+
+  // ── Navegación entre vistas (US-22) ──────────────────────────────────────
+
+  /**
+   * Si solo hay un tablero, navega directamente a él.
+   * Si hay múltiples, se queda en el selector.
+   */
+  private async _autoSelectSingleBoard(): Promise<void> {
+    try {
+      const boards = await getAllBoards();
+      if (boards.length === 1) {
+        this._navigateToBoard(boards[0].id);
+      }
+    } catch {
+      // Si falla, se queda en el selector
+    }
+  }
+
+  private _navigateToBoard(boardId: string): void {
+    this._activeBoardId = boardId;
+    this.setAttribute('view', 'board');
+
+    const selector = this._shadow.querySelector('dojo-board-selector') as HTMLElement | null;
+    const board    = this._shadow.querySelector('dojo-kanban-board') as HTMLElement | null;
+    if (selector) selector.style.display = 'none';
+    if (board) {
+      board.style.display = '';
+      board.setAttribute('board-id', boardId);
+    }
+  }
+
+  private _showBoardSelector(): void {
+    this._activeBoardId = '';
+    this.removeAttribute('view');
+
+    const selector = this._shadow.querySelector('dojo-board-selector') as HTMLElement | null;
+    const board    = this._shadow.querySelector('dojo-kanban-board') as HTMLElement | null;
+    if (board) board.style.display = 'none';
+    if (selector) {
+      selector.style.display = '';
+      (selector as any).refresh?.();
+    }
   }
 
   // ── Export/Import (US-19) ────────────────────────────────────────────────

--- a/src/components/organisms/dojo-board-selector/dojo-board-selector.ts
+++ b/src/components/organisms/dojo-board-selector/dojo-board-selector.ts
@@ -17,7 +17,8 @@
 
 import { getAllBoards, createBoard, updateBoard, deleteBoard } from '../../../db/board.repository.js';
 import { seedDefaultColumns, deleteColumnsByBoard } from '../../../db/column.repository.js';
-import { deleteTasksByBoard } from '../../../db/task.repository.js';
+import { deleteTasksByBoard, getTaskIdsByBoard } from '../../../db/task.repository.js';
+import { deleteActivitiesByTaskId } from '../../../db/activity.repository.js';
 import type { Board } from '../../../types/models.js';
 
 export class DojoBoardSelector extends HTMLElement {
@@ -645,19 +646,52 @@ export class DojoBoardSelector extends HTMLElement {
   private _showDeleteDialogUI(): void {
     this._shadow.querySelector('.delete-backdrop')?.classList.add('visible');
     this._shadow.querySelector('.delete-dialog')?.classList.add('visible');
+    document.addEventListener('keydown', this._onDeleteKeydown);
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLButtonElement>('.delete-cancel-btn')?.focus();
+    });
   }
 
   private _hideDeleteDialog(): void {
     this._shadow.querySelector('.delete-backdrop')?.classList.remove('visible');
     this._shadow.querySelector('.delete-dialog')?.classList.remove('visible');
+    document.removeEventListener('keydown', this._onDeleteKeydown);
     this._pendingDeleteId = null;
   }
+
+  /** Focus trap + Escape para el diálogo de eliminación (WCAG 2.1 SC 2.1.2). */
+  private _onDeleteKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this._hideDeleteDialog();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = Array.from(
+        this._shadow.querySelectorAll<HTMLElement>('.delete-dialog button:not([style*="display: none"])')
+      ).filter(el => el.offsetParent !== null);
+      if (focusable.length < 2) return;
+      const first  = focusable[0];
+      const last   = focusable[focusable.length - 1];
+      const active = this._shadow.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
 
   private async _confirmDelete(): Promise<void> {
     const boardId = this._pendingDeleteId;
     if (!boardId) return;
 
     try {
+      // Limpiar actividad asociada a las tareas del tablero (evita datos huérfanos)
+      const taskIds = await getTaskIdsByBoard(boardId);
+      await Promise.all(taskIds.map(id => deleteActivitiesByTaskId(id)));
       await deleteTasksByBoard(boardId);
       await deleteColumnsByBoard(boardId);
       await deleteBoard(boardId);

--- a/src/components/organisms/dojo-board-selector/dojo-board-selector.ts
+++ b/src/components/organisms/dojo-board-selector/dojo-board-selector.ts
@@ -1,0 +1,675 @@
+/**
+ * dojo-board-selector — Organismo
+ *
+ * Pantalla de selección de tableros. Muestra una grid con los tableros
+ * disponibles y permite crear, renombrar y eliminar tableros.
+ *
+ * ## Eventos despachados
+ * | Nombre                  | Detalle           | Descripción                       |
+ * |-------------------------|-------------------|-----------------------------------|
+ * | dojo:board-selected     | { boardId }       | Usuario seleccionó un tablero     |
+ * | dojo:boards-changed     | —                 | Tablero creado/eliminado/editado  |
+ *
+ * ## CSS Custom Properties
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-radius,
+ * --dojo-text-primary, --dojo-text-secondary, --dojo-primary, --dojo-shadow
+ */
+
+import { getAllBoards, createBoard, updateBoard, deleteBoard } from '../../../db/board.repository.js';
+import { seedDefaultColumns, deleteColumnsByBoard } from '../../../db/column.repository.js';
+import { deleteTasksByBoard } from '../../../db/task.repository.js';
+import type { Board } from '../../../types/models.js';
+
+export class DojoBoardSelector extends HTMLElement {
+  static readonly TAG = 'dojo-board-selector';
+
+  private _shadow: ShadowRoot;
+  private _boards: Board[] = [];
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._render();
+    this._loadBoards();
+  }
+
+  /** Recarga la lista de tableros externamente. */
+  async refresh(): Promise<void> {
+    await this._loadBoards();
+  }
+
+  // ── Carga de datos ───────────────────────────────────────────────────────
+
+  private async _loadBoards(): Promise<void> {
+    try {
+      this._boards = await getAllBoards();
+      this._renderBoardGrid();
+    } catch (err) {
+      console.error('[dojo-board-selector] Error cargando tableros:', err);
+    }
+  }
+
+  // ── Render base ──────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        background: var(--dojo-bg);
+        overflow-y: auto;
+      }
+
+      .selector-header {
+        padding: 2rem 2rem 0;
+        text-align: center;
+      }
+      .selector-title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0 0 0.25rem;
+      }
+      .selector-subtitle {
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        margin: 0;
+      }
+
+      .board-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 1rem;
+        padding: 2rem;
+        max-width: 960px;
+        margin: 0 auto;
+        width: 100%;
+        box-sizing: border-box;
+      }
+
+      .board-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        padding: 1.5rem 1rem;
+        cursor: pointer;
+        transition: box-shadow 0.15s, border-color 0.15s, transform 0.1s;
+        position: relative;
+        min-height: 120px;
+      }
+      .board-card:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        border-color: var(--dojo-primary, #1D4ED8);
+        transform: translateY(-2px);
+      }
+      .board-card:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      .board-emoji {
+        font-size: 2rem;
+        line-height: 1;
+        margin-bottom: 0.5rem;
+      }
+      .board-name {
+        font-size: 0.9375rem;
+        font-weight: 600;
+        color: var(--dojo-text-primary);
+        text-align: center;
+        word-break: break-word;
+        max-width: 100%;
+      }
+      .board-date {
+        font-size: 0.6875rem;
+        color: var(--dojo-text-secondary);
+        margin-top: 0.375rem;
+      }
+
+      .board-actions {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        display: flex;
+        gap: 0.25rem;
+        opacity: 0;
+        transition: opacity 0.15s;
+      }
+      .board-card:hover .board-actions,
+      .board-card:focus-within .board-actions {
+        opacity: 1;
+      }
+      .board-action-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.2rem 0.35rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.8125rem;
+        line-height: 1;
+        color: var(--dojo-text-secondary);
+        transition: background 0.15s, color 0.15s;
+      }
+      .board-action-btn:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+      }
+      .board-action-btn.delete:hover {
+        background: #FEE2E2;
+        color: #EF4444;
+      }
+      .board-action-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Card de "nuevo tablero" */
+      .new-board-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+        border: 2px dashed var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        padding: 1.5rem 1rem;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s;
+        min-height: 120px;
+        color: var(--dojo-text-secondary);
+        font-family: inherit;
+        font-size: 0.9375rem;
+        font-weight: 500;
+      }
+      .new-board-card:hover {
+        background: var(--dojo-surface);
+        border-color: var(--dojo-primary, #1D4ED8);
+        color: var(--dojo-primary, #1D4ED8);
+      }
+      .new-board-card:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+      .new-board-icon {
+        font-size: 1.5rem;
+        margin-bottom: 0.375rem;
+      }
+
+      /* Inline form (create/rename) */
+      .inline-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 1rem;
+        background: var(--dojo-surface);
+        border: 2px solid var(--dojo-primary, #1D4ED8);
+        border-radius: var(--dojo-radius, 6px);
+        min-height: 120px;
+      }
+      .inline-input {
+        padding: 0.4375rem 0.625rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        font-family: inherit;
+        color: var(--dojo-text-primary);
+        background: var(--dojo-bg);
+        outline: none;
+      }
+      .inline-input:focus {
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .inline-row {
+        display: flex;
+        gap: 0.375rem;
+      }
+      .inline-btn {
+        padding: 0.3125rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .inline-btn.cancel {
+        background: transparent;
+        color: var(--dojo-text-secondary);
+      }
+
+      /* Diálogo de confirmación de eliminación */
+      .delete-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+        z-index: 300;
+        display: none;
+      }
+      .delete-backdrop.visible { display: block; }
+      .delete-dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 301;
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+        padding: 1.5rem;
+        width: 380px;
+        max-width: calc(100vw - 2rem);
+        display: none;
+      }
+      .delete-dialog.visible { display: block; }
+      .delete-dialog-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0 0 0.5rem;
+      }
+      .delete-dialog-body {
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        margin: 0 0 1.25rem;
+        line-height: 1.5;
+      }
+      .delete-dialog-actions {
+        display: flex;
+        gap: 0.625rem;
+        justify-content: flex-end;
+      }
+      .delete-cancel-btn,
+      .delete-confirm-btn {
+        padding: 0.4375rem 1rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+      }
+      .delete-cancel-btn {
+        background: transparent;
+        border: 1px solid var(--dojo-border);
+        color: var(--dojo-text-primary);
+      }
+      .delete-confirm-btn {
+        background: #DC2626;
+        border: 1px solid transparent;
+        color: #fff;
+        font-weight: 600;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'selector-header';
+    const title = document.createElement('h1');
+    title.className = 'selector-title';
+    title.textContent = '🥋 Dojo Kanban';
+    const subtitle = document.createElement('p');
+    subtitle.className = 'selector-subtitle';
+    subtitle.textContent = 'Selecciona un tablero para comenzar';
+    header.appendChild(title);
+    header.appendChild(subtitle);
+    this._shadow.appendChild(header);
+
+    // Grid container (populated by _renderBoardGrid)
+    const grid = document.createElement('div');
+    grid.className = 'board-grid';
+    grid.setAttribute('role', 'list');
+    grid.setAttribute('aria-label', 'Tableros disponibles');
+    this._shadow.appendChild(grid);
+
+    // Delete confirmation dialog
+    const backdrop = document.createElement('div');
+    backdrop.className = 'delete-backdrop';
+    backdrop.addEventListener('click', () => this._hideDeleteDialog());
+
+    const dialog = document.createElement('div');
+    dialog.className = 'delete-dialog';
+    dialog.setAttribute('role', 'alertdialog');
+    dialog.setAttribute('aria-labelledby', 'bs-delete-title');
+
+    const dTitle = document.createElement('h2');
+    dTitle.className = 'delete-dialog-title';
+    dTitle.id = 'bs-delete-title';
+    dTitle.textContent = '⚠️ Eliminar tablero';
+
+    const dBody = document.createElement('p');
+    dBody.className = 'delete-dialog-body';
+
+    const dActions = document.createElement('div');
+    dActions.className = 'delete-dialog-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'delete-cancel-btn';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._hideDeleteDialog());
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'delete-confirm-btn';
+    confirmBtn.type = 'button';
+    confirmBtn.textContent = 'Eliminar';
+
+    dActions.appendChild(cancelBtn);
+    dActions.appendChild(confirmBtn);
+    dialog.appendChild(dTitle);
+    dialog.appendChild(dBody);
+    dialog.appendChild(dActions);
+
+    this._shadow.appendChild(backdrop);
+    this._shadow.appendChild(dialog);
+  }
+
+  // ── Render de la grid ────────────────────────────────────────────────────
+
+  private _renderBoardGrid(): void {
+    const grid = this._shadow.querySelector('.board-grid');
+    if (!grid) return;
+    grid.innerHTML = '';
+
+    for (const board of this._boards) {
+      grid.appendChild(this._createBoardCard(board));
+    }
+
+    // Card para crear nuevo tablero
+    const newCard = document.createElement('button');
+    newCard.className = 'new-board-card';
+    newCard.type = 'button';
+    newCard.setAttribute('role', 'listitem');
+    newCard.setAttribute('aria-label', 'Crear nuevo tablero');
+
+    const newIcon = document.createElement('span');
+    newIcon.className = 'new-board-icon';
+    newIcon.textContent = '➕';
+    const newText = document.createElement('span');
+    newText.textContent = 'Nuevo tablero';
+
+    newCard.appendChild(newIcon);
+    newCard.appendChild(newText);
+    newCard.addEventListener('click', () => this._showCreateForm(grid as HTMLElement));
+    grid.appendChild(newCard);
+  }
+
+  private _createBoardCard(board: Board): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'board-card';
+    card.setAttribute('role', 'listitem');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('aria-label', `Tablero: ${board.name}`);
+
+    const emoji = document.createElement('span');
+    emoji.className = 'board-emoji';
+    emoji.setAttribute('aria-hidden', 'true');
+    emoji.textContent = board.emoji || '📋';
+
+    const name = document.createElement('span');
+    name.className = 'board-name';
+    name.textContent = board.name;
+
+    const date = document.createElement('span');
+    date.className = 'board-date';
+    date.textContent = new Date(board.createdAt).toLocaleDateString('es', {
+      day: 'numeric', month: 'short', year: 'numeric',
+    });
+
+    // Action buttons
+    const actions = document.createElement('div');
+    actions.className = 'board-actions';
+
+    const renameBtn = document.createElement('button');
+    renameBtn.className = 'board-action-btn';
+    renameBtn.type = 'button';
+    renameBtn.setAttribute('aria-label', `Renombrar tablero: ${board.name}`);
+    renameBtn.textContent = '✏️';
+    renameBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._showRenameForm(card, board);
+    });
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'board-action-btn delete';
+    deleteBtn.type = 'button';
+    deleteBtn.setAttribute('aria-label', `Eliminar tablero: ${board.name}`);
+    deleteBtn.textContent = '🗑️';
+    deleteBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._showDeleteDialog(board);
+    });
+
+    actions.appendChild(renameBtn);
+    actions.appendChild(deleteBtn);
+
+    card.appendChild(actions);
+    card.appendChild(emoji);
+    card.appendChild(name);
+    card.appendChild(date);
+
+    // Click → select board
+    card.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('dojo:board-selected', {
+        bubbles: true, composed: true,
+        detail: { boardId: board.id },
+      }));
+    });
+    card.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        card.click();
+      }
+    });
+
+    return card;
+  }
+
+  // ── Crear tablero (inline form) ──────────────────────────────────────────
+
+  private _showCreateForm(grid: HTMLElement): void {
+    const newCard = grid.querySelector('.new-board-card');
+    if (!newCard) return;
+
+    const form = document.createElement('div');
+    form.className = 'inline-form';
+    form.setAttribute('role', 'listitem');
+
+    const nameInput = document.createElement('input');
+    nameInput.className = 'inline-input';
+    nameInput.type = 'text';
+    nameInput.placeholder = 'Nombre del tablero';
+    nameInput.maxLength = 60;
+    nameInput.setAttribute('aria-label', 'Nombre del nuevo tablero');
+
+    const emojiInput = document.createElement('input');
+    emojiInput.className = 'inline-input';
+    emojiInput.type = 'text';
+    emojiInput.placeholder = 'Emoji (opcional, ej. 🚀)';
+    emojiInput.maxLength = 4;
+    emojiInput.setAttribute('aria-label', 'Emoji del tablero');
+
+    const row = document.createElement('div');
+    row.className = 'inline-row';
+
+    const createBtn = document.createElement('button');
+    createBtn.className = 'inline-btn';
+    createBtn.type = 'button';
+    createBtn.textContent = 'Crear';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'inline-btn cancel';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._renderBoardGrid());
+
+    const doCreate = async (): Promise<void> => {
+      const name = nameInput.value.trim();
+      if (!name) { nameInput.focus(); return; }
+      createBtn.disabled = true;
+      try {
+        const board = await createBoard({ name, emoji: emojiInput.value.trim() || undefined });
+        await seedDefaultColumns(board.id);
+        this._boards.push(board);
+        this._renderBoardGrid();
+        this.dispatchEvent(new CustomEvent('dojo:boards-changed', { bubbles: true, composed: true }));
+      } catch (err) {
+        console.error('[dojo-board-selector] Error creando tablero:', err);
+        createBtn.disabled = false;
+      }
+    };
+
+    createBtn.addEventListener('click', doCreate);
+    nameInput.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') { e.preventDefault(); doCreate(); }
+      if (e.key === 'Escape') { e.preventDefault(); this._renderBoardGrid(); }
+    });
+    emojiInput.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') { e.preventDefault(); doCreate(); }
+      if (e.key === 'Escape') { e.preventDefault(); this._renderBoardGrid(); }
+    });
+
+    row.appendChild(createBtn);
+    row.appendChild(cancelBtn);
+    form.appendChild(nameInput);
+    form.appendChild(emojiInput);
+    form.appendChild(row);
+
+    newCard.replaceWith(form);
+    requestAnimationFrame(() => nameInput.focus());
+  }
+
+  // ── Renombrar tablero (inline form) ──────────────────────────────────────
+
+  private _showRenameForm(card: HTMLElement, board: Board): void {
+    const form = document.createElement('div');
+    form.className = 'inline-form';
+    form.setAttribute('role', 'listitem');
+
+    const nameInput = document.createElement('input');
+    nameInput.className = 'inline-input';
+    nameInput.type = 'text';
+    nameInput.value = board.name;
+    nameInput.maxLength = 60;
+    nameInput.setAttribute('aria-label', 'Nuevo nombre del tablero');
+
+    const emojiInput = document.createElement('input');
+    emojiInput.className = 'inline-input';
+    emojiInput.type = 'text';
+    emojiInput.value = board.emoji ?? '';
+    emojiInput.maxLength = 4;
+    emojiInput.setAttribute('aria-label', 'Nuevo emoji del tablero');
+
+    const row = document.createElement('div');
+    row.className = 'inline-row';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'inline-btn';
+    saveBtn.type = 'button';
+    saveBtn.textContent = 'Guardar';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'inline-btn cancel';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => this._renderBoardGrid());
+
+    const doRename = async (): Promise<void> => {
+      const name = nameInput.value.trim();
+      if (!name) { nameInput.focus(); return; }
+      saveBtn.disabled = true;
+      try {
+        const updated = await updateBoard(board.id, { name, emoji: emojiInput.value.trim() || undefined });
+        const idx = this._boards.findIndex(b => b.id === board.id);
+        if (idx !== -1) this._boards[idx] = updated;
+        this._renderBoardGrid();
+        this.dispatchEvent(new CustomEvent('dojo:boards-changed', { bubbles: true, composed: true }));
+      } catch (err) {
+        console.error('[dojo-board-selector] Error renombrando tablero:', err);
+        saveBtn.disabled = false;
+      }
+    };
+
+    saveBtn.addEventListener('click', doRename);
+    nameInput.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') { e.preventDefault(); doRename(); }
+      if (e.key === 'Escape') { e.preventDefault(); this._renderBoardGrid(); }
+    });
+
+    row.appendChild(saveBtn);
+    row.appendChild(cancelBtn);
+    form.appendChild(nameInput);
+    form.appendChild(emojiInput);
+    form.appendChild(row);
+
+    card.replaceWith(form);
+    requestAnimationFrame(() => { nameInput.focus(); nameInput.select(); });
+  }
+
+  // ── Eliminar tablero ─────────────────────────────────────────────────────
+
+  private _pendingDeleteId: string | null = null;
+
+  private _showDeleteDialog(board: Board): void {
+    if (this._boards.length <= 1) {
+      // No permitir eliminar el último tablero
+      const body = this._shadow.querySelector('.delete-dialog-body');
+      if (body) body.textContent = 'No se puede eliminar el único tablero. Debe existir al menos un tablero.';
+      const confirmBtn = this._shadow.querySelector<HTMLButtonElement>('.delete-confirm-btn');
+      if (confirmBtn) confirmBtn.style.display = 'none';
+      this._showDeleteDialogUI();
+      return;
+    }
+
+    this._pendingDeleteId = board.id;
+    const body = this._shadow.querySelector('.delete-dialog-body');
+    if (body) body.textContent = `Se eliminará el tablero "${board.name}" junto con todas sus columnas y tareas. Esta acción no se puede deshacer.`;
+    const confirmBtn = this._shadow.querySelector<HTMLButtonElement>('.delete-confirm-btn');
+    if (confirmBtn) {
+      confirmBtn.style.display = '';
+      confirmBtn.onclick = () => this._confirmDelete();
+    }
+    this._showDeleteDialogUI();
+  }
+
+  private _showDeleteDialogUI(): void {
+    this._shadow.querySelector('.delete-backdrop')?.classList.add('visible');
+    this._shadow.querySelector('.delete-dialog')?.classList.add('visible');
+  }
+
+  private _hideDeleteDialog(): void {
+    this._shadow.querySelector('.delete-backdrop')?.classList.remove('visible');
+    this._shadow.querySelector('.delete-dialog')?.classList.remove('visible');
+    this._pendingDeleteId = null;
+  }
+
+  private async _confirmDelete(): Promise<void> {
+    const boardId = this._pendingDeleteId;
+    if (!boardId) return;
+
+    try {
+      await deleteTasksByBoard(boardId);
+      await deleteColumnsByBoard(boardId);
+      await deleteBoard(boardId);
+      this._boards = this._boards.filter(b => b.id !== boardId);
+      this._hideDeleteDialog();
+      this._renderBoardGrid();
+      this.dispatchEvent(new CustomEvent('dojo:boards-changed', { bubbles: true, composed: true }));
+    } catch (err) {
+      console.error('[dojo-board-selector] Error eliminando tablero:', err);
+      this._hideDeleteDialog();
+    }
+  }
+}
+
+customElements.define(DojoBoardSelector.TAG, DojoBoardSelector);

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -29,7 +29,7 @@
  */
 
 import type { Column, Task, Label, Priority } from '../../../types/models.js';
-import { getAllColumns, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
+import { getColumnsByBoard, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
 import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import { getAllLabels } from '../../../db/label.repository.js';
 import { addActivityEvent, deleteActivitiesByTaskId } from '../../../db/activity.repository.js';
@@ -62,8 +62,10 @@ interface TaskCardElement extends HTMLElement {
 
 export class DojoKanbanBoard extends HTMLElement {
   static readonly TAG = 'dojo-kanban-board';
+  static get observedAttributes(): string[] { return ['board-id']; }
 
   private _shadow: ShadowRoot;
+  private _boardId = '';
   private _activeFilter: ActiveFilter = {};
   /** columnId → lista de todas las tareas de esa columna (sin filtrar) */
   private _tasksByColumn: Map<string, Task[]> = new Map();
@@ -88,9 +90,19 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   connectedCallback(): void {
+    this._boardId = this.getAttribute('board-id') ?? '';
     this._render();
-    this._loadBoard();
+    if (this._boardId) this._loadBoard();
   }
+
+  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
+    if (name === 'board-id' && newVal && newVal !== oldVal) {
+      this._boardId = newVal;
+      if (this._shadow.childElementCount > 0) this._loadBoard();
+    }
+  }
+
+  get boardId(): string { return this._boardId; }
 
   // ── API pública ──────────────────────────────────────────────────────────
 
@@ -753,7 +765,7 @@ export class DojoKanbanBoard extends HTMLElement {
 
     try {
       const [columns, labels] = await Promise.all([
-        getAllColumns(),
+        getColumnsByBoard(this._boardId),
         getAllLabels(),
       ]);
       this._labels = labels;
@@ -1074,7 +1086,7 @@ export class DojoKanbanBoard extends HTMLElement {
       ? Math.max(...this._columns.map(c => c.order)) + 1
       : 0;
     try {
-      const newCol = await createColumn({ name, icon, order: nextOrder });
+      const newCol = await createColumn({ name, icon, order: nextOrder, boardId: this._boardId });
       this._columns.push(newCol);
       this._tasksByColumn.set(newCol.id, []);
       this._renderColumns(this._columns);
@@ -1187,6 +1199,7 @@ export class DojoKanbanBoard extends HTMLElement {
         title,
         description,
         statusId,
+        boardId:   this._boardId,
         priority:  priority as Task['priority'],
         labelIds:  [],
         order:     tasks.length,

--- a/src/db/board.repository.ts
+++ b/src/db/board.repository.ts
@@ -1,0 +1,72 @@
+/**
+ * board.repository.ts — CRUD de tableros sobre IndexedDB (US-22).
+ *
+ * Cada tablero agrupa un conjunto independiente de columnas y tareas.
+ * Las etiquetas son globales y se comparten entre todos los tableros.
+ */
+
+import { idbRequest, idbTransaction, getStore } from './database.js';
+import { generateUUID } from '../utils/uuid.js';
+import type { Board } from '../types/models.js';
+
+// ── Tipos internos ─────────────────────────────────────────────────────────
+
+type CreateBoardInput = Omit<Board, 'id' | 'createdAt'>;
+type UpdateBoardInput = Partial<Omit<Board, 'id' | 'createdAt'>>;
+
+// ── Implementación ─────────────────────────────────────────────────────────
+
+/** Devuelve todos los tableros ordenados por fecha de creación ascendente. */
+export async function getAllBoards(): Promise<Board[]> {
+  const { store } = await getStore('boards');
+  const boards    = await idbRequest<Board[]>(store.getAll());
+  return boards.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/** Devuelve un tablero por su ID, o `undefined` si no existe. */
+export async function getBoardById(id: string): Promise<Board | undefined> {
+  const { store } = await getStore('boards');
+  return idbRequest<Board | undefined>(store.get(id));
+}
+
+/**
+ * Crea un nuevo tablero. Asigna `id` y `createdAt` automáticamente.
+ */
+export async function createBoard(input: CreateBoardInput): Promise<Board> {
+  const board: Board = {
+    ...input,
+    id:        generateUUID(),
+    createdAt: new Date().toISOString(),
+  };
+
+  const { store, tx } = await getStore('boards', 'readwrite');
+  store.add(board);
+  await idbTransaction(tx);
+  return board;
+}
+
+/**
+ * Actualiza un tablero existente.
+ * Lanza un `Error` si el tablero no existe.
+ */
+export async function updateBoard(id: string, changes: UpdateBoardInput): Promise<Board> {
+  const existing = await getBoardById(id);
+  if (!existing) throw new Error(`Board not found: ${id}`);
+
+  const updated: Board = { ...existing, ...changes, id, createdAt: existing.createdAt };
+
+  const { store, tx } = await getStore('boards', 'readwrite');
+  store.put(updated);
+  await idbTransaction(tx);
+  return updated;
+}
+
+/**
+ * Elimina un tablero por su ID.
+ * La lógica de negocio debe eliminar columnas y tareas asociadas antes de llamar esta función.
+ */
+export async function deleteBoard(id: string): Promise<void> {
+  const { store, tx } = await getStore('boards', 'readwrite');
+  store.delete(id);
+  await idbTransaction(tx);
+}

--- a/src/db/column.repository.ts
+++ b/src/db/column.repository.ts
@@ -13,7 +13,7 @@ import type { Column } from '../types/models.js';
 // ── Tipos internos ─────────────────────────────────────────────────────────
 
 type CreateColumnInput = Omit<Column, 'id'>;
-type UpdateColumnInput = Partial<Omit<Column, 'id'>>;
+type UpdateColumnInput = Partial<Omit<Column, 'id' | 'boardId'>>;
 
 // ── Implementación ─────────────────────────────────────────────────────────
 
@@ -21,6 +21,14 @@ type UpdateColumnInput = Partial<Omit<Column, 'id'>>;
 export async function getAllColumns(): Promise<Column[]> {
   const { store } = await getStore('columns');
   const columns   = await idbRequest<Column[]>(store.getAll());
+  return columns.sort((a, b) => a.order - b.order);
+}
+
+/** Devuelve todas las columnas de un tablero, ordenadas por `order` ascendente (US-22). */
+export async function getColumnsByBoard(boardId: string): Promise<Column[]> {
+  const { store } = await getStore('columns');
+  const index     = store.index('by-board');
+  const columns   = await idbRequest<Column[]>(index.getAll(boardId));
   return columns.sort((a, b) => a.order - b.order);
 }
 
@@ -70,16 +78,26 @@ export async function deleteColumn(id: string): Promise<void> {
 }
 
 /**
- * Inserta las columnas por defecto si el Object Store está vacío.
- * Se llama una sola vez durante la inicialización de la aplicación.
+ * Inserta las columnas por defecto para un tablero dado.
+ * @param boardId - ID del tablero al que pertenecerán las columnas.
  */
-export async function seedDefaultColumns(): Promise<void> {
-  const existing = await getAllColumns();
-  if (existing.length > 0) return;
-
+export async function seedDefaultColumns(boardId: string): Promise<void> {
   const { store, tx } = await getStore('columns', 'readwrite');
   for (const col of DEFAULT_COLUMNS) {
-    store.add({ ...col, id: generateUUID() });
+    store.add({ ...col, id: generateUUID(), boardId });
+  }
+  await idbTransaction(tx);
+}
+
+/**
+ * Elimina todas las columnas de un tablero (US-22).
+ */
+export async function deleteColumnsByBoard(boardId: string): Promise<void> {
+  const cols = await getColumnsByBoard(boardId);
+  if (cols.length === 0) return;
+  const { store, tx } = await getStore('columns', 'readwrite');
+  for (const col of cols) {
+    store.delete(col.id);
   }
   await idbTransaction(tx);
 }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -5,14 +5,15 @@
  * Toda la asincronía basada en eventos (IDBRequest) se encapsula en Promesas.
  *
  * Object Stores:
- *   - tasks    : keyPath = 'id'  | índices: by-status, by-priority, by-created
- *   - columns  : keyPath = 'id'
+ *   - tasks    : keyPath = 'id'  | índices: by-status, by-priority, by-created, by-board
+ *   - columns  : keyPath = 'id'  | índice: by-board
  *   - labels   : keyPath = 'id'  | índice: by-name (unique)
  *   - activity : keyPath = 'id'  | índice: by-taskId (US-20)
+ *   - boards   : keyPath = 'id'  (US-22)
  */
 
 const DB_NAME    = 'kanban-app-db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 /** Instancia singleton de la base de datos (se inicializa una sola vez). */
 let _db: IDBDatabase | null = null;
@@ -95,7 +96,62 @@ export function openDatabase(): Promise<IDBDatabase> {
         activityStore.createIndex('by-taskId', 'taskId', { unique: false });
       }
 
-      // if (oldVersion < 3) { ... }
+      // v2 → v3: múltiples tableros (US-22)
+      if (oldVersion < 3) {
+        // Nuevo store 'boards'
+        db.createObjectStore('boards', { keyPath: 'id' });
+
+        // Crear tablero por defecto y asignar boardId a datos existentes.
+        // Usamos crypto.randomUUID() directamente aquí porque generateUUID es
+        // un import externo y onupgradeneeded debe ser synchronous.
+        const defaultBoardId = crypto.randomUUID();
+        const now            = new Date().toISOString();
+
+        const tx = (event.target as IDBOpenDBRequest).transaction!;
+
+        // Insertar tablero por defecto
+        const boardStore = tx.objectStore('boards');
+        boardStore.add({
+          id: defaultBoardId,
+          name: 'Mi tablero',
+          emoji: '🥋',
+          createdAt: now,
+        });
+
+        // Añadir índice by-board a columns y asignar boardId a columnas existentes
+        const colStore = tx.objectStore('columns');
+        colStore.createIndex('by-board', 'boardId', { unique: false });
+        const colReq = colStore.openCursor();
+        colReq.onsuccess = () => {
+          const cursor = colReq.result;
+          if (cursor) {
+            const col = cursor.value;
+            if (!col.boardId) {
+              col.boardId = defaultBoardId;
+              cursor.update(col);
+            }
+            cursor.continue();
+          }
+        };
+
+        // Añadir índice by-board a tasks y asignar boardId a tareas existentes
+        const taskStore = tx.objectStore('tasks');
+        taskStore.createIndex('by-board', 'boardId', { unique: false });
+        const taskReq = taskStore.openCursor();
+        taskReq.onsuccess = () => {
+          const cursor = taskReq.result;
+          if (cursor) {
+            const task = cursor.value;
+            if (!task.boardId) {
+              task.boardId = defaultBoardId;
+              cursor.update(task);
+            }
+            cursor.continue();
+          }
+        };
+      }
+
+      // if (oldVersion < 4) { ... }
     };
   });
 

--- a/src/db/export-import.ts
+++ b/src/db/export-import.ts
@@ -11,7 +11,7 @@
  */
 
 import { openDatabase, idbRequest, idbTransaction } from './database.js';
-import type { Column, Task, Label, ActivityEvent } from '../types/models.js';
+import type { Column, Task, Label, ActivityEvent, Board } from '../types/models.js';
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
@@ -29,6 +29,7 @@ export interface BoardExport {
   tasks: Task[];
   labels: Label[];
   activity?: ActivityEvent[];
+  boards?: Board[];
 }
 
 /** Resultado de la validación de un archivo importado. */
@@ -57,13 +58,21 @@ export async function exportBoardData(): Promise<BoardExport> {
   // Incluir activity si el store existe (DB v2+)
   const allNames = db.objectStoreNames;
   const hasActivity = allNames.contains('activity');
-  const txStores = hasActivity ? [...storeNames, 'activity'] : [...storeNames];
+  const hasBoards   = allNames.contains('boards');
+  const txStores = [
+    ...storeNames,
+    ...(hasActivity ? ['activity'] : []),
+    ...(hasBoards   ? ['boards']   : []),
+  ];
   const tx = db.transaction(txStores, 'readonly');
   const columns  = await idbRequest<Column[]>(tx.objectStore('columns').getAll());
   const tasks    = await idbRequest<Task[]>(tx.objectStore('tasks').getAll());
   const labels   = await idbRequest<Label[]>(tx.objectStore('labels').getAll());
   const activity = hasActivity
     ? await idbRequest<ActivityEvent[]>(tx.objectStore('activity').getAll())
+    : [];
+  const boards   = hasBoards
+    ? await idbRequest<Board[]>(tx.objectStore('boards').getAll())
     : [];
 
   return {
@@ -73,6 +82,7 @@ export async function exportBoardData(): Promise<BoardExport> {
     tasks,
     labels:     labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })),
     activity:   activity.sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+    boards:     boards.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
   };
 }
 
@@ -183,9 +193,12 @@ export async function importBoardData(data: BoardExport): Promise<void> {
   const db = await openDatabase();
   const allNames = db.objectStoreNames;
   const hasActivity = allNames.contains('activity');
-  const storeNames = hasActivity
-    ? ['columns', 'tasks', 'labels', 'activity']
-    : ['columns', 'tasks', 'labels'];
+  const hasBoards   = allNames.contains('boards');
+  const storeNames = [
+    'columns', 'tasks', 'labels',
+    ...(hasActivity ? ['activity'] : []),
+    ...(hasBoards   ? ['boards']   : []),
+  ];
   const tx = db.transaction(storeNames, 'readwrite');
 
   const colStore   = tx.objectStore('columns');
@@ -208,6 +221,27 @@ export async function importBoardData(data: BoardExport): Promise<void> {
     activityStore.clear();
     if (data.activity) {
       for (const evt of data.activity) activityStore.add(evt);
+    }
+  }
+
+  // 4. Importar tableros si existen en el archivo y el store está disponible (US-22)
+  if (hasBoards) {
+    const boardStore = tx.objectStore('boards');
+    boardStore.clear();
+    if (data.boards && data.boards.length > 0) {
+      for (const board of data.boards) boardStore.add(board);
+    } else {
+      // Si no hay boards en los datos importados (export antiguo),
+      // crear un tablero por defecto para las columnas/tareas importadas.
+      const defaultId = crypto.randomUUID();
+      boardStore.add({ id: defaultId, name: 'Mi tablero', emoji: '🥋', createdAt: new Date().toISOString() });
+      // Asignar boardId a columnas y tareas que no lo tienen
+      for (const col of data.columns) {
+        if (!col.boardId) colStore.put({ ...col, boardId: defaultId });
+      }
+      for (const task of data.tasks) {
+        if (!task.boardId) taskStore.put({ ...task, boardId: defaultId });
+      }
     }
   }
 

--- a/src/db/task.repository.ts
+++ b/src/db/task.repository.ts
@@ -119,3 +119,18 @@ export async function reorderTasks(statusId: string, orderedIds: string[]): Prom
 
   await idbTransaction(tx);
 }
+
+/**
+ * Elimina todas las tareas de un tablero (US-22).
+ */
+export async function deleteTasksByBoard(boardId: string): Promise<void> {
+  const db    = await openDatabase();
+  const tx    = db.transaction('tasks', 'readwrite');
+  const store = tx.objectStore('tasks');
+  const index = store.index('by-board');
+  const tasks = await idbRequest<Task[]>(index.getAll(boardId));
+  for (const task of tasks) {
+    store.delete(task.id);
+  }
+  await idbTransaction(tx);
+}

--- a/src/db/task.repository.ts
+++ b/src/db/task.repository.ts
@@ -121,6 +121,16 @@ export async function reorderTasks(statusId: string, orderedIds: string[]): Prom
 }
 
 /**
+ * Devuelve los IDs de todas las tareas de un tablero (US-22).
+ */
+export async function getTaskIdsByBoard(boardId: string): Promise<string[]> {
+  const { store } = await getStore('tasks');
+  const index     = store.index('by-board');
+  const tasks     = await idbRequest<Task[]>(index.getAll(boardId));
+  return tasks.map(t => t.id);
+}
+
+/**
  * Elimina todas las tareas de un tablero (US-22).
  */
 export async function deleteTasksByBoard(boardId: string): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@
  */
 
 import { openDatabase } from './db/database.js';
-import { seedDefaultColumns } from './db/column.repository.js';
 import { seedDefaultLabels } from './db/label.repository.js';
 import { initTheme } from './utils/theme.js';
 
@@ -27,13 +26,10 @@ async function bootstrap(): Promise<void> {
     // 2. Abrir (o crear) la base de datos
     await openDatabase();
 
-    // 3. Seed de columnas por defecto (solo si el store está vacío)
-    await seedDefaultColumns();
-
-    // 4. Seed de etiquetas por defecto (solo si el store está vacío)
+    // 3. Seed de etiquetas por defecto (solo si el store está vacío)
     await seedDefaultLabels();
 
-    // 5. Registrar Web Components — US-01 Visualización del tablero Kanban
+    // 4. Registrar Web Components — US-01 Visualización del tablero Kanban
     await import('./components/organisms/dojo-app/dojo-app.js');
 
     // 6. Montar la app (el elemento <dojo-app> ya está en el HTML)

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -27,6 +27,8 @@ export interface Subtask {
 export interface Task {
   /** UUID v4 generado en el cliente. */
   id: string;
+  /** FK → Board.id — tablero al que pertenece (US-22). */
+  boardId: string;
   /** Título visible de la tarea. Máx. 120 caracteres. */
   title: string;
   /** Descripción en formato Markdown. Puede estar vacío. */
@@ -55,6 +57,8 @@ export interface Task {
 export interface Column {
   /** UUID v4. */
   id: string;
+  /** FK → Board.id — tablero al que pertenece (US-22). */
+  boardId: string;
   /** Nombre visible de la columna. Máx. 50 caracteres. */
   name: string;
   /** Emoji o nombre de ícono que representa el estado (ej. "✅"). */
@@ -66,7 +70,7 @@ export interface Column {
 }
 
 /** Columnas por defecto que se insertan al inicializar la base de datos. */
-export const DEFAULT_COLUMNS: Omit<Column, 'id'>[] = [
+export const DEFAULT_COLUMNS: Omit<Column, 'id' | 'boardId'>[] = [
   { name: 'Backlog',      icon: '📋', order: 0 },
   { name: 'Por hacer',    icon: '🔲', order: 1 },
   { name: 'En progreso',  icon: '🔄', order: 2 },
@@ -74,6 +78,23 @@ export const DEFAULT_COLUMNS: Omit<Column, 'id'>[] = [
   { name: 'Hecho',        icon: '✅', order: 4 },
   { name: 'Bloqueado',    icon: '🚫', order: 5 },
 ];
+
+// ── Board (US-22) ──────────────────────────────────────────────────────────
+
+/** Representa un tablero Kanban independiente. */
+export interface Board {
+  /** UUID v4. */
+  id: string;
+  /** Nombre visible del tablero. Máx. 60 caracteres. */
+  name: string;
+  /** Emoji decorativo opcional del tablero. */
+  emoji?: string;
+  /** Fecha de creación en formato ISO 8601. */
+  createdAt: string;
+}
+
+/** Nombre del tablero por defecto creado en la migración. */
+export const DEFAULT_BOARD_NAME = 'Mi tablero';
 
 // ── Label ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Resumen

Implementación completa de **US-22: Múltiples tableros**, que permite al usuario crear, gestionar y navegar entre múltiples tableros Kanban independientes.

## Cambios realizados

### Modelo de datos
- **`Board` interface** nueva: `{ id, name, emoji?, createdAt }`
- **`boardId: string`** añadido a interfaces `Task` y `Column`
- Constante `DEFAULT_BOARD_NAME` para el tablero inicial

### Base de datos (v2 → v3)
- Nuevo object store `boards` (keyPath = id)
- Índice `by-board` en stores `columns` y `tasks`
- Migración con cursor: asigna `boardId` del tablero por defecto a todos los registros existentes
- Tablero por defecto creado en la migración con `crypto.randomUUID()`

### Repositorios
- **`board.repository.ts`** (NUEVO): CRUD completo (`getAllBoards`, `getBoardById`, `createBoard`, `updateBoard`, `deleteBoard`)
- **`column.repository.ts`**: `getColumnsByBoard(boardId)`, `seedDefaultColumns(boardId)`, `deleteColumnsByBoard(boardId)`
- **`task.repository.ts`**: `deleteTasksByBoard(boardId)`

### Componentes UI
- **`dojo-board-selector`** (NUEVO): Grid de tableros con creación inline, renombrado, eliminación con confirmación. Previene eliminar el último tablero.
- **`dojo-kanban-board`**: Acepta atributo `board-id` y carga solo columnas/tareas del tablero activo
- **`dojo-app`**: Orquesta navegación entre selector ↔ tablero con botón "← Tableros". Auto-selecciona si hay un solo tablero.

### Export/Import
- Incluye `boards` en la exportación
- Import retrocompatible: crea tablero por defecto si los datos importados no incluyen boards

### Bootstrap
- Eliminado seed global de columnas en `main.ts` (ahora per-board en migración y creación)

## Criterios de aceptación cubiertos
- [x] Pantalla de selección de tableros con grid
- [x] Crear nuevo tablero (con columnas por defecto)
- [x] Renombrar tablero (nombre + emoji)
- [x] Eliminar tablero (con confirmación, no permite eliminar el último)
- [x] Columnas y tareas asociadas a `boardId`
- [x] Etiquetas globales compartidas entre tableros
- [x] Migración de datos existentes al tablero por defecto
- [x] Navegación tablero ↔ selector
- [x] Export/import incluye boards

Closes #40