### PR TITLE
feat(projects): add project grouping with task identifiers (US-26)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -2379,6 +2379,31 @@ Se modifica `_buildDescriptionField()` en `dojo-task-detail` para que el tab act
 - **Si `task.description.trim()` tiene contenido**: se invoca `switchToPreview()` inmediatamente tras construir el DOM. Esto activa el tab "Vista previa", oculta el textarea, renderiza el Markdown y ajusta los atributos `aria-selected` y `tabindex` (roving tabindex).
 - **Si la descripción está vacía o solo contiene whitespace**: no se ejecuta ningún cambio; el tab "Editar" permanece activo con el textarea visible y su placeholder.
 
+#### Archivo modificado
+
+| Archivo | Cambio |
+|---|---|
+| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Comprobación de contenido + `switchToPreview()` al final de `_buildDescriptionField()` |
+
+#### Receta
+
+1. Al final de `_buildDescriptionField()`, después de `section.appendChild(previewPanel)`, se añade:
+   ```ts
+   if (task.description.trim()) {
+     switchToPreview();
+     editTab.setAttribute('tabindex', '-1');
+     previewTab.setAttribute('tabindex', '0');
+   }
+   ```
+2. `switchToPreview()` ya existía: activa el tab "Vista previa", oculta textarea, muestra panel con Markdown renderizado via `parseMarkdown()`.
+3. El ajuste manual de `tabindex` es necesario porque `switchToPreview()` no modifica el roving tabindex (solo los handlers de click/keyboard lo hacían).
+
+### Accesibilidad (WCAG 2.1)
+
+- Roving tabindex correctamente inicializado: el tab activo tiene `tabindex="0"`, el inactivo `tabindex="-1"`
+- `aria-selected` refleja el tab activo al abrir
+- Navegación por teclado (ArrowLeft/Right, Home/End) funciona sin cambios
+
 ---
 
 ## Paso 27 — Agrupación de tareas por proyectos (US-26 / Issue #44)
@@ -2462,28 +2487,3 @@ Se introduce el concepto de **Proyecto** como entidad de primer nivel que agrupa
 - `aria-modal`, `aria-labelledby`, `inert` en panel de gestión de proyectos
 - Focus trap: Escape cierra el panel
 - Botón eliminar deshabilitado visualmente para proyecto General (`disabled`, `title` explicativo)
