### PR TITLE
feat(wiki): US-27 — Wiki / Guía de usuario

### DIFF
--- a/docs/wiki/01-inicio-rapido.md
+++ b/docs/wiki/01-inicio-rapido.md
@@ -1,0 +1,29 @@
+# Inicio rápido
+
+Empieza a usar Dojo Kanban en cinco pasos.
+
+## 1. Crear un tablero
+
+Al abrir la aplicación por primera vez verás el **Selector de tableros**.  
+Haz clic en **"Nuevo tablero"** para crear el primer tablero y asígnale un nombre.
+
+## 2. Añadir columnas
+
+Dentro del tablero encontrarás las columnas por defecto (`Por hacer`, `En progreso`, `Hecho`).  
+Puedes añadir más columnas con el botón **"+ Columna"** que aparece al final del tablero.
+
+## 3. Crear tu primera tarea
+
+Haz clic en **"+ Tarea"** en cualquier columna para abrir el formulario de creación.  
+Los campos mínimos son el **título**; la descripción, etiquetas, fecha límite y asignación son opcionales.
+
+## 4. Organizar las tareas
+
+Arrastra y suelta las tarjetas entre columnas para actualizar su estado.  
+También puedes reordenar tareas dentro de la misma columna.
+
+## 5. Explorar el resto de funcionalidades
+
+- Usa **`Cmd / Ctrl + K`** para abrir la paleta de comandos y buscar tareas rápidamente.
+- Accede a **Etiquetas**, **Proyectos** y **Personas** desde el encabezado.
+- Exporta e importa datos con los botones **📤 Exportar** y **📥 Importar**.

--- a/docs/wiki/02-gestion-columnas.md
+++ b/docs/wiki/02-gestion-columnas.md
@@ -1,0 +1,27 @@
+# Gestión de columnas
+
+Las columnas representan los estados del flujo de trabajo de tu tablero.
+
+## Crear una columna
+
+1. Haz clic en el botón **"+ Columna"** situado al final del tablero.
+2. Escribe el nombre de la nueva columna en el diálogo que aparece.
+3. Confirma con **Crear** o pulsa `Enter`.
+
+## Renombrar una columna
+
+1. Haz clic en el menú **⋮** (tres puntos) en la cabecera de la columna.
+2. Selecciona **Renombrar**.
+3. Edita el nombre y confirma.
+
+## Eliminar una columna
+
+1. Abre el menú **⋮** de la columna que deseas eliminar.
+2. Selecciona **Eliminar**.
+3. Confirma en el diálogo de alerta — se eliminarán también todas las tareas contenidas.
+
+> ⚠️ **Atención:** La eliminación de una columna es una acción irreversible. Todos los datos de las tareas en esa columna se perderán.
+
+## Reordenar columnas
+
+Arrastra la cabecera de cualquier columna (zona del título) hacia la izquierda o la derecha para cambiar su posición en el tablero.

--- a/docs/wiki/03-gestion-tareas.md
+++ b/docs/wiki/03-gestion-tareas.md
@@ -1,0 +1,45 @@
+# Gestión de tareas
+
+Las tareas son las unidades de trabajo del tablero. Cada una pertenece a una columna.
+
+## Crear una tarea
+
+1. Haz clic en **"+ Tarea"** en la columna deseada.
+2. Completa los campos disponibles:
+
+   | Campo | Requerido | Descripción |
+   |-------|-----------|-------------|
+   | Título | ✅ | Nombre breve y descriptivo |
+   | Descripción | No | Soporta formato **Markdown** |
+   | Prioridad | No | `Urgente`, `Alta`, `Media`, `Baja` |
+   | Etiquetas | No | Una o varias etiquetas existentes |
+   | Fecha límite | No | Fecha de vencimiento (con alerta visual) |
+   | Proyecto | No | Agrupación de tareas (US-26) |
+   | Asignados | No | Personas responsables |
+
+3. Haz clic en **Guardar**.
+
+## Editar una tarea
+
+Haz clic sobre la tarjeta para abrir el panel de detalle.  
+Desde ahí puedes modificar cualquier campo y guardar los cambios.
+
+## Eliminar una tarea
+
+1. Abre el detalle de la tarea.
+2. Haz clic en el botón **Eliminar** (🗑️).
+3. Confirma en el diálogo de alerta.
+
+## Mover una tarea
+
+- **Drag & Drop:** Arrastra la tarjeta hacia otra columna.
+- **Menú contextual:** Usa el menú de la tarjeta para mover rápidamente a una columna destino.
+
+## Subtareas
+
+Dentro del detalle de una tarea puedes añadir **subtareas** (checklist).  
+Cada subtarea tiene un estado de completado independiente que se refleja en la tarjeta con una barra de progreso.
+
+## Historial de actividad
+
+El panel de detalle muestra el historial de cambios realizados sobre la tarea con fecha y descripción de cada evento.

--- a/docs/wiki/04-etiquetas.md
+++ b/docs/wiki/04-etiquetas.md
@@ -1,0 +1,36 @@
+# Etiquetas
+
+Las etiquetas permiten categorizar y filtrar tareas visualmente.
+
+## Crear una etiqueta
+
+1. Haz clic en **🏷️ Gestionar etiquetas** en el encabezado.
+2. En el panel, haz clic en **"Nueva etiqueta"**.
+3. Escribe un nombre y selecciona un color con contraste WCAG AA garantizado.
+4. Confirma con **Crear**.
+
+> Las etiquetas creadas quedan disponibles para todas las tareas del tablero.
+
+## Asignar etiquetas a una tarea
+
+- **Al crear la tarea:** Selecciona las etiquetas en el formulario de creación.
+- **Al editar la tarea:** Abre el detalle y usa el selector de etiquetas.
+
+Puedes asignar **múltiples etiquetas** a la misma tarea.
+
+## Editar una etiqueta
+
+1. Abre **🏷️ Gestionar etiquetas**.
+2. Haz clic en el ícono de edición ✏️ de la etiqueta que deseas modificar.
+3. Cambia el nombre, el color o ambos.
+4. Confirma con **Guardar**. Los cambios se propagan inmediatamente a todas las tareas que usen esa etiqueta.
+
+## Eliminar una etiqueta
+
+1. Abre **🏷️ Gestionar etiquetas**.
+2. Haz clic en el ícono de eliminación 🗑️.
+3. Confirma en el diálogo — la etiqueta se retirará de todas las tareas asociadas.
+
+## Etiquetas por defecto
+
+Al iniciar la aplicación se crean automáticamente las etiquetas: `Bug`, `Feature`, `Mejora`, `Documentación` y `Urgente`.

--- a/docs/wiki/05-drag-and-drop.md
+++ b/docs/wiki/05-drag-and-drop.md
@@ -1,0 +1,29 @@
+# Drag & Drop
+
+El tablero permite reorganizar tareas y columnas de forma intuitiva mediante arrastrar y soltar.
+
+## Mover una tarea entre columnas
+
+1. Mantén pulsado el botón del ratón (o toca con el dedo en móvil) sobre la tarjeta.
+2. Arrastra la tarjeta hacia la columna destino.
+3. Suelta cuando la columna destino esté resaltada.
+
+La tarea se inserta al final de la columna destino y el cambio se persiste automáticamente en IndexedDB.
+
+## Reordenar tareas dentro de una columna
+
+1. Arrastra la tarjeta hacia arriba o hacia abajo dentro de la misma columna.
+2. Suelta en la posición deseada — las demás tarjetas se desplazan automáticamente.
+
+## Reordenar columnas
+
+1. Haz clic y mantén pulsado sobre la **cabecera** de la columna (zona del título).
+2. Arrastra la columna hacia la izquierda o la derecha.
+3. Suelta cuando esté en la posición deseada.
+
+## Accesibilidad — modo sin ratón
+
+Si no puedes usar drag & drop, puedes mover tareas desde el **menú contextual** de la tarjeta:
+
+1. Haz clic en el icono ⋮ de la tarjeta.
+2. Selecciona **Mover a →** y elige la columna destino.

--- a/docs/wiki/06-filtros-busqueda.md
+++ b/docs/wiki/06-filtros-busqueda.md
@@ -1,0 +1,37 @@
+# Filtros y búsqueda
+
+Dojo Kanban ofrece dos mecanismos de búsqueda: la **barra de filtros** del tablero y la **paleta de comandos** global.
+
+## Barra de filtros del tablero
+
+Situada en la parte superior del tablero, permite filtrar las tareas visibles en tiempo real.
+
+### Filtrar por texto
+
+Escribe en el campo de búsqueda para filtrar tareas cuyo **título o descripción** contengan el texto introducido.  
+El filtrado es instantáneo (debounce de 200 ms) y no distingue mayúsculas.
+
+### Filtrar por etiqueta
+
+Haz clic en una o varias etiquetas del selector para mostrar solo las tareas que las tengan asignadas.  
+Los filtros de etiqueta son acumulativos (AND).
+
+### Filtrar por prioridad
+
+Selecciona un nivel de prioridad (`Urgente`, `Alta`, `Media`, `Baja`) para limitar las tareas mostradas.
+
+### Limpiar filtros
+
+Haz clic en **"Limpiar"** o vacía el campo de texto para restablecer la vista completa.
+
+---
+
+## Paleta de comandos global
+
+Abre la paleta con **`Cmd + K`** (Mac) o **`Ctrl + K`** (Windows/Linux).
+
+- Escribe para buscar tareas por título o descripción en **todos los tableros**.
+- Usa las flechas **↑ / ↓** para navegar entre resultados.
+- Pulsa **Enter** para abrir la tarea seleccionada.
+- Pulsa **Escape** para cerrar la paleta.
+- Desde la paleta también puedes **crear una tarea nueva** con el título buscado si no existe ninguna coincidencia.