-
-#### Archivo modificado
-
-| Archivo | Cambio |
-|---|---|
-| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | Comprobación de contenido + `switchToPreview()` al final de `_buildDescriptionField()` |
-
-#### Receta
-
-1. Al final de `_buildDescriptionField()`, después de `section.appendChild(previewPanel)`, se añade:
-   ```ts
-   if (task.description.trim()) {
-     switchToPreview();
-     editTab.setAttribute('tabindex', '-1');
-     previewTab.setAttribute('tabindex', '0');
-   }
-   ```
-2. `switchToPreview()` ya existía: activa el tab "Vista previa", oculta textarea, muestra panel con Markdown renderizado via `parseMarkdown()`.
-3. El ajuste manual de `tabindex` es necesario porque `switchToPreview()` no modifica el roving tabindex (solo los handlers de click/keyboard lo hacían).
-
-### Accesibilidad (WCAG 2.1)
-
-- Roving tabindex correctamente inicializado: el tab activo tiene `tabindex="0"`, el inactivo `tabindex="-1"`
-- `aria-selected` refleja el tab activo al abrir
-- Navegación por teclado (ArrowLeft/Right, Home/End) funciona sin cambios

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -38,6 +38,7 @@
    - [Paso 24 — Múltiples tableros (US-22 / Issue #40)](#paso-24--múltiples-tableros-us-22)
    - [Paso 25 — Etiquetas durante la creación de tareas (US-23 / Issue #41)](#paso-25--etiquetas-durante-la-creación-de-tareas-us-23--issue-41)
    - [Paso 26 — Vista previa Markdown por defecto (US-25 / Issue #43)](#paso-26--vista-previa-markdown-por-defecto-us-25--issue-43)
+   - [Paso 27 — Agrupación de tareas por proyectos (US-26 / Issue #44)](#paso-27--agrupación-de-tareas-por-proyectos-us-26--issue-44)
 
 ---
 
@@ -2377,6 +2378,90 @@ Se modifica `_buildDescriptionField()` en `dojo-task-detail` para que el tab act
 
 - **Si `task.description.trim()` tiene contenido**: se invoca `switchToPreview()` inmediatamente tras construir el DOM. Esto activa el tab "Vista previa", oculta el textarea, renderiza el Markdown y ajusta los atributos `aria-selected` y `tabindex` (roving tabindex).
 - **Si la descripción está vacía o solo contiene whitespace**: no se ejecuta ningún cambio; el tab "Editar" permanece activo con el textarea visible y su placeholder.
+
+---
+
+## Paso 27 — Agrupación de tareas por proyectos (US-26 / Issue #44)
+
+> **Issue:** #44 · **PR:** #59 · **Rama:** `feat/44-agrupacion-tareas-proyectos`
+
+### Problema
+
+Todas las tareas existían en un espacio plano sin ninguna forma de agruparlas por contexto, área de trabajo o dominio. El usuario no tenía manera de distinguir a simple vista a qué proyecto o iniciativa pertenecía cada tarea, ni filtrar el tablero para enfocarse en un subconjunto.
+
+### Solución
+
+Se introduce el concepto de **Proyecto** como entidad de primer nivel que agrupa tareas bajo un **prefijo único** e **identificadores secuenciales legibles** (ej. `WEB-005`, `API-012`).
+
+### Decisión de arquitectura (ADR)
+
+| Aspecto | Decisión | Justificación |
+|---|---|---|
+| Identificador de tarea | `PREFIX-NNN` (3 dígitos con pad) | Balance entre legibilidad y escalabilidad; familiar para usuarios de JIRA/Linear |
+| Prefijo inmutable | Una vez creado no se puede cambiar | Los task numbers ya emitidos perderían coherencia si el prefijo muta |
+| Proyecto General | Siempre presente, no eliminable | Garantiza que toda tarea tiene un proyecto asociado; simplifica migraciones |
+| Generación atómica | Read-increment-write en transacción IDB `readwrite` | Evita números duplicados en operaciones concurrentes |
+| Reasignación al eliminar | Tareas pasan a General (preservan task number original) | No se pierden identificadores históricos |
+
+### Archivos creados
+
+| Archivo | Propósito |
+|---|---|
+| `src/db/project.repository.ts` | CRUD de proyectos: `getAllProjects`, `getProjectById`, `getProjectByPrefix`, `createProject`, `updateProject`, `deleteProject`, `getNextTaskNumber`, `seedDefaultProject` |
+| `src/components/organisms/dojo-project-manager/dojo-project-manager.ts` | Panel lateral para gestionar proyectos (crear, editar, eliminar) |
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `src/types/models.ts` | Interfaz `Project`, constantes `DEFAULT_PROJECT_NAME`/`DEFAULT_PROJECT_PREFIX`, campos `projectId` y `taskNumber` en `Task` |
+| `src/db/database.ts` | Migración v3→v4: store `projects`, índice `by-prefix`, índice `by-project` en tasks, seed de General, migración de tareas existentes |
+| `src/db/export-import.ts` | Export/import incluyen el store `projects` |
+| `src/main.ts` | Llama `seedDefaultProject()` al iniciar |
+| `src/components/atoms/dojo-task-card/dojo-task-card.ts` | Atributo `task-number`, getter, CSS y DOM para mostrar el identificador |
+| `src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts` | Carga de proyectos, filtro por proyecto, selector de proyecto en toolbar, asignación de proyecto y task number al crear tareas |
+| `src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts` | Selector de proyecto en formulario de creación, carga de proyectos en paralelo con etiquetas |
+| `src/components/organisms/dojo-app/dojo-app.ts` | Botón "Proyectos" en header, monta `<dojo-project-manager>`, refresca tablero ante cambios |
+
+### Receta: Migración de IndexedDB (v3 → v4)
+
+1. **Constante `DB_VERSION`** se incrementa de 3 a 4 en `database.ts`.
+2. En el handler `onupgradeneeded`, se añade un bloque condicional `if (oldVersion < 4)` que:
+   - Crea el object store `projects` con `keyPath: 'id'` e índice único `by-prefix`.
+   - Crea índice `by-project` en el store `tasks` sobre el campo `projectId`.
+   - Inserta un proyecto "General" (prefijo `GEN`) con `nextTaskNumber: 1`.
+   - Recorre todas las tareas existentes con un cursor, asignando `projectId` al General y `taskNumber` secuencial (`GEN-001`, `GEN-002`, …).
+   - Actualiza `nextTaskNumber` del proyecto General tras migrar.
+
+### Receta: Generación atómica de task numbers
+
+1. `getNextTaskNumber(projectId)` abre una transacción `readwrite` sobre el store `projects`.
+2. Lee el proyecto, extrae `nextTaskNumber`, formatea como `PREFIX-NNN`.
+3. Incrementa `nextTaskNumber` y hace `put` en la misma transacción.
+4. Retorna el string formateado.
+5. El `_handleCreateTask()` del kanban-board llama esta función antes de `createTask()`, garantizando unicidad.
+
+### Receta: Panel de gestión de proyectos
+
+1. **Patrón**: Replica la estructura de `dojo-label-manager` (panel lateral + backdrop + ARIA).
+2. **Crear**: Formulario inline con campos nombre, prefijo (auto-uppercase, regex `[A-Z]{1,5}`) y descripción opcional.
+3. **Editar**: Formulario inline con prefijo deshabilitado (inmutable). Solo nombre y descripción editables.
+4. **Eliminar**: Confirmación inline con advertencia de reasignación a General. Proyecto General tiene botón deshabilitado.
+5. **Eventos**: `dojo:project-created`, `dojo:project-updated`, `dojo:project-deleted` burbujean a `dojo-app` que refresca el tablero.
+
+### Receta: Filtro por proyecto en el tablero
+
+1. El `dojo-kanban-board` carga todos los proyectos en `_loadBoard()` y construye un `<select>` en la barra de filtros.
+2. Al cambiar la selección, se actualiza `_activeFilter.projectId` y se invoca `_filterTasks()`.
+3. `_filterTasks()` compara `task.projectId` contra el filtro activo (si existe).
+4. "Limpiar filtros" resetea el select a valor vacío.
+
+### Accesibilidad (WCAG 2.1)
+
+- `aria-label` en selector de proyecto (diálogo y filtro)
+- `aria-modal`, `aria-labelledby`, `inert` en panel de gestión de proyectos
+- Focus trap: Escape cierra el panel
+- Botón eliminar deshabilitado visualmente para proyecto General (`disabled`, `title` explicativo)
 
 #### Archivo modificado
 

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -488,13 +488,15 @@ export class DojoTaskCard extends HTMLElement {
       this._shadow.appendChild(progressRow);
     }
 
-    // ── Título ────────────────────────────────────────────────────────────    // Identificador de proyecto (US-26)
+    // ── Identificador de proyecto (US-26) ──────────────────────────────────
     if (this.taskNumber) {
       const numEl = document.createElement('span');
       numEl.className = 'task-number';
       numEl.textContent = this.taskNumber;
       this._shadow.appendChild(numEl);
     }
+
+    // ── Título ────────────────────────────────────────────────────────────
     const titleEl = document.createElement('p');
     titleEl.className = 'title';
     titleEl.textContent = this.taskTitle;

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -36,7 +36,7 @@ export class DojoTaskCard extends HTMLElement {
   static readonly TAG = 'dojo-task-card';
 
   static get observedAttributes(): string[] {
-    return ['task-id', 'task-title', 'task-priority', 'task-created-at', 'task-due-date'];
+    return ['task-id', 'task-title', 'task-priority', 'task-created-at', 'task-due-date', 'task-number'];
   }
 
   private _shadow: ShadowRoot;
@@ -101,6 +101,7 @@ export class DojoTaskCard extends HTMLElement {
   get priority(): string  { return this.getAttribute('task-priority') ?? 'medium'; }
   get createdAt(): string { return this.getAttribute('task-created-at') ?? ''; }
   get dueDate(): string   { return this.getAttribute('task-due-date') ?? ''; }
+  get taskNumber(): string { return this.getAttribute('task-number') ?? ''; }
 
   // ── Drag handlers ─────────────────────────────────────────────────────────
 
@@ -277,6 +278,16 @@ export class DojoTaskCard extends HTMLElement {
         line-height: 1.4;
         word-break: break-word;
         margin: 0 0 0.5rem 0;
+      }
+
+      /* Identificador de proyecto (US-26) */
+      .task-number {
+        font-size: 0.625rem;
+        font-weight: 600;
+        color: var(--dojo-primary, #1D4ED8);
+        letter-spacing: 0.04em;
+        margin-bottom: 0.125rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       }
 
       /* Footer: prioridad (izq) + fecha (der) */
@@ -477,7 +488,13 @@ export class DojoTaskCard extends HTMLElement {
       this._shadow.appendChild(progressRow);
     }
 
-    // ── Título ────────────────────────────────────────────────────────────
+    // ── Título ────────────────────────────────────────────────────────────    // Identificador de proyecto (US-26)
+    if (this.taskNumber) {
+      const numEl = document.createElement('span');
+      numEl.className = 'task-number';
+      numEl.textContent = this.taskNumber;
+      this._shadow.appendChild(numEl);
+    }
     const titleEl = document.createElement('p');
     titleEl.className = 'title';
     titleEl.textContent = this.taskTitle;

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -14,6 +14,7 @@
 
 import '../dojo-kanban-board/dojo-kanban-board.js';
 import '../dojo-label-manager/dojo-label-manager.js';
+import '../dojo-project-manager/dojo-project-manager.js';
 import '../dojo-board-selector/dojo-board-selector.js';
 import '../../atoms/dojo-theme-toggle/dojo-theme-toggle.js';
 
@@ -354,6 +355,22 @@ export class DojoApp extends HTMLElement {
       (labelMgr as any).show();
     });
 
+    // ── Botón Gestionar proyectos (US-26) ───────────────────────────────────
+    const manageProjectBtn = document.createElement('button');
+    manageProjectBtn.className = 'header-btn';
+    manageProjectBtn.type = 'button';
+    manageProjectBtn.setAttribute('aria-label', 'Gestionar proyectos');
+    const projBtnIcon = document.createElement('span');
+    projBtnIcon.setAttribute('aria-hidden', 'true');
+    projBtnIcon.textContent = '📁';
+    const projBtnText = document.createElement('span');
+    projBtnText.textContent = 'Proyectos';
+    manageProjectBtn.appendChild(projBtnIcon);
+    manageProjectBtn.appendChild(projBtnText);
+    manageProjectBtn.addEventListener('click', () => {
+      (projectMgr as any).show();
+    });
+
     // ── Botón Exportar (US-19) ──────────────────────────────────────────────
     const exportBtn = document.createElement('button');
     exportBtn.className = 'header-btn';
@@ -397,6 +414,7 @@ export class DojoApp extends HTMLElement {
     const headerActions = document.createElement('div');
     headerActions.className = 'header-actions';
     headerActions.appendChild(manageLabelBtn);
+    headerActions.appendChild(manageProjectBtn);
     headerActions.appendChild(exportBtn);
     headerActions.appendChild(importBtn);
     headerActions.appendChild(importInput);
@@ -447,6 +465,21 @@ export class DojoApp extends HTMLElement {
     // ── Panel de gestión de etiquetas (US-11) ───────────────────────────────────────
     const labelMgr = document.createElement('dojo-label-manager');
     this._shadow.appendChild(labelMgr);
+
+    // ── Panel de gestión de proyectos (US-26) ────────────────────────────────────────
+    const projectMgr = document.createElement('dojo-project-manager');
+    this._shadow.appendChild(projectMgr);
+
+    // Cuando se crea/actualiza/elimina un proyecto, refrescar el tablero
+    this._shadow.addEventListener('dojo:project-created', () => {
+      (board as any)._loadBoard?.();
+    });
+    this._shadow.addEventListener('dojo:project-updated', () => {
+      (board as any)._loadBoard?.();
+    });
+    this._shadow.addEventListener('dojo:project-deleted', () => {
+      (board as any)._loadBoard?.();
+    });
 
     // Cuando se actualiza una etiqueta, propagar al tablero para refrescar los chips
     this._shadow.addEventListener('dojo:label-updated', (e: Event) => {

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -1269,10 +1269,11 @@ export class DojoKanbanBoard extends HTMLElement {
       } else {
         // Asignar al proyecto General si no se especificó proyecto
         const general = await getProjectByPrefix('GEN');
-        if (general) {
-          resolvedProjectId = general.id;
-          taskNumber = await getNextTaskNumber(general.id);
+        if (!general) {
+          throw new Error('No se encontró el proyecto "General" (GEN). Ejecute seedDefaultProject().');
         }
+        resolvedProjectId = general.id;
+        taskNumber = await getNextTaskNumber(general.id);
       }
 
       const newTask = await createTask({

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -28,10 +28,11 @@
  * --dojo-shadow, --dojo-radius, --dojo-primary
  */
 
-import type { Column, Task, Label, Priority } from '../../../types/models.js';
+import type { Column, Task, Label, Priority, Project } from '../../../types/models.js';
 import { getColumnsByBoard, createColumn, updateColumn, deleteColumn } from '../../../db/column.repository.js';
 import { getTasksByStatus, createTask, updateTask, deleteTask, reorderTasks } from '../../../db/task.repository.js';
 import { getAllLabels } from '../../../db/label.repository.js';
+import { getAllProjects, getNextTaskNumber, getProjectByPrefix } from '../../../db/project.repository.js';
 import { addActivityEvent, deleteActivitiesByTaskId } from '../../../db/activity.repository.js';
 import '../../molecules/dojo-kanban-column/dojo-kanban-column.js';
 import '../../atoms/dojo-task-card/dojo-task-card.js';
@@ -50,6 +51,7 @@ interface ActiveFilter {
   labelIds?: string[];
   searchText?: string;
   sortBy?: SortMode;
+  projectId?: string;
 }
 
 /** Contrato de la propiedad taskLabels expuesta por dojo-task-card (US-10). */
@@ -73,6 +75,8 @@ export class DojoKanbanBoard extends HTMLElement {
   private _columns: Column[] = [];
   /** Lista completa de etiquetas (US-10) */
   private _labels: Label[] = [];
+  /** Lista completa de proyectos (US-26) */
+  private _projects: Project[] = [];
   // Referencias UI del toolbar de filtros (US-15)
   private _filterBarContent: HTMLElement | null = null;
   private _filterClearAllBtn: HTMLButtonElement | null = null;
@@ -83,6 +87,8 @@ export class DojoKanbanBoard extends HTMLElement {
   private _selectedLabelIds: Set<string> = new Set();
   private _selectedPriorities: Set<Priority> = new Set();
   private _filterDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // US-26: referencia UI del filtro de proyecto
+  private _filterProjectSelect: HTMLSelectElement | null = null;
 
   constructor() {
     super();
@@ -560,6 +566,31 @@ export class DojoKanbanBoard extends HTMLElement {
 
     content.appendChild(labelSection);
 
+    // ── Selector de proyecto (US-26) ──────────────────────────────────────
+    const projectSep = document.createElement('div');
+    projectSep.className = 'filter-sep';
+    projectSep.setAttribute('aria-hidden', 'true');
+    content.appendChild(projectSep);
+
+    const projectLabel = document.createElement('span');
+    projectLabel.className = 'filter-label';
+    projectLabel.textContent = 'Proyecto:';
+    content.appendChild(projectLabel);
+
+    const projectSelect = document.createElement('select');
+    projectSelect.className = 'filter-search';
+    projectSelect.setAttribute('aria-label', 'Filtrar por proyecto');
+    const allOpt = document.createElement('option');
+    allOpt.value = '';
+    allOpt.textContent = 'Todos';
+    projectSelect.appendChild(allOpt);
+    this._filterProjectSelect = projectSelect;
+    projectSelect.addEventListener('change', () => {
+      this.activeFilter = { ...this._activeFilter, projectId: projectSelect.value || undefined };
+      this._updateClearAllVisibility();
+    });
+    content.appendChild(projectSelect);
+
     // ── Botón "Limpiar filtros" ───────────────────────────────────────────
     const clearAllBtn = document.createElement('button');
     clearAllBtn.className = 'filter-clear';
@@ -657,13 +688,40 @@ export class DojoKanbanBoard extends HTMLElement {
     this._updateClearAllVisibility();
   }
 
+  /** Reconstruye las opciones del selector de proyectos (US-26). */
+  private _rebuildProjectFilterSelect(): void {
+    if (!this._filterProjectSelect) return;
+    // Preservar selección actual
+    const currentValue = this._filterProjectSelect.value;
+    // Limpiar opciones (excepto "Todos")
+    while (this._filterProjectSelect.options.length > 1) {
+      this._filterProjectSelect.remove(1);
+    }
+    for (const proj of this._projects) {
+      const opt = document.createElement('option');
+      opt.value = proj.id;
+      opt.textContent = `${proj.prefix} — ${proj.name}`;
+      this._filterProjectSelect.appendChild(opt);
+    }
+    // Restaurar selección si sigue existiendo
+    if (this._projects.some(p => p.id === currentValue)) {
+      this._filterProjectSelect.value = currentValue;
+    } else {
+      this._filterProjectSelect.value = '';
+      if (this._activeFilter.projectId) {
+        this._activeFilter = { ...this._activeFilter, projectId: undefined };
+      }
+    }
+  }
+
   /** Muestra/oculta el botón "Limpiar filtros" y actualiza el estado visual del toggle. */
   private _updateClearAllVisibility(): void {
     if (!this._filterClearAllBtn || !this._filterToggleBtn) return;
     const hasActive =
       (this._activeFilter.priorities?.length ?? 0) > 0 ||
       (this._activeFilter.labelIds?.length ?? 0) > 0 ||
-      !!(this._activeFilter.searchText);
+      !!(this._activeFilter.searchText) ||
+      !!(this._activeFilter.projectId);
     this._filterClearAllBtn.style.display = hasActive ? '' : 'none';
     this._filterToggleBtn.classList.toggle('has-active', hasActive);
   }
@@ -678,6 +736,7 @@ export class DojoKanbanBoard extends HTMLElement {
       this._filterDebounceTimer = null;
     }
     if (this._filterSearchInput) this._filterSearchInput.value = '';
+    if (this._filterProjectSelect) this._filterProjectSelect.value = '';
     if (this._filterBarContent) {
       this._filterBarContent.querySelectorAll<HTMLButtonElement>('[data-priority]').forEach(b => {
         b.classList.remove('active');
@@ -764,12 +823,15 @@ export class DojoKanbanBoard extends HTMLElement {
     this._tasksByColumn.clear();
 
     try {
-      const [columns, labels] = await Promise.all([
+      const [columns, labels, projects] = await Promise.all([
         getColumnsByBoard(this._boardId),
         getAllLabels(),
+        getAllProjects(),
       ]);
       this._labels = labels;
+      this._projects = projects;
       this._rebuildLabelFilterChips(); // Poblar chips de etiquetas en el toolbar (US-15)
+      this._rebuildProjectFilterSelect(); // Poblar selector de proyectos (US-26)
 
       // Cargar tareas de todas las columnas en paralelo
       const taskResults = await Promise.all(
@@ -849,6 +911,7 @@ export class DojoKanbanBoard extends HTMLElement {
       card.setAttribute('task-title',      task.title);
       card.setAttribute('task-priority',   task.priority);
       card.setAttribute('task-created-at', task.createdAt);
+      if (task.taskNumber) card.setAttribute('task-number', task.taskNumber);
       if (task.dueDate) card.setAttribute('task-due-date', task.dueDate);
       (card as TaskCardElement).taskLabels = this._getTaskLabels(task);
       const subs = task.subtasks ?? [];
@@ -903,7 +966,7 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private _filterTasks(tasks: Task[]): Task[] {
-    const { priorities, labelIds, searchText } = this._activeFilter;
+    const { priorities, labelIds, searchText, projectId } = this._activeFilter;
     const lowerSearch = searchText ? searchText.toLowerCase() : null;
     return tasks.filter(task => {
       if (priorities && priorities.length > 0 && !priorities.includes(task.priority)) return false;
@@ -912,6 +975,7 @@ export class DojoKanbanBoard extends HTMLElement {
         const hasLabel = labelIds.some(id => taskLabelIds.includes(id));
         if (!hasLabel) return false;
       }
+      if (projectId && task.projectId !== projectId) return false;
       if (lowerSearch) {
         const titleMatch = task.title.toLowerCase().includes(lowerSearch);
         const descMatch  = (task.description ?? '').toLowerCase().includes(lowerSearch);
@@ -1181,13 +1245,14 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private async _handleCreateTask(e: CustomEvent): Promise<void> {
-    const { statusId, title, description, priority, dueDate, labelIds } = e.detail as {
+    const { statusId, title, description, priority, dueDate, labelIds, projectId } = e.detail as {
       statusId:    string;
       title:       string;
       description: string;
       priority:    string;
       dueDate?:    string | null;
       labelIds?:   string[];
+      projectId?:  string;
     };
     // Validar que la columna exista (puede haberse eliminado mientras el diálogo estaba abierto)
     if (!this._columns.some(c => c.id === statusId)) {
@@ -1196,15 +1261,31 @@ export class DojoKanbanBoard extends HTMLElement {
     }
     const tasks = this._tasksByColumn.get(statusId) ?? [];
     try {
+      // US-26: resolver proyecto y obtener taskNumber
+      let resolvedProjectId = projectId || '';
+      let taskNumber = '';
+      if (resolvedProjectId) {
+        taskNumber = await getNextTaskNumber(resolvedProjectId);
+      } else {
+        // Asignar al proyecto General si no se especificó proyecto
+        const general = await getProjectByPrefix('GEN');
+        if (general) {
+          resolvedProjectId = general.id;
+          taskNumber = await getNextTaskNumber(general.id);
+        }
+      }
+
       const newTask = await createTask({
         title,
         description,
         statusId,
-        boardId:   this._boardId,
-        priority:  priority as Task['priority'],
-        labelIds:  labelIds ?? [],
-        order:     tasks.length,
-        dueDate:   dueDate ?? null,
+        boardId:     this._boardId,
+        projectId:   resolvedProjectId,
+        taskNumber,
+        priority:    priority as Task['priority'],
+        labelIds:    labelIds ?? [],
+        order:       tasks.length,
+        dueDate:     dueDate ?? null,
       });
 
       // US-20: registrar evento de creación

--- a/src/components/organisms/dojo-project-manager/dojo-project-manager.ts
+++ b/src/components/organisms/dojo-project-manager/dojo-project-manager.ts
@@ -1,0 +1,894 @@
+/**
+ * dojo-project-manager — Organismo
+ *
+ * Panel lateral para gestionar los proyectos existentes (US-26).
+ * Permite crear, editar nombre/descripción y eliminar proyectos.
+ * Los cambios se persisten en IndexedDB y se propagan al tablero
+ * mediante eventos personalizados.
+ *
+ * ## API pública
+ * | Método  | Descripción                                          |
+ * |---------|----------------------------------------------------- |
+ * | show()  | Abre el panel y carga los proyectos desde IndexedDB  |
+ * | hide()  | Cierra el panel                                      |
+ *
+ * ## Eventos despachados
+ * | Nombre                | Detalle         | Descripción                         |
+ * |-----------------------|-----------------|-------------------------------------|
+ * | dojo:project-created  | { project }     | Proyecto creado en IndexedDB        |
+ * | dojo:project-updated  | { project }     | Proyecto actualizado en IndexedDB   |
+ * | dojo:project-deleted  | { projectId }   | Proyecto eliminado de IndexedDB     |
+ *
+ * ## Atributos observados
+ * | Atributo | Valores          | Descripción       |
+ * |----------|------------------|--------------------|
+ * | open     | presente/ausente | Panel visible      |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*,
+ * --dojo-primary, --dojo-shadow, --dojo-radius
+ */
+
+import type { Project } from '../../../types/models.js';
+import { DEFAULT_PROJECT_PREFIX } from '../../../types/models.js';
+import {
+  getAllProjects,
+  createProject,
+  updateProject,
+  deleteProject,
+  isValidPrefix,
+} from '../../../db/project.repository.js';
+
+export class DojoProjectManager extends HTMLElement {
+  static readonly TAG = 'dojo-project-manager';
+
+  static get observedAttributes(): string[] { return ['open']; }
+
+  private _shadow: ShadowRoot;
+  private _projects: Project[] = [];
+  private _editingId: string | null = null;
+  private _deletingId: string | null = null;
+  private _creating = false;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._render();
+  }
+
+  attributeChangedCallback(name: string, _oldVal: string | null, newVal: string | null): void {
+    if (name === 'open') {
+      const panel = this._shadow.querySelector<HTMLElement>('.panel');
+      const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+      const isOpen = newVal !== null;
+      if (panel) {
+        panel.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        if (isOpen) {
+          panel.removeAttribute('inert');
+        } else {
+          panel.setAttribute('inert', '');
+        }
+      }
+      if (backdrop) backdrop.classList.toggle('visible', isOpen);
+    }
+  }
+
+  // ── API pública ──────────────────────────────────────────────────────────
+
+  async show(): Promise<void> {
+    this._projects = await getAllProjects();
+    this._editingId  = null;
+    this._deletingId = null;
+    this._creating   = false;
+    this.setAttribute('open', '');
+    this._buildContent();
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLButtonElement>('.panel-close')?.focus();
+    });
+  }
+
+  hide(): void {
+    this.removeAttribute('open');
+    this._editingId  = null;
+    this._deletingId = null;
+    this._creating   = false;
+  }
+
+  // ── Render base ──────────────────────────────────────────────────────────
+
+  private _render(): void {
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      .backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,.45);
+        z-index: 40;
+      }
+      .backdrop.visible { display: block; }
+
+      .panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(400px, 100vw);
+        background: var(--dojo-surface);
+        border-left: 1px solid var(--dojo-border);
+        box-shadow: -4px 0 16px rgba(0,0,0,.12);
+        z-index: 50;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transform: translateX(100%);
+        transition: transform 0.25s ease;
+      }
+      :host([open]) .panel {
+        transform: translateX(0);
+      }
+
+      .panel-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.875rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+        flex-shrink: 0;
+      }
+      .panel-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0;
+        flex: 1;
+      }
+      .panel-close {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-size: 1.125rem;
+        color: var(--dojo-text-secondary);
+        padding: 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        line-height: 1;
+        transition: color 0.15s, background 0.15s;
+      }
+      .panel-close:hover { color: var(--dojo-text-primary); background: var(--dojo-bg); }
+      .panel-close:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      .panel-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0.5rem 0;
+      }
+
+      .empty-state {
+        padding: 1.25rem;
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        text-align: center;
+        margin: 0;
+      }
+
+      /* Botón crear proyecto */
+      .create-btn-wrap {
+        padding: 0.75rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+      }
+      .create-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 6px);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 0.8125rem;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s, border-color 0.15s;
+      }
+      .create-btn:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .create-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Lista de proyectos */
+      .project-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .project-row {
+        display: flex;
+        align-items: center;
+        gap: 0.625rem;
+        padding: 0.625rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+      }
+      .project-row:last-child { border-bottom: none; }
+
+      .project-prefix {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 48px;
+        padding: 0.125rem 0.5rem;
+        background: var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        border-radius: var(--dojo-radius-sm, 4px);
+        flex-shrink: 0;
+        letter-spacing: 0.03em;
+        font-family: monospace;
+      }
+
+      .project-info {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+        overflow: hidden;
+      }
+      .project-name {
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .project-desc {
+        font-size: 0.75rem;
+        color: var(--dojo-text-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .action-btn {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        padding: 0.25rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        flex-shrink: 0;
+        line-height: 1;
+        transition: background 0.15s, color 0.15s;
+      }
+      .action-btn:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .action-btn.danger:hover { background: #FEE2E2; color: #B91C1C; }
+      .action-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* Formulario inline (editar / crear) */
+      .inline-form {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.5rem 0;
+      }
+      .form-label {
+        font-size: 0.6875rem;
+        font-weight: 700;
+        color: var(--dojo-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .form-input {
+        font-size: 0.8125rem;
+        padding: 0.375rem 0.5rem;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        font-family: inherit;
+        outline: none;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .form-input:focus {
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .form-input:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .form-hint {
+        font-size: 0.6875rem;
+        color: var(--dojo-text-secondary);
+        margin: 0;
+      }
+      .form-error {
+        font-size: 0.75rem;
+        color: #EF4444;
+        margin: 0;
+      }
+
+      .form-actions {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: flex-end;
+        padding-top: 0.25rem;
+      }
+      .btn-secondary {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        border: 1px solid var(--dojo-border);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        transition: background 0.15s;
+      }
+      .btn-secondary:hover { background: var(--dojo-bg); color: var(--dojo-text-primary); }
+      .btn-primary {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        background: var(--dojo-primary, #1D4ED8);
+        border: 1px solid var(--dojo-primary, #1D4ED8);
+        color: #fff;
+        font-weight: 600;
+        transition: opacity 0.15s;
+      }
+      .btn-primary:hover { opacity: 0.88; }
+      .btn-primary:disabled { opacity: 0.55; cursor: not-allowed; }
+      .btn-secondary:focus-visible,
+      .btn-primary:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+      .btn-danger {
+        padding: 0.25rem 0.625rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.75rem;
+        cursor: pointer;
+        font-family: inherit;
+        background: #EF4444;
+        border: 1px solid #EF4444;
+        color: #fff;
+        font-weight: 600;
+        transition: opacity 0.15s;
+      }
+      .btn-danger:hover { opacity: 0.88; }
+      .btn-danger:disabled { opacity: 0.55; cursor: not-allowed; }
+      .btn-danger:focus-visible {
+        outline: 2px solid #EF4444;
+        outline-offset: 2px;
+      }
+
+      /* Confirmación de eliminación inline */
+      .delete-confirm {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.5rem 0;
+      }
+      .delete-confirm-msg {
+        font-size: 0.8125rem;
+        color: var(--dojo-text-primary);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .delete-confirm-warning {
+        font-size: 0.75rem;
+        color: #B45309;
+        margin: 0;
+        background: #FEF3C7;
+        border: 1px solid #F59E0B;
+        border-radius: var(--dojo-radius-sm, 4px);
+        padding: 0.3rem 0.5rem;
+      }
+      .delete-confirm-actions {
+        display: flex;
+        gap: 0.375rem;
+        justify-content: flex-end;
+        padding-top: 0.25rem;
+      }
+
+      /* Formulario crear (arriba de la lista) */
+      .create-form-wrap {
+        padding: 0.75rem 1.25rem;
+        border-bottom: 1px solid var(--dojo-border);
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Backdrop
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.addEventListener('click', () => this.hide());
+    this._shadow.appendChild(backdrop);
+
+    // Panel
+    const panel = document.createElement('aside');
+    panel.className = 'panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'true');
+    panel.setAttribute('aria-labelledby', 'pm-title');
+    panel.setAttribute('aria-hidden', 'true');
+    panel.setAttribute('inert', '');
+
+    // Header
+    const panelHeader = document.createElement('div');
+    panelHeader.className = 'panel-header';
+
+    const panelTitle = document.createElement('h2');
+    panelTitle.id = 'pm-title';
+    panelTitle.className = 'panel-title';
+    panelTitle.textContent = 'Gestionar proyectos';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'panel-close';
+    closeBtn.type = 'button';
+    closeBtn.textContent = '✕';
+    closeBtn.setAttribute('aria-label', 'Cerrar panel de proyectos');
+    closeBtn.addEventListener('click', () => this.hide());
+
+    panelHeader.appendChild(panelTitle);
+    panelHeader.appendChild(closeBtn);
+    panel.appendChild(panelHeader);
+
+    // Contenido desplazable
+    const content = document.createElement('div');
+    content.className = 'panel-content';
+    panel.appendChild(content);
+
+    this._shadow.appendChild(panel);
+
+    // Escape cierra el panel
+    this._shadow.addEventListener('keydown', ((e: Event) => {
+      if ((e as KeyboardEvent).key === 'Escape' && this.hasAttribute('open')) this.hide();
+    }) as EventListener);
+  }
+
+  // ── Construcción dinámica ────────────────────────────────────────────────
+
+  private _buildContent(): void {
+    const content = this._shadow.querySelector('.panel-content');
+    if (!content) return;
+    content.innerHTML = '';
+
+    // Botón o formulario de creación
+    if (this._creating) {
+      content.appendChild(this._buildCreateForm());
+    } else {
+      const createWrap = document.createElement('div');
+      createWrap.className = 'create-btn-wrap';
+      const createBtn = document.createElement('button');
+      createBtn.className = 'create-btn';
+      createBtn.type = 'button';
+      const plusIcon = document.createElement('span');
+      plusIcon.setAttribute('aria-hidden', 'true');
+      plusIcon.textContent = '➕';
+      const plusText = document.createElement('span');
+      plusText.textContent = 'Nuevo proyecto';
+      createBtn.appendChild(plusIcon);
+      createBtn.appendChild(plusText);
+      createBtn.addEventListener('click', () => {
+        this._creating   = true;
+        this._editingId  = null;
+        this._deletingId = null;
+        this._buildContent();
+        requestAnimationFrame(() => {
+          this._shadow.querySelector<HTMLInputElement>('.create-name-input')?.focus();
+        });
+      });
+      createWrap.appendChild(createBtn);
+      content.appendChild(createWrap);
+    }
+
+    if (this._projects.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'No hay proyectos. Crea uno para agrupar tus tareas.';
+      content.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'project-list';
+    list.setAttribute('role', 'list');
+
+    for (const project of this._projects) {
+      list.appendChild(this._buildProjectRow(project));
+    }
+
+    content.appendChild(list);
+  }
+
+  // ── Formulario de creación ───────────────────────────────────────────────
+
+  private _buildCreateForm(): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.className = 'create-form-wrap';
+
+    const form = document.createElement('div');
+    form.className = 'inline-form';
+
+    // Nombre
+    const nameLabel = document.createElement('label');
+    nameLabel.className = 'form-label';
+    nameLabel.textContent = 'Nombre';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'form-input create-name-input';
+    nameInput.maxLength = 60;
+    nameInput.placeholder = 'Ej. Sitio Web';
+    nameLabel.appendChild(nameInput);
+    form.appendChild(nameLabel);
+
+    // Prefijo
+    const prefixLabel = document.createElement('label');
+    prefixLabel.className = 'form-label';
+    prefixLabel.textContent = 'Prefijo';
+    const prefixInput = document.createElement('input');
+    prefixInput.type = 'text';
+    prefixInput.className = 'form-input';
+    prefixInput.maxLength = 5;
+    prefixInput.placeholder = 'Ej. WEB';
+    prefixInput.addEventListener('input', () => {
+      prefixInput.value = prefixInput.value.toUpperCase().replace(/[^A-Z]/g, '');
+    });
+    const prefixHint = document.createElement('p');
+    prefixHint.className = 'form-hint';
+    prefixHint.textContent = '1-5 letras mayúsculas. Inmutable tras la creación.';
+    prefixLabel.appendChild(prefixInput);
+    prefixLabel.appendChild(prefixHint);
+    form.appendChild(prefixLabel);
+
+    // Descripción
+    const descLabel = document.createElement('label');
+    descLabel.className = 'form-label';
+    descLabel.textContent = 'Descripción (opcional)';
+    const descInput = document.createElement('input');
+    descInput.type = 'text';
+    descInput.className = 'form-input';
+    descInput.maxLength = 200;
+    descInput.placeholder = 'Breve descripción del proyecto';
+    descLabel.appendChild(descInput);
+    form.appendChild(descLabel);
+
+    // Error
+    const errorEl = document.createElement('p');
+    errorEl.className = 'form-error';
+    errorEl.style.display = 'none';
+    form.appendChild(errorEl);
+
+    // Acciones
+    const actions = document.createElement('div');
+    actions.className = 'form-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => {
+      this._creating = false;
+      this._buildContent();
+    });
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'btn-primary';
+    saveBtn.type = 'button';
+    saveBtn.textContent = 'Crear proyecto';
+    saveBtn.addEventListener('click', async () => {
+      const name   = nameInput.value.trim();
+      const prefix = prefixInput.value.trim().toUpperCase();
+      const desc   = descInput.value.trim();
+
+      if (!name) {
+        errorEl.textContent = 'El nombre es obligatorio.';
+        errorEl.style.display = '';
+        nameInput.focus();
+        return;
+      }
+      if (!isValidPrefix(prefix)) {
+        errorEl.textContent = 'El prefijo debe tener entre 1 y 5 letras mayúsculas (A-Z).';
+        errorEl.style.display = '';
+        prefixInput.focus();
+        return;
+      }
+
+      saveBtn.disabled = true;
+      errorEl.style.display = 'none';
+
+      try {
+        const created = await createProject({ name, prefix, description: desc });
+        this._projects.push(created);
+        this._creating = false;
+        this._buildContent();
+        this.dispatchEvent(new CustomEvent('dojo:project-created', {
+          bubbles: true, composed: true,
+          detail: { project: created },
+        }));
+      } catch (err) {
+        saveBtn.disabled = false;
+        errorEl.textContent = err instanceof Error ? err.message : 'Error al crear el proyecto.';
+        errorEl.style.display = '';
+      }
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(saveBtn);
+    form.appendChild(actions);
+    wrap.appendChild(form);
+
+    return wrap;
+  }
+
+  // ── Fila de proyecto ─────────────────────────────────────────────────────
+
+  private _buildProjectRow(project: Project): HTMLLIElement {
+    const item = document.createElement('li');
+    item.className = 'project-row';
+    item.dataset['projectId'] = project.id;
+
+    if (this._editingId === project.id) {
+      item.appendChild(this._buildEditForm(project));
+    } else if (this._deletingId === project.id) {
+      item.appendChild(this._buildDeleteConfirm(project));
+    } else {
+      const prefix = document.createElement('span');
+      prefix.className = 'project-prefix';
+      prefix.textContent = project.prefix;
+
+      const info = document.createElement('div');
+      info.className = 'project-info';
+      const nameEl = document.createElement('span');
+      nameEl.className = 'project-name';
+      nameEl.textContent = project.name;
+      nameEl.title = project.name;
+      info.appendChild(nameEl);
+      if (project.description) {
+        const descEl = document.createElement('span');
+        descEl.className = 'project-desc';
+        descEl.textContent = project.description;
+        descEl.title = project.description;
+        info.appendChild(descEl);
+      }
+
+      const editBtn = document.createElement('button');
+      editBtn.className = 'action-btn';
+      editBtn.type = 'button';
+      editBtn.textContent = '✏️';
+      editBtn.setAttribute('aria-label', `Editar proyecto "${project.name}"`);
+      editBtn.addEventListener('click', () => {
+        this._editingId  = project.id;
+        this._deletingId = null;
+        this._creating   = false;
+        this._buildContent();
+        requestAnimationFrame(() => {
+          this._shadow.querySelector<HTMLInputElement>('.edit-name-input')?.focus();
+        });
+      });
+
+      // No mostrar botón eliminar para proyecto General
+      const isDefault = project.prefix === DEFAULT_PROJECT_PREFIX;
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'action-btn danger';
+      deleteBtn.type = 'button';
+      deleteBtn.textContent = '🗑️';
+      deleteBtn.setAttribute('aria-label', `Eliminar proyecto "${project.name}"`);
+      if (isDefault) {
+        deleteBtn.disabled = true;
+        deleteBtn.title = 'No se puede eliminar el proyecto por defecto';
+        deleteBtn.style.opacity = '0.35';
+        deleteBtn.style.cursor = 'not-allowed';
+      } else {
+        deleteBtn.addEventListener('click', () => {
+          this._editingId  = null;
+          this._deletingId = project.id;
+          this._creating   = false;
+          this._buildContent();
+          requestAnimationFrame(() => {
+            this._shadow.querySelector<HTMLButtonElement>('.btn-secondary')?.focus();
+          });
+        });
+      }
+
+      item.appendChild(prefix);
+      item.appendChild(info);
+      item.appendChild(editBtn);
+      item.appendChild(deleteBtn);
+    }
+
+    return item;
+  }
+
+  // ── Formulario de edición inline ─────────────────────────────────────────
+
+  private _buildEditForm(project: Project): HTMLElement {
+    const form = document.createElement('div');
+    form.className = 'inline-form';
+
+    // Prefijo (solo lectura)
+    const prefixLabel = document.createElement('label');
+    prefixLabel.className = 'form-label';
+    prefixLabel.textContent = 'Prefijo';
+    const prefixInput = document.createElement('input');
+    prefixInput.type = 'text';
+    prefixInput.className = 'form-input';
+    prefixInput.value = project.prefix;
+    prefixInput.disabled = true;
+    prefixLabel.appendChild(prefixInput);
+    form.appendChild(prefixLabel);
+
+    // Nombre
+    const nameLabel = document.createElement('label');
+    nameLabel.className = 'form-label';
+    nameLabel.textContent = 'Nombre';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'form-input edit-name-input';
+    nameInput.maxLength = 60;
+    nameInput.value = project.name;
+    nameLabel.appendChild(nameInput);
+    form.appendChild(nameLabel);
+
+    // Descripción
+    const descLabel = document.createElement('label');
+    descLabel.className = 'form-label';
+    descLabel.textContent = 'Descripción';
+    const descInput = document.createElement('input');
+    descInput.type = 'text';
+    descInput.className = 'form-input';
+    descInput.maxLength = 200;
+    descInput.value = project.description || '';
+    descLabel.appendChild(descInput);
+    form.appendChild(descLabel);
+
+    // Error
+    const errorEl = document.createElement('p');
+    errorEl.className = 'form-error';
+    errorEl.style.display = 'none';
+    form.appendChild(errorEl);
+
+    // Acciones
+    const actions = document.createElement('div');
+    actions.className = 'form-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => {
+      this._editingId = null;
+      this._buildContent();
+    });
+
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'btn-primary';
+    saveBtn.type = 'button';
+    saveBtn.textContent = 'Guardar';
+    saveBtn.addEventListener('click', async () => {
+      const name = nameInput.value.trim();
+      const desc = descInput.value.trim();
+
+      if (!name) {
+        errorEl.textContent = 'El nombre es obligatorio.';
+        errorEl.style.display = '';
+        nameInput.focus();
+        return;
+      }
+
+      saveBtn.disabled = true;
+      errorEl.style.display = 'none';
+
+      try {
+        const updated = await updateProject(project.id, { name, description: desc });
+        const idx = this._projects.findIndex(p => p.id === project.id);
+        if (idx >= 0) this._projects[idx] = updated;
+        this._editingId = null;
+        this._buildContent();
+        this.dispatchEvent(new CustomEvent('dojo:project-updated', {
+          bubbles: true, composed: true,
+          detail: { project: updated },
+        }));
+      } catch (err) {
+        saveBtn.disabled = false;
+        errorEl.textContent = err instanceof Error ? err.message : 'Error al guardar.';
+        errorEl.style.display = '';
+      }
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(saveBtn);
+    form.appendChild(actions);
+
+    return form;
+  }
+
+  // ── Confirmación de eliminación ──────────────────────────────────────────
+
+  private _buildDeleteConfirm(project: Project): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'delete-confirm';
+
+    const msg = document.createElement('p');
+    msg.className = 'delete-confirm-msg';
+    msg.textContent = `¿Eliminar el proyecto "${project.name}" (${project.prefix})?`;
+    container.appendChild(msg);
+
+    const warning = document.createElement('p');
+    warning.className = 'delete-confirm-warning';
+    warning.setAttribute('role', 'alert');
+    warning.textContent = 'Las tareas de este proyecto se reasignarán al proyecto "General".';
+    container.appendChild(warning);
+
+    const actions = document.createElement('div');
+    actions.className = 'delete-confirm-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn-secondary';
+    cancelBtn.type = 'button';
+    cancelBtn.textContent = 'Cancelar';
+    cancelBtn.addEventListener('click', () => {
+      this._deletingId = null;
+      this._buildContent();
+    });
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.className = 'btn-danger';
+    confirmBtn.type = 'button';
+    confirmBtn.textContent = 'Eliminar';
+    confirmBtn.addEventListener('click', async () => {
+      confirmBtn.disabled = true;
+
+      try {
+        await deleteProject(project.id);
+        this._projects = this._projects.filter(p => p.id !== project.id);
+        this._deletingId = null;
+        this._buildContent();
+        this.dispatchEvent(new CustomEvent('dojo:project-deleted', {
+          bubbles: true, composed: true,
+          detail: { projectId: project.id },
+        }));
+      } catch (err) {
+        confirmBtn.disabled = false;
+        const errMsg = document.createElement('p');
+        errMsg.className = 'form-error';
+        errMsg.textContent = err instanceof Error ? err.message : 'Error al eliminar.';
+        container.appendChild(errMsg);
+      }
+    });
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    container.appendChild(actions);
+
+    return container;
+  }
+}
+
+customElements.define(DojoProjectManager.TAG, DojoProjectManager);

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -24,8 +24,9 @@
  * --dojo-danger, --dojo-radius, --dojo-radius-sm, --dojo-shadow
  */
 
-import type { Priority, Label } from '../../../types/models.js';
+import type { Priority, Label, Project } from '../../../types/models.js';
 import { getAllLabels, createLabel } from '../../../db/label.repository.js';
+import { getAllProjects } from '../../../db/project.repository.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 
 const PRIORITIES: { value: Priority; label: string }[] = [
@@ -45,6 +46,8 @@ export class DojoTaskDialog extends HTMLElement {
   // US-23: estado de etiquetas
   private _allLabels: Label[] = [];
   private _selectedLabelIds: Set<string> = new Set();
+  // US-26: estado de proyectos
+  private _allProjects: Project[] = [];
 
   // Referencia estable para poder eliminar el listener de teclado
   private _onDocKeydown = (e: KeyboardEvent): void => {
@@ -70,14 +73,16 @@ export class DojoTaskDialog extends HTMLElement {
     this._columnId   = columnId;
     this._columnName = columnName;
     this._selectedLabelIds = new Set();
-    // Cargar etiquetas (US-23) y luego construir el formulario
-    getAllLabels()
-      .then(labels => { this._allLabels = labels; })
-      .catch(() => { this._allLabels = []; })
-      .finally(() => {
-        this._buildForm();
-        this._open();
-      });
+    // Cargar etiquetas (US-23) y proyectos (US-26), luego construir el formulario
+    Promise.all([
+      getAllLabels().catch(() => [] as Label[]),
+      getAllProjects().catch(() => [] as Project[]),
+    ]).then(([labels, projects]) => {
+      this._allLabels = labels;
+      this._allProjects = projects;
+      this._buildForm();
+      this._open();
+    });
   }
 
   // ── Estado del diálogo ────────────────────────────────────────────────────
@@ -623,6 +628,31 @@ export class DojoTaskDialog extends HTMLElement {
     dueField.appendChild(dueInput);
     dialog.appendChild(dueField);
 
+    // ── Campo: Proyecto (US-26) ────────────────────────────────────────────
+    const projField = document.createElement('div');
+    projField.className = 'field';
+
+    const projLabel = document.createElement('label');
+    projLabel.setAttribute('for', 'task-project-select');
+    projLabel.textContent = 'Proyecto';
+
+    const projSelect = document.createElement('select');
+    projSelect.id = 'task-project-select';
+    projSelect.setAttribute('aria-label', 'Seleccionar proyecto');
+
+    for (const proj of this._allProjects) {
+      const opt = document.createElement('option');
+      opt.value = proj.id;
+      opt.textContent = `${proj.prefix} — ${proj.name}`;
+      // Seleccionar "General" por defecto
+      if (proj.prefix === 'GEN') opt.selected = true;
+      projSelect.appendChild(opt);
+    }
+
+    projField.appendChild(projLabel);
+    projField.appendChild(projSelect);
+    dialog.appendChild(projField);
+
     // ── Campo: Etiquetas (US-23) ──────────────────────────────────────────
     const labelsField = document.createElement('div');
     labelsField.className = 'labels-field';
@@ -1084,6 +1114,7 @@ export class DojoTaskDialog extends HTMLElement {
           description: descInput.value.trim(),
           priority:    priSelect.value as Priority,
           labelIds:    [...this._selectedLabelIds],
+          projectId:   projSelect.value || undefined,
           dueDate:     (() => {
             if (!dueInput.value) return null;
             const parts = dueInput.value.split('-');

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -13,7 +13,7 @@
  */
 
 const DB_NAME    = 'kanban-app-db';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 
 /** Instancia singleton de la base de datos (se inicializa una sola vez). */
 let _db: IDBDatabase | null = null;
@@ -151,7 +151,57 @@ export function openDatabase(): Promise<IDBDatabase> {
         };
       }
 
-      // if (oldVersion < 4) { ... }
+      // v3 → v4: proyectos — agrupación de tareas (US-26)
+      if (oldVersion < 4) {
+        const tx = (event.target as IDBOpenDBRequest).transaction!;
+        const now = new Date().toISOString();
+
+        // Nuevo store 'projects' con índice único por prefijo
+        const projectStore = db.createObjectStore('projects', { keyPath: 'id' });
+        projectStore.createIndex('by-prefix', 'prefix', { unique: true });
+
+        // Crear proyecto por defecto "General" con prefijo "GEN"
+        const defaultProjectId = crypto.randomUUID();
+        projectStore.add({
+          id:             defaultProjectId,
+          name:           'General',
+          prefix:         'GEN',
+          description:    'Proyecto por defecto para tareas sin proyecto asignado.',
+          nextTaskNumber: 1,
+          createdAt:      now,
+        });
+
+        // Añadir índice by-project en tasks y asignar projectId + taskNumber a tareas existentes
+        const taskStore = tx.objectStore('tasks');
+        taskStore.createIndex('by-project', 'projectId', { unique: false });
+        let counter = 0;
+        const taskReq = taskStore.openCursor();
+        taskReq.onsuccess = () => {
+          const cursor = taskReq.result;
+          if (cursor) {
+            const task = cursor.value;
+            if (!task.projectId) {
+              counter++;
+              task.projectId  = defaultProjectId;
+              task.taskNumber = `GEN-${String(counter).padStart(3, '0')}`;
+              cursor.update(task);
+            }
+            cursor.continue();
+          } else {
+            // Actualizar nextTaskNumber del proyecto General
+            const projReq = tx.objectStore('projects').get(defaultProjectId);
+            projReq.onsuccess = () => {
+              const proj = projReq.result;
+              if (proj) {
+                proj.nextTaskNumber = counter + 1;
+                tx.objectStore('projects').put(proj);
+              }
+            };
+          }
+        };
+      }
+
+      // if (oldVersion < 5) { ... }
     };
   });
 

--- a/src/db/export-import.ts
+++ b/src/db/export-import.ts
@@ -11,7 +11,7 @@
  */
 
 import { openDatabase, idbRequest, idbTransaction } from './database.js';
-import type { Column, Task, Label, ActivityEvent, Board } from '../types/models.js';
+import type { Column, Task, Label, ActivityEvent, Board, Project } from '../types/models.js';
 
 // ── Tipos ──────────────────────────────────────────────────────────────────
 
@@ -30,6 +30,7 @@ export interface BoardExport {
   labels: Label[];
   activity?: ActivityEvent[];
   boards?: Board[];
+  projects?: Project[];
 }
 
 /** Resultado de la validación de un archivo importado. */
@@ -59,10 +60,12 @@ export async function exportBoardData(): Promise<BoardExport> {
   const allNames = db.objectStoreNames;
   const hasActivity = allNames.contains('activity');
   const hasBoards   = allNames.contains('boards');
+  const hasProjects = allNames.contains('projects');
   const txStores = [
     ...storeNames,
     ...(hasActivity ? ['activity'] : []),
     ...(hasBoards   ? ['boards']   : []),
+    ...(hasProjects ? ['projects'] : []),
   ];
   const tx = db.transaction(txStores, 'readonly');
   const columns  = await idbRequest<Column[]>(tx.objectStore('columns').getAll());
@@ -74,6 +77,9 @@ export async function exportBoardData(): Promise<BoardExport> {
   const boards   = hasBoards
     ? await idbRequest<Board[]>(tx.objectStore('boards').getAll())
     : [];
+  const projects = hasProjects
+    ? await idbRequest<Project[]>(tx.objectStore('projects').getAll())
+    : [];
 
   return {
     version:    CURRENT_VERSION,
@@ -83,6 +89,7 @@ export async function exportBoardData(): Promise<BoardExport> {
     labels:     labels.sort((a, b) => a.name.localeCompare(b.name, 'es', { sensitivity: 'base' })),
     activity:   activity.sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
     boards:     boards.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
+    projects:   projects.sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
   };
 }
 
@@ -194,10 +201,12 @@ export async function importBoardData(data: BoardExport): Promise<void> {
   const allNames = db.objectStoreNames;
   const hasActivity = allNames.contains('activity');
   const hasBoards   = allNames.contains('boards');
+  const hasProjects = allNames.contains('projects');
   const storeNames = [
     'columns', 'tasks', 'labels',
     ...(hasActivity ? ['activity'] : []),
     ...(hasBoards   ? ['boards']   : []),
+    ...(hasProjects ? ['projects'] : []),
   ];
   const tx = db.transaction(storeNames, 'readwrite');
 
@@ -242,6 +251,27 @@ export async function importBoardData(data: BoardExport): Promise<void> {
       for (const task of data.tasks) {
         if (!task.boardId) taskStore.put({ ...task, boardId: defaultId });
       }
+    }
+  }
+
+  // 5. Importar proyectos si existen en el archivo y el store está disponible (US-26)
+  if (hasProjects) {
+    const projectStore = tx.objectStore('projects');
+    projectStore.clear();
+    if (data.projects && data.projects.length > 0) {
+      for (const project of data.projects) projectStore.add(project);
+    } else {
+      // Si no hay projects en los datos importados (export antiguo),
+      // crear un proyecto General por defecto.
+      const defaultProjId = crypto.randomUUID();
+      projectStore.add({
+        id: defaultProjId,
+        name: 'General',
+        prefix: 'GEN',
+        description: 'Proyecto por defecto para tareas sin proyecto asignado.',
+        nextTaskNumber: 1,
+        createdAt: new Date().toISOString(),
+      });
     }
   }
 

--- a/src/db/project.repository.ts
+++ b/src/db/project.repository.ts
@@ -1,0 +1,183 @@
+/**
+ * project.repository.ts — CRUD de proyectos sobre IndexedDB (US-26).
+ *
+ * Los proyectos agrupan tareas bajo identificadores legibles (ej. "WEB-005").
+ * Cada proyecto tiene un prefijo único (máx. 5 chars, uppercase) y un contador
+ * secuencial para generar taskNumbers.
+ */
+
+import { idbRequest, idbTransaction, getStore, openDatabase } from './database.js';
+import { generateUUID } from '../utils/uuid.js';
+import type { Project } from '../types/models.js';
+import { DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_PREFIX } from '../types/models.js';
+
+// ── Tipos internos ─────────────────────────────────────────────────────────
+
+type CreateProjectInput = Omit<Project, 'id' | 'nextTaskNumber' | 'createdAt'>;
+type UpdateProjectInput = Partial<Pick<Project, 'name' | 'description'>>;
+
+// ── Validación ─────────────────────────────────────────────────────────────
+
+const PREFIX_RE = /^[A-Z]{1,5}$/;
+
+/** Valida que un prefijo cumpla el formato: 1-5 letras, solo mayúsculas. */
+export function isValidPrefix(prefix: string): boolean {
+  return PREFIX_RE.test(prefix);
+}
+
+// ── Implementación ─────────────────────────────────────────────────────────
+
+/** Devuelve todos los proyectos ordenados por fecha de creación ascendente. */
+export async function getAllProjects(): Promise<Project[]> {
+  const { store } = await getStore('projects');
+  const projects  = await idbRequest<Project[]>(store.getAll());
+  return projects.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+/** Devuelve un proyecto por su ID, o `undefined` si no existe. */
+export async function getProjectById(id: string): Promise<Project | undefined> {
+  const { store } = await getStore('projects');
+  return idbRequest<Project | undefined>(store.get(id));
+}
+
+/** Devuelve un proyecto por su prefijo, o `undefined` si no existe. */
+export async function getProjectByPrefix(prefix: string): Promise<Project | undefined> {
+  const { store } = await getStore('projects');
+  const index     = store.index('by-prefix');
+  return idbRequest<Project | undefined>(index.get(prefix.toUpperCase()));
+}
+
+/**
+ * Crea un nuevo proyecto. Asigna `id`, `nextTaskNumber` (1) y `createdAt` automáticamente.
+ * Valida formato y unicidad del prefijo.
+ */
+export async function createProject(input: CreateProjectInput): Promise<Project> {
+  const normalizedPrefix = input.prefix.toUpperCase();
+
+  if (!isValidPrefix(normalizedPrefix)) {
+    throw new Error('El prefijo debe tener entre 1 y 5 letras mayúsculas (A-Z).');
+  }
+
+  // Verificar unicidad del prefijo
+  const existing = await getProjectByPrefix(normalizedPrefix);
+  if (existing) {
+    throw new Error(`Ya existe un proyecto con el prefijo "${normalizedPrefix}".`);
+  }
+
+  const project: Project = {
+    id:             generateUUID(),
+    name:           input.name,
+    prefix:         normalizedPrefix,
+    description:    input.description,
+    nextTaskNumber: 1,
+    createdAt:      new Date().toISOString(),
+  };
+
+  const { store, tx } = await getStore('projects', 'readwrite');
+  store.add(project);
+  await idbTransaction(tx);
+  return project;
+}
+
+/**
+ * Actualiza un proyecto existente. El prefijo es inmutable.
+ * Lanza un `Error` si el proyecto no existe.
+ */
+export async function updateProject(id: string, changes: UpdateProjectInput): Promise<Project> {
+  const existing = await getProjectById(id);
+  if (!existing) throw new Error(`Project not found: ${id}`);
+
+  const updated: Project = {
+    ...existing,
+    ...changes,
+    id,
+    prefix:         existing.prefix,       // prefijo inmutable
+    nextTaskNumber: existing.nextTaskNumber,
+    createdAt:      existing.createdAt,
+  };
+
+  const { store, tx } = await getStore('projects', 'readwrite');
+  store.put(updated);
+  await idbTransaction(tx);
+  return updated;
+}
+
+/**
+ * Elimina un proyecto por su ID y reasigna sus tareas al proyecto "General".
+ * No permite eliminar el proyecto por defecto "General".
+ */
+export async function deleteProject(id: string): Promise<void> {
+  const project = await getProjectById(id);
+  if (!project) return;
+
+  if (project.prefix === DEFAULT_PROJECT_PREFIX) {
+    throw new Error('No se puede eliminar el proyecto por defecto "General".');
+  }
+
+  // Buscar el proyecto General para reasignación
+  const generalProject = await getProjectByPrefix(DEFAULT_PROJECT_PREFIX);
+  if (!generalProject) {
+    throw new Error('No se encontró el proyecto "General" para reasignar tareas.');
+  }
+
+  const db = await openDatabase();
+  const tx = db.transaction(['projects', 'tasks'], 'readwrite');
+
+  // Reasignar tareas del proyecto eliminado al proyecto General
+  const taskStore = tx.objectStore('tasks');
+  const taskIndex = taskStore.index('by-project');
+  const tasks     = await idbRequest(taskIndex.getAll(id));
+  for (const task of tasks) {
+    task.projectId = generalProject.id;
+    // El taskNumber se mantiene como estaba (conserva trazabilidad)
+    taskStore.put(task);
+  }
+
+  // Eliminar el proyecto
+  tx.objectStore('projects').delete(id);
+  await idbTransaction(tx);
+}
+
+/**
+ * Obtiene el siguiente taskNumber para un proyecto y lo incrementa atómicamente.
+ * Devuelve el identificador legible (ej. "WEB-005").
+ */
+export async function getNextTaskNumber(projectId: string): Promise<string> {
+  const db = await openDatabase();
+  const tx = db.transaction('projects', 'readwrite');
+  const store = tx.objectStore('projects');
+
+  const project = await idbRequest<Project | undefined>(store.get(projectId));
+  if (!project) throw new Error(`Project not found: ${projectId}`);
+
+  const num        = project.nextTaskNumber;
+  const taskNumber = `${project.prefix}-${String(num).padStart(3, '0')}`;
+
+  project.nextTaskNumber = num + 1;
+  store.put(project);
+  await idbTransaction(tx);
+
+  return taskNumber;
+}
+
+/**
+ * Inicializa el proyecto por defecto "General" si no existe.
+ * Idempotente: no hace nada si ya existe.
+ */
+export async function seedDefaultProject(): Promise<void> {
+  const existing = await getProjectByPrefix(DEFAULT_PROJECT_PREFIX);
+  if (existing) return;
+
+  const project: Project = {
+    id:             generateUUID(),
+    name:           DEFAULT_PROJECT_NAME,
+    prefix:         DEFAULT_PROJECT_PREFIX,
+    description:    'Proyecto por defecto para tareas sin proyecto asignado.',
+    nextTaskNumber: 1,
+    createdAt:      new Date().toISOString(),
+  };
+
+  const { store, tx } = await getStore('projects', 'readwrite');
+  store.add(project);
+  await idbTransaction(tx);
+}

--- a/src/db/project.repository.ts
+++ b/src/db/project.repository.ts
@@ -107,21 +107,23 @@ export async function updateProject(id: string, changes: UpdateProjectInput): Pr
  * No permite eliminar el proyecto por defecto "General".
  */
 export async function deleteProject(id: string): Promise<void> {
-  const project = await getProjectById(id);
+  const db = await openDatabase();
+  const tx = db.transaction(['projects', 'tasks'], 'readwrite');
+  const projectStore = tx.objectStore('projects');
+
+  const project = await idbRequest<Project | undefined>(projectStore.get(id));
   if (!project) return;
 
   if (project.prefix === DEFAULT_PROJECT_PREFIX) {
     throw new Error('No se puede eliminar el proyecto por defecto "General".');
   }
 
-  // Buscar el proyecto General para reasignación
-  const generalProject = await getProjectByPrefix(DEFAULT_PROJECT_PREFIX);
+  // Buscar el proyecto General para reasignación dentro de la misma transacción
+  const prefixIndex    = projectStore.index('by-prefix');
+  const generalProject = await idbRequest<Project | undefined>(prefixIndex.get(DEFAULT_PROJECT_PREFIX));
   if (!generalProject) {
     throw new Error('No se encontró el proyecto "General" para reasignar tareas.');
   }
-
-  const db = await openDatabase();
-  const tx = db.transaction(['projects', 'tasks'], 'readwrite');
 
   // Reasignar tareas del proyecto eliminado al proyecto General
   const taskStore = tx.objectStore('tasks');
@@ -134,7 +136,7 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   // Eliminar el proyecto
-  tx.objectStore('projects').delete(id);
+  projectStore.delete(id);
   await idbTransaction(tx);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@
 
 import { openDatabase } from './db/database.js';
 import { seedDefaultLabels } from './db/label.repository.js';
+import { seedDefaultProject } from './db/project.repository.js';
 import { initTheme } from './utils/theme.js';
 
 // ── Inicialización ─────────────────────────────────────────────────────────
@@ -28,6 +29,9 @@ async function bootstrap(): Promise<void> {
 
     // 3. Seed de etiquetas por defecto (solo si el store está vacío)
     await seedDefaultLabels();
+
+    // 3b. Seed de proyecto por defecto "General" (US-26)
+    await seedDefaultProject();
 
     // 4. Registrar Web Components — US-01 Visualización del tablero Kanban
     await import('./components/organisms/dojo-app/dojo-app.js');

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -29,6 +29,10 @@ export interface Task {
   id: string;
   /** FK → Board.id — tablero al que pertenece (US-22). */
   boardId: string;
+  /** FK → Project.id — proyecto al que pertenece (US-26). */
+  projectId: string;
+  /** Identificador legible del proyecto, ej. "WEB-005" (US-26). */
+  taskNumber: string;
   /** Título visible de la tarea. Máx. 120 caracteres. */
   title: string;
   /** Descripción en formato Markdown. Puede estar vacío. */
@@ -95,6 +99,29 @@ export interface Board {
 
 /** Nombre del tablero por defecto creado en la migración. */
 export const DEFAULT_BOARD_NAME = 'Mi tablero';
+
+// ── Project (US-26) ────────────────────────────────────────────────────────
+
+/** Representa un proyecto que agrupa tareas con identificadores legibles. */
+export interface Project {
+  /** UUID v4. */
+  id: string;
+  /** Nombre visible del proyecto. Máx. 60 caracteres. */
+  name: string;
+  /** Prefijo único (máx. 5 caracteres, uppercase, solo letras). Inmutable tras creación. */
+  prefix: string;
+  /** Descripción opcional del proyecto. */
+  description: string;
+  /** Siguiente número secuencial para asignar a la próxima tarea. */
+  nextTaskNumber: number;
+  /** Fecha de creación en formato ISO 8601. */
+  createdAt: string;
+}
+
+/** Nombre del proyecto por defecto. */
+export const DEFAULT_PROJECT_NAME = 'General';
+/** Prefijo del proyecto por defecto. */
+export const DEFAULT_PROJECT_PREFIX = 'GEN';
 
 // ── Label ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Descripción

Implementa la **US-26 — Agrupación de tareas por proyectos**, permitiendo organizar las tareas bajo proyectos con identificadores legibles (ej. `WEB-005`, `API-012`).

## Cambios realizados

### Modelo de datos
- **`src/types/models.ts`**: Nuevo `interface Project` con campos `id`, `name`, `prefix`, `description`, `nextTaskNumber`, `createdAt`. Constantes `DEFAULT_PROJECT_NAME` y `DEFAULT_PROJECT_PREFIX`. Campos `projectId` y `taskNumber` añadidos a `Task`.

### Persistencia
- **`src/db/database.ts`**: Migración v3 → v4 que crea el store `projects` con índice `by-prefix`, índice `by-project` en `tasks`, inserta proyecto "General" por defecto y migra tareas existentes con número secuencial.
- **`src/db/project.repository.ts`** *(nuevo)*: CRUD completo — `getAllProjects`, `getProjectById`, `getProjectByPrefix`, `createProject` (validación de prefijo + unicidad), `updateProject` (prefijo inmutable), `deleteProject` (reasigna tareas a General), `getNextTaskNumber` (incremento atómico), `seedDefaultProject`.
- **`src/db/export-import.ts`**: Incluye `projects` en exportación e importación.

### Componentes
- **`dojo-task-card`**: Muestra el `taskNumber` sobre el título (monospace, color primario).
- **`dojo-kanban-board`**: Carga proyectos, filtro por proyecto en barra de filtros, selector de proyecto en toolbar, asignación de proyecto y taskNumber al crear tareas.
- **`dojo-task-dialog`**: Selector de proyecto en formulario de creación, incluye `projectId` en el evento `dojo:dialog-create-task`.
- **`dojo-project-manager`** *(nuevo)*: Panel lateral con CRUD de proyectos — crear con validación de prefijo, edición inline (prefijo inmutable), eliminación con confirmación y reasignación. El proyecto "General" no puede eliminarse.
- **`dojo-app`**: Botón "📁 Proyectos" en header, monta `<dojo-project-manager>`, refresca tablero ante cambios de proyectos.

### Bootstrap
- **`src/main.ts`**: Llama `seedDefaultProject()` al iniciar.

## Criterios de aceptación verificados

- ✅ Crear, editar, eliminar proyectos (General protegido)
- ✅ Prefijo único, inmutable, 1-5 letras mayúsculas
- ✅ Identificadores legibles en tarjetas (PREFIX-NNN)
- ✅ Filtrado por proyecto en el tablero
- ✅ Selector de proyecto al crear tareas
- ✅ Migración de datos existentes al proyecto General
- ✅ Export/Import incluye proyectos
- ✅ Zero dependencies mantenido

Closes #44