--- a/docs/wiki/07-atajos-teclado.md
+++ b/docs/wiki/07-atajos-teclado.md
@@ -1,0 +1,46 @@
+# Atajos de teclado
+
+Dojo Kanban está diseñado para ser completamente operable por teclado.
+
+## Globales
+
+| Atajo | Acción |
+|-------|--------|
+| `Cmd / Ctrl + K` | Abrir / cerrar la paleta de comandos |
+| `Escape` | Cerrar el diálogo, panel o paleta activa |
+| `?` | Abrir esta guía de usuario |
+
+## Paleta de comandos
+
+| Atajo | Acción |
+|-------|--------|
+| `↑` / `↓` | Navegar entre resultados |
+| `Enter` | Abrir la tarea seleccionada |
+| `Escape` | Cerrar la paleta |
+
+## Diálogos y paneles
+
+| Atajo | Acción |
+|-------|--------|
+| `Escape` | Cerrar el diálogo activo |
+| `Tab` | Mover el foco al siguiente elemento interactivo |
+| `Shift + Tab` | Mover el foco al elemento anterior |
+| `Enter` / `Espacio` | Activar el botón enfocado |
+
+## Tablero
+
+| Atajo | Acción |
+|-------|--------|
+| `Tab` | Navegar entre tarjetas y controles del tablero |
+| `Enter` | Abrir el detalle de la tarea enfocada |
+
+## Formularios
+
+| Atajo | Acción |
+|-------|--------|
+| `Enter` | Enviar el formulario (cuando el foco está en un campo de texto de una sola línea) |
+| `Escape` | Cancelar y cerrar el formulario |
+
+---
+
+> **Nota:** En macOS utiliza `Cmd`, en Windows y Linux utiliza `Ctrl`.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,13 @@
+# Guía de usuario — Dojo Kanban
+
+Bienvenido a la documentación de **Dojo Kanban**. Usa el índice lateral para navegar entre las secciones.
+
+## Secciones disponibles
+
+1. [Inicio rápido](./01-inicio-rapido.md)
+2. [Gestión de columnas](./02-gestion-columnas.md)
+3. [Gestión de tareas](./03-gestion-tareas.md)
+4. [Etiquetas](./04-etiquetas.md)
+5. [Drag & Drop](./05-drag-and-drop.md)
+6. [Filtros y búsqueda](./06-filtros-busqueda.md)
+7. [Atajos de teclado](./07-atajos-teclado.md)

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -14,6 +14,7 @@
 
 import '../dojo-kanban-board/dojo-kanban-board.js';
 import '../dojo-label-manager/dojo-label-manager.js';
+import '../dojo-wiki/dojo-wiki.js';
 import '../dojo-project-manager/dojo-project-manager.js';
 import '../dojo-person-manager/dojo-person-manager.js';
 import '../dojo-command-palette/dojo-command-palette.js';
@@ -322,6 +323,32 @@ export class DojoApp extends HTMLElement {
       :host([view="board"]) .back-btn { display: inline-flex; }
       :host([view="board"]) .header-actions { display: flex; }
       :host(:not([view="board"])) .header-actions { display: none; }
+
+      /* Botón de ayuda — siempre visible (US-27) */
+      .help-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s, border-color 0.15s;
+        flex-shrink: 0;
+      }
+      .help-btn:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        border-color: var(--dojo-primary, #1D4ED8);
+      }
+      .help-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -457,7 +484,19 @@ export class DojoApp extends HTMLElement {
     backBtn.addEventListener('click', () => this._showBoardSelector());
     appHeader.appendChild(backBtn);
 
+    // ── Botón Ayuda (US-27) ─────────────────────────────────────────────────
+    const helpBtn = document.createElement('button');
+    helpBtn.className = 'help-btn';
+    helpBtn.type = 'button';
+    helpBtn.setAttribute('aria-label', 'Abrir guía de usuario');
+    helpBtn.setAttribute('title', 'Ayuda (también: ?)');
+    helpBtn.textContent = '?';
+    helpBtn.addEventListener('click', () => {
+      (wiki as any).show?.();
+    });
+
     appHeader.appendChild(headerActions);
+    appHeader.appendChild(helpBtn);
     appHeader.appendChild(themeToggle);
     this._shadow.appendChild(appHeader);
 
@@ -497,6 +536,10 @@ export class DojoApp extends HTMLElement {
     // ── Paleta de comandos (US-28) ───────────────────────────────────────────────────
     const palette = document.createElement('dojo-command-palette');
     this._shadow.appendChild(palette);
+
+    // ── Wiki / Guía de usuario (US-27) ───────────────────────────────────────────────
+    const wiki = document.createElement('dojo-wiki');
+    this._shadow.appendChild(wiki);
 
     // Seleccionar tarea desde la paleta
     this._shadow.addEventListener('dojo:palette-select-task', (e: Event) => {

--- a/src/components/organisms/dojo-wiki/dojo-wiki.ts
+++ b/src/components/organisms/dojo-wiki/dojo-wiki.ts
@@ -1,0 +1,727 @@
+/**
+ * dojo-wiki — Organismo
+ *
+ * Panel de guía de usuario / wiki accesible desde el encabezado de la app.
+ * Muestra las secciones de ayuda en un panel lateral con navegación por índice.
+ *
+ * ## API pública
+ * | Método | Descripción                |
+ * |--------|----------------------------|
+ * | show() | Abre el panel de ayuda     |
+ * | hide() | Cierra el panel de ayuda   |
+ *
+ * ## Atributos observados
+ * | Atributo | Valores          | Descripción       |
+ * |----------|------------------|-------------------|
+ * | open     | presente/ausente | Panel visible      |
+ *
+ * ## Atajos de teclado
+ * | Tecla   | Acción                          |
+ * |---------|---------------------------------|
+ * | Escape  | Cierra el panel                 |
+ * | ?       | Abre el panel (global, US-27)   |
+ *
+ * ## CSS Custom Properties heredadas
+ * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-*,
+ * --dojo-primary, --dojo-shadow, --dojo-radius
+ */
+
+// ── Tipos internos ─────────────────────────────────────────────────────────
+
+interface WikiSection {
+  id: string;
+  title: string;
+  icon: string;
+  /** Contenido en HTML (pre-compilado desde Markdown). */
+  html: string;
+}
+
+// ── Contenido de la wiki ──────────────────────────────────────────────────
+// El contenido se embebe directamente en el componente para garantizar
+// la disponibilidad offline (PWA — US-31) sin fetch ni dependencias externas.
+
+const WIKI_SECTIONS: WikiSection[] = [
+  {
+    id: 'inicio-rapido',
+    title: 'Inicio rápido',
+    icon: '🚀',
+    html: `
+      <h2>Inicio rápido</h2>
+      <p>Empieza a usar Dojo Kanban en cinco pasos.</p>
+
+      <h3>1. Crear un tablero</h3>
+      <p>Al abrir la aplicación verás el <strong>Selector de tableros</strong>.
+      Haz clic en <strong>"Nuevo tablero"</strong> para crear el primero.</p>
+
+      <h3>2. Añadir columnas</h3>
+      <p>El tablero incluye columnas por defecto (<em>Por hacer</em>, <em>En progreso</em>, <em>Hecho</em>).
+      Añade más con el botón <strong>"+ Columna"</strong> al final del tablero.</p>
+
+      <h3>3. Crear tu primera tarea</h3>
+      <p>Haz clic en <strong>"+ Tarea"</strong> en cualquier columna. El único campo obligatorio
+      es el <strong>título</strong>; el resto son opcionales.</p>
+
+      <h3>4. Organizar las tareas</h3>
+      <p>Arrastra y suelta las tarjetas entre columnas para actualizar su estado.</p>
+
+      <h3>5. Explorar el resto</h3>
+      <ul>
+        <li>Usa <kbd>Cmd / Ctrl + K</kbd> para la paleta de comandos.</li>
+        <li>Accede a <strong>Etiquetas</strong>, <strong>Proyectos</strong> y <strong>Personas</strong> desde el encabezado.</li>
+        <li>Exporta e importa datos con <strong>📤 Exportar</strong> / <strong>📥 Importar</strong>.</li>
+      </ul>
+    `,
+  },
+  {
+    id: 'gestion-columnas',
+    title: 'Gestión de columnas',
+    icon: '📋',
+    html: `
+      <h2>Gestión de columnas</h2>
+      <p>Las columnas representan los estados del flujo de trabajo de tu tablero.</p>
+
+      <h3>Crear una columna</h3>
+      <ol>
+        <li>Haz clic en <strong>"+ Columna"</strong> al final del tablero.</li>
+        <li>Escribe el nombre en el diálogo.</li>
+        <li>Confirma con <strong>Crear</strong> o pulsa <kbd>Enter</kbd>.</li>
+      </ol>
+
+      <h3>Renombrar una columna</h3>
+      <ol>
+        <li>Haz clic en el menú <strong>⋮</strong> de la cabecera de la columna.</li>
+        <li>Selecciona <strong>Renombrar</strong> y edita el nombre.</li>
+      </ol>
+
+      <h3>Eliminar una columna</h3>
+      <ol>
+        <li>Abre el menú <strong>⋮</strong> de la columna.</li>
+        <li>Selecciona <strong>Eliminar</strong> y confirma el diálogo de alerta.</li>
+      </ol>
+      <p class="warning">⚠️ La eliminación es irreversible — se eliminarán también todas las tareas contenidas.</p>
+
+      <h3>Reordenar columnas</h3>
+      <p>Arrastra la cabecera de la columna hacia la izquierda o la derecha para cambiar su posición.</p>
+    `,
+  },
+  {
+    id: 'gestion-tareas',
+    title: 'Gestión de tareas',
+    icon: '✅',
+    html: `
+      <h2>Gestión de tareas</h2>
+
+      <h3>Crear una tarea</h3>
+      <p>Haz clic en <strong>"+ Tarea"</strong> en la columna deseada y completa los campos:</p>
+      <table>
+        <thead><tr><th>Campo</th><th>Req.</th><th>Descripción</th></tr></thead>
+        <tbody>
+          <tr><td>Título</td><td>✅</td><td>Nombre breve y descriptivo</td></tr>
+          <tr><td>Descripción</td><td>—</td><td>Soporta formato <strong>Markdown</strong></td></tr>
+          <tr><td>Prioridad</td><td>—</td><td>Urgente · Alta · Media · Baja</td></tr>
+          <tr><td>Etiquetas</td><td>—</td><td>Una o varias etiquetas existentes</td></tr>
+          <tr><td>Fecha límite</td><td>—</td><td>Fecha de vencimiento con alerta visual</td></tr>
+          <tr><td>Proyecto</td><td>—</td><td>Agrupación de tareas</td></tr>
+          <tr><td>Asignados</td><td>—</td><td>Personas responsables</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Editar una tarea</h3>
+      <p>Haz clic sobre la tarjeta para abrir el panel de detalle y modifica cualquier campo.</p>
+
+      <h3>Eliminar una tarea</h3>
+      <p>Abre el detalle → botón <strong>🗑️ Eliminar</strong> → confirma en el diálogo.</p>
+
+      <h3>Subtareas</h3>
+      <p>En el detalle puedes añadir subtareas (checklist). El progreso se muestra en la tarjeta.</p>
+
+      <h3>Historial de actividad</h3>
+      <p>El panel de detalle registra todos los cambios realizados sobre la tarea con fecha y descripción.</p>
+    `,
+  },
+  {
+    id: 'etiquetas',
+    title: 'Etiquetas',
+    icon: '🏷️',
+    html: `
+      <h2>Etiquetas</h2>
+      <p>Las etiquetas permiten categorizar y filtrar tareas visualmente.</p>
+
+      <h3>Crear una etiqueta</h3>
+      <ol>
+        <li>Haz clic en <strong>🏷️ Gestionar etiquetas</strong> en el encabezado.</li>
+        <li>Haz clic en <strong>"Nueva etiqueta"</strong>.</li>
+        <li>Escribe un nombre y selecciona un color con contraste WCAG AA.</li>
+        <li>Confirma con <strong>Crear</strong>.</li>
+      </ol>
+
+      <h3>Asignar etiquetas a una tarea</h3>
+      <p>Al <strong>crear</strong> o <strong>editar</strong> una tarea usa el selector de etiquetas.
+      Puedes asignar <strong>múltiples etiquetas</strong> a la misma tarea.</p>
+
+      <h3>Editar una etiqueta</h3>
+      <p>En el panel de etiquetas, haz clic en ✏️ de la etiqueta deseada. Los cambios se
+      propagan inmediatamente a todas las tareas que la usen.</p>
+
+      <h3>Eliminar una etiqueta</h3>
+      <p>Haz clic en 🗑️ en el panel de etiquetas. La etiqueta se retira de todas las tareas asociadas.</p>
+
+      <h3>Etiquetas por defecto</h3>
+      <p>Al iniciar la app se crean: <strong>Bug</strong>, <strong>Feature</strong>,
+      <strong>Mejora</strong>, <strong>Documentación</strong> y <strong>Urgente</strong>.</p>
+    `,
+  },
+  {
+    id: 'drag-and-drop',
+    title: 'Drag & Drop',
+    icon: '↕️',
+    html: `
+      <h2>Drag &amp; Drop</h2>
+
+      <h3>Mover una tarea entre columnas</h3>
+      <ol>
+        <li>Mantén pulsado el botón del ratón sobre la tarjeta.</li>
+        <li>Arrastra hacia la columna destino.</li>
+        <li>Suelta cuando la columna esté resaltada.</li>
+      </ol>
+      <p>La tarea se inserta al final de la columna y el cambio se persiste automáticamente.</p>
+
+      <h3>Reordenar tareas dentro de una columna</h3>
+      <p>Arrastra la tarjeta hacia arriba o hacia abajo dentro de la misma columna y suelta en la posición deseada.</p>
+
+      <h3>Reordenar columnas</h3>
+      <p>Haz clic y mantén pulsado sobre la <strong>cabecera</strong> de la columna, luego arrástrala a la posición deseada.</p>
+
+      <h3>Modo sin ratón</h3>
+      <p>Si no puedes usar drag &amp; drop, usa el <strong>menú contextual ⋮</strong> de la tarjeta y selecciona
+      <strong>Mover a →</strong> para elegir la columna destino.</p>
+    `,
+  },
+  {
+    id: 'filtros-busqueda',
+    title: 'Filtros y búsqueda',
+    icon: '🔍',
+    html: `
+      <h2>Filtros y búsqueda</h2>
+
+      <h3>Barra de filtros del tablero</h3>
+      <p>Situada en la parte superior del tablero, filtra las tareas visibles en tiempo real.</p>
+      <ul>
+        <li><strong>Texto:</strong> filtra por título o descripción (debounce 200 ms, sin distinguir mayúsculas).</li>
+        <li><strong>Etiqueta:</strong> selecciona una o varias etiquetas — los filtros son acumulativos (AND).</li>
+        <li><strong>Prioridad:</strong> limita las tareas a un nivel de prioridad concreto.</li>
+        <li><strong>Limpiar:</strong> haz clic en "Limpiar" o vacía el campo para restablecer la vista.</li>
+      </ul>
+
+      <h3>Paleta de comandos global</h3>
+      <p>Abre con <kbd>Cmd + K</kbd> (Mac) o <kbd>Ctrl + K</kbd> (Windows/Linux).</p>
+      <ul>
+        <li>Busca tareas por título o descripción en <strong>todos los tableros</strong>.</li>
+        <li>Navega con <kbd>↑</kbd> / <kbd>↓</kbd> y abre con <kbd>Enter</kbd>.</li>
+        <li>Cierra con <kbd>Escape</kbd>.</li>
+        <li>Si no hay resultados, puedes <strong>crear la tarea</strong> directamente desde la paleta.</li>
+      </ul>
+    `,
+  },
+  {
+    id: 'atajos-teclado',
+    title: 'Atajos de teclado',
+    icon: '⌨️',
+    html: `
+      <h2>Atajos de teclado</h2>
+
+      <h3>Globales</h3>
+      <table>
+        <thead><tr><th>Atajo</th><th>Acción</th></tr></thead>
+        <tbody>
+          <tr><td><kbd>Cmd / Ctrl + K</kbd></td><td>Abrir / cerrar la paleta de comandos</td></tr>
+          <tr><td><kbd>Escape</kbd></td><td>Cerrar el diálogo, panel o paleta activa</td></tr>
+          <tr><td><kbd>?</kbd></td><td>Abrir esta guía de usuario</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Paleta de comandos</h3>
+      <table>
+        <thead><tr><th>Atajo</th><th>Acción</th></tr></thead>
+        <tbody>
+          <tr><td><kbd>↑</kbd> / <kbd>↓</kbd></td><td>Navegar entre resultados</td></tr>
+          <tr><td><kbd>Enter</kbd></td><td>Abrir la tarea seleccionada</td></tr>
+          <tr><td><kbd>Escape</kbd></td><td>Cerrar la paleta</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Diálogos y paneles</h3>
+      <table>
+        <thead><tr><th>Atajo</th><th>Acción</th></tr></thead>
+        <tbody>
+          <tr><td><kbd>Escape</kbd></td><td>Cerrar el diálogo activo</td></tr>
+          <tr><td><kbd>Tab</kbd></td><td>Siguiente elemento interactivo</td></tr>
+          <tr><td><kbd>Shift + Tab</kbd></td><td>Elemento interactivo anterior</td></tr>
+          <tr><td><kbd>Enter</kbd> / <kbd>Espacio</kbd></td><td>Activar el botón enfocado</td></tr>
+        </tbody>
+      </table>
+
+      <p class="note">En macOS usa <kbd>Cmd</kbd>; en Windows y Linux usa <kbd>Ctrl</kbd>.</p>
+    `,
+  },
+];
+
+// ── Clase ──────────────────────────────────────────────────────────────────
+
+export class DojoWiki extends HTMLElement {
+  static readonly TAG = 'dojo-wiki';
+
+  static get observedAttributes(): string[] { return ['open']; }
+
+  private _shadow: ShadowRoot;
+  private _activeSectionId = WIKI_SECTIONS[0].id;
+  /** Elemento que tenía el foco antes de abrir el panel. */
+  private _previousFocus: HTMLElement | null = null;
+
+  // ── Keyboard handler (referencia estable para cleanup) ─────────────────
+
+  private _onDocKeydown = (e: KeyboardEvent): void => {
+    // '?' abre la wiki (cuando no hay otro diálogo activo ni se está escribiendo)
+    if (e.key === '?' && !this.hasAttribute('open')) {
+      const target = e.target as HTMLElement;
+      const tag = target.tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || target.isContentEditable) return;
+      e.preventDefault();
+      this.show();
+      return;
+    }
+
+    if (!this.hasAttribute('open')) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hide();
+    }
+
+    // Focus trap (WCAG 2.1 SC 2.1.2)
+    if (e.key === 'Tab') {
+      const panel = this._shadow.querySelector<HTMLElement>('.panel');
+      if (!panel) return;
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(el => el.offsetParent !== null);
+      if (focusable.length < 2) return;
+      const first = focusable[0];
+      const last  = focusable[focusable.length - 1];
+      const active = this._shadow.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._render();
+    document.addEventListener('keydown', this._onDocKeydown);
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener('keydown', this._onDocKeydown);
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, newVal: string | null): void {
+    if (name !== 'open') return;
+    const panel    = this._shadow.querySelector<HTMLElement>('.panel');
+    const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
+    const isOpen   = newVal !== null;
+    if (panel) {
+      panel.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+      if (isOpen) panel.removeAttribute('inert');
+      else        panel.setAttribute('inert', '');
+    }
+    if (backdrop) backdrop.classList.toggle('visible', isOpen);
+  }
+
+  // ── API pública ──────────────────────────────────────────────────────────
+
+  show(sectionId?: string): void {
+    if (sectionId) this._activeSectionId = sectionId;
+    this._previousFocus = document.activeElement as HTMLElement;
+    this.setAttribute('open', '');
+    this._updateContent();
+    requestAnimationFrame(() => {
+      this._shadow.querySelector<HTMLButtonElement>('.panel-close')?.focus();
+    });
+  }
+
+  hide(): void {
+    this.removeAttribute('open');
+    this._previousFocus?.focus();
+    this._previousFocus = null;
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      /* ── Backdrop ─────────────────────────────────────────────── */
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.4);
+        z-index: 200;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+      }
+      .backdrop.visible {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      /* ── Panel lateral ────────────────────────────────────────── */
+      .panel {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(720px, 100vw);
+        z-index: 201;
+        background: var(--dojo-surface);
+        border-left: 1px solid var(--dojo-border);
+        box-shadow: -4px 0 24px rgba(0,0,0,0.12);
+        display: flex;
+        flex-direction: column;
+        transform: translateX(100%);
+        transition: transform 0.22s ease;
+      }
+      :host([open]) .panel {
+        transform: translateX(0);
+      }
+
+      /* ── Cabecera del panel ───────────────────────────────────── */
+      .panel-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0 1.25rem;
+        height: 52px;
+        border-bottom: 1px solid var(--dojo-border);
+        flex-shrink: 0;
+      }
+      .panel-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        flex: 1;
+      }
+      .panel-close {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border: none;
+        border-radius: var(--dojo-radius-sm, 4px);
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 1.25rem;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s;
+        flex-shrink: 0;
+      }
+      .panel-close:hover {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+      }
+      .panel-close:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
+
+      /* ── Cuerpo: sidebar + contenido ─────────────────────────── */
+      .panel-body {
+        display: flex;
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      /* ── Sidebar de navegación ───────────────────────────────── */
+      .sidebar {
+        width: 220px;
+        flex-shrink: 0;
+        border-right: 1px solid var(--dojo-border);
+        overflow-y: auto;
+        padding: 0.75rem 0;
+        background: var(--dojo-bg);
+      }
+      .sidebar-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        width: 100%;
+        padding: 0.5rem 1.25rem;
+        border: none;
+        background: transparent;
+        color: var(--dojo-text-secondary);
+        font-size: 0.875rem;
+        font-family: inherit;
+        text-align: left;
+        cursor: pointer;
+        border-radius: 0;
+        transition: background 0.12s, color 0.12s;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .sidebar-item:hover {
+        background: var(--dojo-surface-hover);
+        color: var(--dojo-text-primary);
+      }
+      .sidebar-item.active {
+        background: var(--dojo-surface);
+        color: var(--dojo-primary, #1D4ED8);
+        font-weight: 600;
+        border-right: 3px solid var(--dojo-primary, #1D4ED8);
+      }
+      .sidebar-item:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: -2px;
+      }
+      .sidebar-icon {
+        font-size: 1rem;
+        flex-shrink: 0;
+      }
+
+      /* ── Área de contenido ───────────────────────────────────── */
+      .content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 1.75rem 2rem;
+      }
+
+      /* ── Tipografía del contenido ────────────────────────────── */
+      .content h2 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+        margin: 0 0 1.25rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 2px solid var(--dojo-border);
+      }
+      .content h3 {
+        font-size: 0.9375rem;
+        font-weight: 600;
+        color: var(--dojo-text-primary);
+        margin: 1.25rem 0 0.5rem;
+      }
+      .content p,
+      .content li {
+        font-size: 0.875rem;
+        color: var(--dojo-text-secondary);
+        line-height: 1.6;
+        margin: 0 0 0.5rem;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.25rem;
+        margin: 0 0 0.75rem;
+      }
+      .content li { margin-bottom: 0.25rem; }
+      .content strong { color: var(--dojo-text-primary); font-weight: 600; }
+      .content em { font-style: italic; }
+
+      /* ── Tablas ──────────────────────────────────────────────── */
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8125rem;
+        margin: 0.75rem 0 1rem;
+      }
+      .content th {
+        background: var(--dojo-bg);
+        color: var(--dojo-text-primary);
+        font-weight: 600;
+        padding: 0.5rem 0.75rem;
+        text-align: left;
+        border: 1px solid var(--dojo-border);
+      }
+      .content td {
+        padding: 0.4375rem 0.75rem;
+        border: 1px solid var(--dojo-border);
+        color: var(--dojo-text-secondary);
+        vertical-align: top;
+      }
+      .content tr:nth-child(even) td {
+        background: var(--dojo-bg);
+      }
+
+      /* ── Teclas ──────────────────────────────────────────────── */
+      .content kbd {
+        display: inline-block;
+        padding: 0.15em 0.45em;
+        font-size: 0.8125rem;
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        background: var(--dojo-bg);
+        border: 1px solid var(--dojo-border);
+        border-radius: 4px;
+        box-shadow: 0 1px 0 var(--dojo-border);
+        color: var(--dojo-text-primary);
+        white-space: nowrap;
+      }
+
+      /* ── Mensajes especiales ─────────────────────────────────── */
+      .content .warning {
+        background: #FEF3C7;
+        border-left: 3px solid #D97706;
+        border-radius: 0 var(--dojo-radius-sm, 4px) var(--dojo-radius-sm, 4px) 0;
+        padding: 0.625rem 0.875rem;
+        color: #92400E;
+        font-size: 0.8125rem;
+      }
+      .content .note {
+        background: var(--dojo-bg);
+        border-left: 3px solid var(--dojo-primary, #1D4ED8);
+        border-radius: 0 var(--dojo-radius-sm, 4px) var(--dojo-radius-sm, 4px) 0;
+        padding: 0.625rem 0.875rem;
+        color: var(--dojo-text-secondary);
+        font-size: 0.8125rem;
+      }
+      [data-theme="dark"] .content .warning {
+        background: rgba(217,119,6,0.15);
+        color: #FCD34D;
+      }
+
+      /* ── Responsive: sidebar colapsado en pantallas pequeñas ── */
+      @media (max-width: 600px) {
+        .sidebar { width: 52px; }
+        .sidebar-item span:not(.sidebar-icon) { display: none; }
+        .sidebar-item { padding: 0.5rem; justify-content: center; }
+        .content { padding: 1.25rem; }
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // ── Backdrop ─────────────────────────────────────────────────────────
+    const backdrop = document.createElement('div');
+    backdrop.className = 'backdrop';
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.addEventListener('click', () => this.hide());
+    this._shadow.appendChild(backdrop);
+
+    // ── Panel ─────────────────────────────────────────────────────────────
+    const panel = document.createElement('div');
+    panel.className = 'panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-labelledby', 'wiki-title');
+    panel.setAttribute('aria-modal', 'true');
+    panel.setAttribute('aria-hidden', 'true');
+    panel.setAttribute('inert', '');
+
+    // Cabecera
+    const panelHeader = document.createElement('header');
+    panelHeader.className = 'panel-header';
+
+    const panelIcon = document.createElement('span');
+    panelIcon.setAttribute('aria-hidden', 'true');
+    panelIcon.textContent = '📖';
+
+    const panelTitle = document.createElement('h1');
+    panelTitle.className = 'panel-title';
+    panelTitle.id = 'wiki-title';
+    panelTitle.textContent = 'Guía de usuario';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'panel-close';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('aria-label', 'Cerrar guía de usuario');
+    closeBtn.textContent = '✕';
+    closeBtn.addEventListener('click', () => this.hide());
+
+    panelHeader.append(panelIcon, panelTitle, closeBtn);
+    panel.appendChild(panelHeader);
+
+    // Cuerpo: sidebar + contenido
+    const panelBody = document.createElement('div');
+    panelBody.className = 'panel-body';
+
+    // Sidebar
+    const sidebar = document.createElement('nav');
+    sidebar.className = 'sidebar';
+    sidebar.setAttribute('aria-label', 'Secciones de la guía');
+
+    for (const section of WIKI_SECTIONS) {
+      const btn = document.createElement('button');
+      btn.className = 'sidebar-item';
+      btn.type = 'button';
+      btn.dataset['section'] = section.id;
+      btn.setAttribute('aria-current', section.id === this._activeSectionId ? 'page' : 'false');
+
+      const icon = document.createElement('span');
+      icon.className = 'sidebar-icon';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = section.icon;
+
+      const label = document.createElement('span');
+      label.textContent = section.title;
+
+      btn.append(icon, label);
+      btn.addEventListener('click', () => this._selectSection(section.id));
+      sidebar.appendChild(btn);
+    }
+
+    // Área de contenido
+    const contentEl = document.createElement('div');
+    contentEl.className = 'content';
+    contentEl.setAttribute('role', 'region');
+    contentEl.setAttribute('aria-label', 'Contenido de la sección');
+    contentEl.setAttribute('aria-live', 'polite');
+
+    panelBody.append(sidebar, contentEl);
+    panel.appendChild(panelBody);
+    this._shadow.appendChild(panel);
+
+    this._updateContent();
+  }
+
+  // ── Sección activa ───────────────────────────────────────────────────────
+
+  private _selectSection(id: string): void {
+    this._activeSectionId = id;
+    this._updateContent();
+  }
+
+  private _updateContent(): void {
+    const section = WIKI_SECTIONS.find(s => s.id === this._activeSectionId)
+                 ?? WIKI_SECTIONS[0];
+
+    // Actualizar sidebar (estado activo)
+    this._shadow.querySelectorAll<HTMLButtonElement>('.sidebar-item').forEach(btn => {
+      const isActive = btn.dataset['section'] === section.id;
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-current', isActive ? 'page' : 'false');
+    });
+
+    // Actualizar contenido
+    // El HTML proviene de strings literales definidos en esta misma clase,
+    // no contiene input del usuario — sin riesgo de XSS.
+    const contentEl = this._shadow.querySelector<HTMLElement>('.content');
+    if (contentEl) {
+      contentEl.innerHTML = section.html;
+    }
+  }
+}
+
+// ── Registro ──────────────────────────────────────────────────────────────
+
+customElements.define(DojoWiki.TAG, DojoWiki);


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa la guía de usuario completa (US-27) con documentación Markdown y un Web Component interactivo accesible desde el header.

## Cambios

### 📚 Documentación (`docs/wiki/`)
| Archivo | Contenido |
|---|---|
| `index.md` | Índice con enlaces a las 7 secciones |
| `01-inicio-rapido.md` | 5 pasos para empezar |
| `02-gestion-columnas.md` | Crear, renombrar, eliminar y reordenar columnas |
| `03-gestion-tareas.md` | CRUD de tareas, campos disponibles, subtareas, historial |
| `04-etiquetas.md` | Crear, asignar, editar y eliminar etiquetas; labels por defecto |
| `05-drag-and-drop.md` | Mover tareas y columnas, modo sin ratón |
| `06-filtros-busqueda.md` | Barra de filtros y paleta de comandos |
| `07-atajos-teclado.md` | Tablas de atajos globales, paleta, diálogos, tablero y formularios |

### 🧩 Web Component (`dojo-wiki`)
- Organismo con patrón backdrop + panel lateral (720 px), sidebar de navegación (220 px) + área de contenido
- API pública `show(sectionId?)` / `hide()`
- Atributo observado `open`
- Atajo `?` para abrir (no interfiere en `<input>` / `<textarea>`)
- `Escape` para cerrar, focus trap WCAG 2.1 SC 2.1.2
- `_previousFocus` restaura el foco al cerrar
- Contenido embebido (offline-first, sin fetch, zero dependencies)

### 🔧 Integración (`dojo-app`)
- Botón `?` (help-btn) añadido al header entre las acciones y el toggle de tema
- Elemento `<dojo-wiki>` montado en el shadow DOM

## Criterios de aceptación (US-27)
- [x] Existe una guía de usuario accesible desde la interfaz
- [x] Cubre las funcionalidades principales del tablero
- [x] Disponible sin conexión (contenido embebido)
- [x] Accesible mediante atajo de teclado `?`

Closes #45