### PR TITLE
fix(persons): make US-29 person assignment fully functional (#47)

### DIFF
--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -53,6 +53,7 @@ interface ActiveFilter {
   searchText?: string;
   sortBy?: SortMode;
   projectId?: string;
+  assigneeId?: string;
 }
 
 /** Contrato de la propiedad taskLabels expuesta por dojo-task-card (US-10). */
@@ -93,6 +94,8 @@ export class DojoKanbanBoard extends HTMLElement {
   private _filterDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   // US-26: referencia UI del filtro de proyecto
   private _filterProjectSelect: HTMLSelectElement | null = null;
+  // US-29: referencia UI del filtro de persona asignada
+  private _filterPersonSelect: HTMLSelectElement | null = null;
 
   constructor() {
     super();
@@ -123,9 +126,9 @@ export class DojoKanbanBoard extends HTMLElement {
     }
     if (!task) return;
     try {
-      const labels = await getAllLabels();
+      const [labels, persons] = await Promise.all([getAllLabels(), getAllPersons()]);
       const detail = this._getTaskDetail() as any;
-      if (detail?.openTask) detail.openTask(task, this._columns, labels);
+      if (detail?.openTask) detail.openTask(task, this._columns, labels, persons);
     } catch (err) {
       console.error('[dojo-kanban-board] Error al abrir detalle de tarea:', err);
     }
@@ -764,6 +767,29 @@ export class DojoKanbanBoard extends HTMLElement {
     this._updateClearAllVisibility();
   }
 
+  /** Reconstruye las opciones del selector de personas asignadas (US-29). */
+  private _rebuildPersonFilterSelect(): void {
+    if (!this._filterPersonSelect) return;
+    const currentValue = this._filterPersonSelect.value;
+    while (this._filterPersonSelect.options.length > 1) {
+      this._filterPersonSelect.remove(1);
+    }
+    for (const person of this._persons) {
+      const opt = document.createElement('option');
+      opt.value = person.id;
+      opt.textContent = `${person.avatar || '👤'} ${person.name}`;
+      this._filterPersonSelect.appendChild(opt);
+    }
+    if (this._persons.some(p => p.id === currentValue)) {
+      this._filterPersonSelect.value = currentValue;
+    } else {
+      this._filterPersonSelect.value = '';
+      if (this._activeFilter.assigneeId) {
+        this._activeFilter = { ...this._activeFilter, assigneeId: undefined };
+      }
+    }
+  }
+
   /** Reconstruye las opciones del selector de proyectos (US-26). */
   private _rebuildProjectFilterSelect(): void {
     if (!this._filterProjectSelect) return;
@@ -797,7 +823,8 @@ export class DojoKanbanBoard extends HTMLElement {
       (this._activeFilter.priorities?.length ?? 0) > 0 ||
       (this._activeFilter.labelIds?.length ?? 0) > 0 ||
       !!(this._activeFilter.searchText) ||
-      !!(this._activeFilter.projectId);
+      !!(this._activeFilter.projectId) ||
+      !!(this._activeFilter.assigneeId);
     this._filterClearAllBtn.style.display = hasActive ? '' : 'none';
     this._filterToggleBtn.classList.toggle('has-active', hasActive);
   }
@@ -813,6 +840,7 @@ export class DojoKanbanBoard extends HTMLElement {
     }
     if (this._filterSearchInput) this._filterSearchInput.value = '';
     if (this._filterProjectSelect) this._filterProjectSelect.value = '';
+    if (this._filterPersonSelect)  this._filterPersonSelect.value  = '';
     if (this._filterBarContent) {
       this._filterBarContent.querySelectorAll<HTMLButtonElement>('[data-priority]').forEach(b => {
         b.classList.remove('active');
@@ -908,8 +936,9 @@ export class DojoKanbanBoard extends HTMLElement {
       this._labels = labels;
       this._projects = projects;
       this._persons = persons;
-      this._rebuildLabelFilterChips(); // Poblar chips de etiquetas en el toolbar (US-15)
+      this._rebuildLabelFilterChips();    // Poblar chips de etiquetas en el toolbar (US-15)
       this._rebuildProjectFilterSelect(); // Poblar selector de proyectos (US-26)
+      this._rebuildPersonFilterSelect();  // Poblar selector de personas (US-29)
 
       // Cargar tareas de todas las columnas en paralelo
       const taskResults = await Promise.all(
@@ -1052,7 +1081,7 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private _filterTasks(tasks: Task[]): Task[] {
-    const { priorities, labelIds, searchText, projectId } = this._activeFilter;
+    const { priorities, labelIds, searchText, projectId, assigneeId } = this._activeFilter;
     const lowerSearch = searchText ? searchText.toLowerCase() : null;
     return tasks.filter(task => {
       if (priorities && priorities.length > 0 && !priorities.includes(task.priority)) return false;
@@ -1062,6 +1091,7 @@ export class DojoKanbanBoard extends HTMLElement {
         if (!hasLabel) return false;
       }
       if (projectId && task.projectId !== projectId) return false;
+      if (assigneeId && !(task.assignees ?? []).includes(assigneeId)) return false;
       if (lowerSearch) {
         const titleMatch = task.title.toLowerCase().includes(lowerSearch);
         const descMatch  = (task.description ?? '').toLowerCase().includes(lowerSearch);
@@ -1331,13 +1361,14 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private async _handleCreateTask(e: CustomEvent): Promise<void> {
-    const { statusId, title, description, priority, dueDate, labelIds, projectId } = e.detail as {
+    const { statusId, title, description, priority, dueDate, labelIds, assignees, projectId } = e.detail as {
       statusId:    string;
       title:       string;
       description: string;
       priority:    string;
       dueDate?:    string | null;
       labelIds?:   string[];
+      assignees?:  string[];
       projectId?:  string;
     };
     // Validar que la columna exista (puede haberse eliminado mientras el diálogo estaba abierto)
@@ -1371,7 +1402,7 @@ export class DojoKanbanBoard extends HTMLElement {
         taskNumber,
         priority:    priority as Task['priority'],
         labelIds:    labelIds ?? [],
-        assignees:   [], // Sin personas asignadas inicialmente (US-29)
+        assignees:   assignees ?? [],
         order:       tasks.length,
         dueDate:     dueDate ?? null,
       });
@@ -1399,9 +1430,9 @@ export class DojoKanbanBoard extends HTMLElement {
     }
     if (!task) return;
     try {
-      const labels = await getAllLabels();
+      const [labels, persons] = await Promise.all([getAllLabels(), getAllPersons()]);
       const detail = this._getTaskDetail() as any;
-      if (detail?.openTask) detail.openTask(task, this._columns, labels);
+      if (detail?.openTask) detail.openTask(task, this._columns, labels, persons);
     } catch (err) {
       console.error('[dojo-kanban-board] Error al abrir detalle de tarea:', err);
     }

--- a/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
+++ b/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
@@ -563,6 +563,7 @@ export class DojoPersonManager extends HTMLElement {
       </div>
     `;
     this._generateAvatarGrid();
+    this._setupEventListeners();
   }
 
   /** Configura los event listeners del panel. */
@@ -671,64 +672,175 @@ export class DojoPersonManager extends HTMLElement {
 
       const li = document.createElement('li');
       
-      if (isDeleting) {
-        // Mostrar confirmación de eliminación
-        li.innerHTML = 
-          '<div class="confirm-delete">' +
-            '<p><strong>¿Eliminar "' + person.name + '"?</strong></p>' +
-            (taskCount > 0 ? 
-              '<p>⚠️ Esta persona está asignada a ' + taskCount + ' tarea' + (taskCount === 1 ? '' : 's') + '. Se desasignará automáticamente.</p>' : 
-              '<p>Esta persona no tiene tareas asignadas.</p>'
-            ) +
-            '<div class="confirm-delete-actions">' +
-              '<button class="btn btn-danger btn-sm" id="confirm-delete-' + person.id + '">' +
-                '🗑️ Confirmar eliminación' +
-              '</button>' +
-              '<button class="btn btn-secondary btn-sm" id="cancel-delete-' + person.id + '">' +
-                'Cancelar' +
-              '</button>' +
-            '</div>' +
-          '</div>';
+      const isEditing = this._editingId === person.id;
 
-        // Event listeners para confirmación
-        li.querySelector('#confirm-delete-' + person.id)?.addEventListener('click', () => {
-          this._confirmDeletePerson();
+      if (isEditing) {
+        // ── Formulario de edición inline ────────────────────────────────
+        const isPersonEmoji = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(person.avatar);
+
+        const editForm = document.createElement('div');
+        editForm.className = 'create-form';
+        editForm.style.marginBottom = '8px';
+
+        const editTitle = document.createElement('h3');
+        editTitle.textContent = '✏️ Editar persona';
+        editForm.appendChild(editTitle);
+
+        // Nombre
+        const nameGroup = document.createElement('div');
+        nameGroup.className = 'form-group';
+        const nameLabel = document.createElement('label');
+        nameLabel.textContent = 'Nombre completo';
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.className = 'form-input';
+        nameInput.value = person.name;
+        nameInput.maxLength = 60;
+        nameGroup.appendChild(nameLabel);
+        nameGroup.appendChild(nameInput);
+        editForm.appendChild(nameGroup);
+
+        // Avatar grid
+        const avatarGroup = document.createElement('div');
+        avatarGroup.className = 'form-group';
+        const avatarLabel = document.createElement('label');
+        avatarLabel.textContent = 'Avatar';
+        avatarGroup.appendChild(avatarLabel);
+
+        const editAvatarGrid = document.createElement('div');
+        editAvatarGrid.className = 'avatar-grid';
+        PRESET_AVATARS.forEach(av => {
+          const opt = document.createElement('div');
+          opt.className = 'avatar-option' + (av === person.avatar ? ' selected' : '');
+          opt.textContent = av;
+          opt.addEventListener('click', () => {
+            editAvatarGrid.querySelectorAll('.avatar-option').forEach(el => el.classList.remove('selected'));
+            opt.classList.add('selected');
+          });
+          editAvatarGrid.appendChild(opt);
+        });
+        avatarGroup.appendChild(editAvatarGrid);
+        editForm.appendChild(avatarGroup);
+
+        // Acciones
+        const actions = document.createElement('div');
+        actions.style.display = 'flex';
+        actions.style.gap = '8px';
+
+        const saveBtn = document.createElement('button');
+        saveBtn.className = 'btn btn-primary';
+        saveBtn.textContent = '💾 Guardar';
+        saveBtn.addEventListener('click', async () => {
+          const newName = nameInput.value.trim();
+          if (!newName) { nameInput.focus(); return; }
+          const selectedAvatar = editAvatarGrid.querySelector<HTMLElement>('.avatar-option.selected')?.textContent || person.avatar;
+          await this._handleUpdatePerson(person.id, newName, selectedAvatar);
         });
 
-        li.querySelector('#cancel-delete-' + person.id)?.addEventListener('click', () => {
-          this._cancelDeletePerson();
+        const cancelEditBtn = document.createElement('button');
+        cancelEditBtn.className = 'btn btn-secondary';
+        cancelEditBtn.textContent = 'Cancelar';
+        cancelEditBtn.addEventListener('click', () => {
+          this._editingId = null;
+          this._renderPersonList();
         });
+
+        actions.appendChild(saveBtn);
+        actions.appendChild(cancelEditBtn);
+        editForm.appendChild(actions);
+
+        li.appendChild(editForm);
+
+      } else if (isDeleting) {
+        // Mostrar confirmación de eliminación — construido con createElement (OWASP A3)
+        const confirmBox = document.createElement('div');
+        confirmBox.className = 'confirm-delete';
+
+        const titleP = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = `¿Eliminar "${person.name}"?`;
+        titleP.appendChild(strong);
+        confirmBox.appendChild(titleP);
+
+        const warnP = document.createElement('p');
+        warnP.textContent = taskCount > 0
+          ? `⚠️ Esta persona está asignada a ${taskCount} tarea${taskCount === 1 ? '' : 's'}. Se desasignará automáticamente.`
+          : 'Esta persona no tiene tareas asignadas.';
+        confirmBox.appendChild(warnP);
+
+        const actionsDiv = document.createElement('div');
+        actionsDiv.className = 'confirm-delete-actions';
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.className = 'btn btn-danger btn-sm';
+        confirmBtn.textContent = '🗑️ Confirmar eliminación';
+        confirmBtn.addEventListener('click', () => this._confirmDeletePerson());
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn btn-secondary btn-sm';
+        cancelBtn.textContent = 'Cancelar';
+        cancelBtn.addEventListener('click', () => this._cancelDeletePerson());
+
+        actionsDiv.appendChild(confirmBtn);
+        actionsDiv.appendChild(cancelBtn);
+        confirmBox.appendChild(actionsDiv);
+
+        li.appendChild(confirmBox);
 
       } else {
-        // Mostrar persona normal
+        // Mostrar persona normal — construido con createElement (OWASP A3)
         const isEmoji = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(person.avatar);
-        
-        li.innerHTML = 
-          '<div class="person-item">' +
-            '<div class="person-avatar" style="' + (isEmoji ? 'background: transparent; color: inherit; border: 1px solid var(--dojo-border, #E5E7EB);' : '') + '">' + person.avatar + '</div>' +
-            '<div class="person-info">' +
-              '<div class="person-name">' + person.name + '</div>' +
-              '<div class="person-stats">' + taskCount + ' tarea' + (taskCount === 1 ? '' : 's') + ' asignada' + (taskCount === 1 ? '' : 's') + '</div>' +
-            '</div>' +
-            '<div class="person-actions">' +
-              '<button class="action-btn" id="edit-' + person.id + '" title="Editar persona">' +
-                '✏️' +
-              '</button>' +
-              '<button class="action-btn" id="delete-' + person.id + '" title="Eliminar persona">' +
-                '🗑️' +
-              '</button>' +
-            '</div>' +
-          '</div>';
 
-        // Event listeners para acciones
-        li.querySelector('#edit-' + person.id)?.addEventListener('click', () => {
-          // TODO: Implementar edición inline
-          console.log('Editar persona:', person.id);
+        const personItem = document.createElement('div');
+        personItem.className = 'person-item';
+
+        const avatarEl = document.createElement('div');
+        avatarEl.className = 'person-avatar';
+        if (isEmoji) avatarEl.style.cssText = 'background: transparent; color: inherit; border: 1px solid var(--dojo-border, #E5E7EB);';
+        avatarEl.textContent = person.avatar;
+
+        const infoEl = document.createElement('div');
+        infoEl.className = 'person-info';
+
+        const nameEl = document.createElement('div');
+        nameEl.className = 'person-name';
+        nameEl.textContent = person.name;
+
+        const statsEl = document.createElement('div');
+        statsEl.className = 'person-stats';
+        statsEl.textContent = `${taskCount} tarea${taskCount === 1 ? '' : 's'} asignada${taskCount === 1 ? '' : 's'}`;
+
+        infoEl.appendChild(nameEl);
+        infoEl.appendChild(statsEl);
+
+        const actEl = document.createElement('div');
+        actEl.className = 'person-actions';
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'action-btn';
+        editBtn.title = 'Editar persona';
+        editBtn.setAttribute('aria-label', `Editar ${person.name}`);
+        editBtn.textContent = '✏️';
+        editBtn.addEventListener('click', () => {
+          this._editingId = person.id;
+          this._renderPersonList();
         });
 
-        li.querySelector('#delete-' + person.id)?.addEventListener('click', () => {
-          this._handleDeletePerson(person.id);
-        });
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'action-btn';
+        deleteBtn.title = 'Eliminar persona';
+        deleteBtn.setAttribute('aria-label', `Eliminar ${person.name}`);
+        deleteBtn.textContent = '🗑️';
+        deleteBtn.addEventListener('click', () => this._handleDeletePerson(person.id));
+
+        actEl.appendChild(editBtn);
+        actEl.appendChild(deleteBtn);
+
+        personItem.appendChild(avatarEl);
+        personItem.appendChild(infoEl);
+        personItem.appendChild(actEl);
+
+        li.appendChild(personItem);
       }
 
       listEl.appendChild(li);

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -26,7 +26,7 @@
  * --dojo-primary, --dojo-radius, --dojo-radius-sm, --dojo-shadow
  */
 
-import type { Task, Column, Label, Priority, ActivityEvent, Subtask } from '../../../types/models.js';
+import type { Task, Column, Label, Priority, ActivityEvent, Subtask, Person } from '../../../types/models.js';
 import { parseMarkdown } from '../../../utils/markdown.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import { createLabel } from '../../../db/label.repository.js';
@@ -55,6 +55,7 @@ export class DojoTaskDetail extends HTMLElement {
   private _task: Task | null = null;
   private _columns: Column[] = [];
   private _allLabels: Label[] = [];
+  private _allPersons: Person[] = [];
   private _labelsPickerOpen = false;
   /** Preserva el overflow del body antes de abrir el panel (se restaura al cerrar). Fix #5 */
   private _prevOverflow: string = '';
@@ -110,10 +111,11 @@ export class DojoTaskDetail extends HTMLElement {
     return this._task?.id ?? null;
   }
 
-  openTask(task: Task, columns: Column[], labels: Label[]): void {
-    this._task           = { ...task };
-    this._columns        = columns;
-    this._allLabels      = labels;
+  openTask(task: Task, columns: Column[], labels: Label[], persons: Person[] = []): void {
+    this._task             = { ...task };
+    this._columns          = columns;
+    this._allLabels        = labels;
+    this._allPersons       = persons;
     this._labelsPickerOpen = false;
     this._buildContent();
     this._openPanel();
@@ -476,6 +478,26 @@ export class DojoTaskDetail extends HTMLElement {
         margin-top: 0.25rem;
       }
       .labels-picker.open { display: block; }
+      .labels-picker-opt {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        width: 100%;
+        padding: 0.4375rem 0.75rem;
+        background: transparent;
+        border: none;
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+        cursor: pointer;
+        font-family: inherit;
+        text-align: left;
+        transition: background 0.1s;
+      }
+      .labels-picker-opt:hover { background: var(--dojo-bg); }
+      .labels-picker-opt:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: -2px;
+      }
       .label-option {
         display: flex;
         align-items: center;
@@ -899,6 +921,7 @@ export class DojoTaskDetail extends HTMLElement {
     body.appendChild(this._buildDueDateField(task));
     body.appendChild(this._buildDescriptionField(task));
     body.appendChild(this._buildLabelsField(task));
+    body.appendChild(this._buildAssigneesField(task));
     body.appendChild(this._buildSubtasksField(task));
     body.appendChild(this._buildMetadata(task));
 
@@ -1675,6 +1698,144 @@ export class DojoTaskDetail extends HTMLElement {
     row.appendChild(clearBtn);
     section.appendChild(lbl);
     section.appendChild(row);
+    return section;
+  }
+
+  // ── Sección de asignados (US-29) ──────────────────────────────────────────
+
+  private _buildAssigneesField(task: Task): HTMLElement {
+    const section = document.createElement('div');
+    section.className = 'section';
+
+    const sectionLbl = document.createElement('span');
+    sectionLbl.className = 'section-lbl';
+    sectionLbl.textContent = 'Asignados';
+
+    const chips = document.createElement('div');
+    chips.className = 'labels-chips';
+    chips.setAttribute('aria-label', 'Personas asignadas a la tarea');
+
+    const pickerWrapper = document.createElement('div');
+    pickerWrapper.style.cssText = 'position:relative;display:inline-block;';
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'add-label-btn';
+    addBtn.setAttribute('aria-label', 'Asignar persona');
+    addBtn.textContent = '+ Asignar';
+
+    const picker = document.createElement('div');
+    picker.className = 'labels-picker';
+    picker.style.display = 'none';
+    picker.setAttribute('role', 'listbox');
+    picker.setAttribute('aria-label', 'Seleccionar persona a asignar');
+
+    let pickerOpen = false;
+
+    const closePicker = (): void => {
+      pickerOpen = false;
+      picker.style.display = 'none';
+    };
+
+    const rebuildChips = (): void => {
+      chips.innerHTML = '';
+      const currentIds = this._task?.assignees ?? [];
+      const assigned = currentIds
+        .map(id => this._allPersons.find(p => p.id === id))
+        .filter((p): p is Person => p !== undefined);
+
+      for (const person of assigned) {
+        const chip = document.createElement('span');
+        chip.className = 'label-chip';
+        chip.style.cssText = 'display:inline-flex;align-items:center;gap:0.25rem;padding:0.2rem 0.5rem;background:var(--dojo-surface);border:1px solid var(--dojo-border);border-radius:999px;font-size:0.75rem;';
+        chip.textContent = `${person.avatar || '👤'} ${person.name}`;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'label-chip-remove';
+        removeBtn.setAttribute('aria-label', `Desasignar a ${person.name}`);
+        removeBtn.textContent = '×';
+        removeBtn.addEventListener('click', () => {
+          if (!this._task) return;
+          const newIds = (this._task.assignees ?? []).filter(id => id !== person.id);
+          this._save({ assignees: newIds });
+          rebuildChips();
+          rebuildPicker();
+        });
+
+        chip.appendChild(removeBtn);
+        chips.appendChild(chip);
+      }
+
+      chips.appendChild(pickerWrapper);
+    };
+
+    const rebuildPicker = (): void => {
+      picker.innerHTML = '';
+      const currentIds = new Set(this._task?.assignees ?? []);
+      const available = this._allPersons.filter(p => !currentIds.has(p.id));
+
+      if (available.length === 0) {
+        const empty = document.createElement('p');
+        empty.style.cssText = 'padding:0.5rem;font-size:0.8125rem;color:var(--dojo-text-secondary);margin:0;';
+        empty.textContent = 'No hay personas disponibles.';
+        picker.appendChild(empty);
+        return;
+      }
+
+      for (const person of available) {
+        const opt = document.createElement('button');
+        opt.type = 'button';
+        opt.className = 'labels-picker-opt';
+        opt.setAttribute('role', 'option');
+        opt.textContent = `${person.avatar || '👤'} ${person.name}`;
+        opt.addEventListener('click', () => {
+          if (!this._task) return;
+          const newIds = [...(this._task.assignees ?? []), person.id];
+          this._save({ assignees: newIds });
+          closePicker();
+          rebuildChips();
+        });
+        picker.appendChild(opt);
+      }
+    };
+
+    addBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      pickerOpen = !pickerOpen;
+      if (pickerOpen) {
+        rebuildPicker();
+        picker.style.display = 'block';
+        requestAnimationFrame(() => picker.querySelector<HTMLElement>('button')?.focus());
+      } else {
+        closePicker();
+      }
+    });
+
+    picker.addEventListener('keydown', (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        closePicker();
+        addBtn.focus();
+      }
+    });
+
+    pickerWrapper.appendChild(addBtn);
+    pickerWrapper.appendChild(picker);
+
+    section.appendChild(sectionLbl);
+    section.appendChild(chips);
+
+    // Solo renderizar si hay personas en el directorio
+    if (this._allPersons.length > 0) {
+      rebuildChips();
+    } else {
+      const empty = document.createElement('p');
+      empty.style.cssText = 'font-size:0.8125rem;color:var(--dojo-text-secondary);margin:0.25rem 0;';
+      empty.textContent = 'No hay personas en el directorio. Crea personas desde el menú.';
+      section.appendChild(empty);
+    }
+
     return section;
   }
 

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -24,9 +24,10 @@
  * --dojo-danger, --dojo-radius, --dojo-radius-sm, --dojo-shadow
  */
 
-import type { Priority, Label, Project } from '../../../types/models.js';
+import type { Priority, Label, Project, Person } from '../../../types/models.js';
 import { getAllLabels, createLabel } from '../../../db/label.repository.js';
 import { getAllProjects } from '../../../db/project.repository.js';
+import { getAllPersons } from '../../../db/person.repository.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 
 const PRIORITIES: { value: Priority; label: string }[] = [
@@ -48,6 +49,9 @@ export class DojoTaskDialog extends HTMLElement {
   private _selectedLabelIds: Set<string> = new Set();
   // US-26: estado de proyectos
   private _allProjects: Project[] = [];
+  // US-29: estado de personas asignadas
+  private _allPersons: Person[] = [];
+  private _selectedAssigneeIds: Set<string> = new Set();
   // US-28: título prellenado desde la paleta de comandos
   private _prefillTitle = '';
 
@@ -76,13 +80,16 @@ export class DojoTaskDialog extends HTMLElement {
     this._columnName = columnName;
     this._prefillTitle = prefillTitle;
     this._selectedLabelIds = new Set();
-    // Cargar etiquetas (US-23) y proyectos (US-26), luego construir el formulario
+    this._selectedAssigneeIds = new Set();
+    // Cargar etiquetas (US-23), proyectos (US-26) y personas (US-29), luego construir el formulario
     Promise.all([
       getAllLabels().catch(() => [] as Label[]),
       getAllProjects().catch(() => [] as Project[]),
-    ]).then(([labels, projects]) => {
+      getAllPersons().catch(() => [] as Person[]),
+    ]).then(([labels, projects, persons]) => {
       this._allLabels = labels;
       this._allProjects = projects;
+      this._allPersons = persons;
       this._buildForm();
       this._open();
     });
@@ -137,6 +144,8 @@ export class DojoTaskDialog extends HTMLElement {
         box-shadow: var(--dojo-shadow);
         width: 100%;
         max-width: 560px;
+        max-height: calc(100vh - 2rem);
+        overflow-y: auto;
         padding: 1.5rem;
         display: flex;
         flex-direction: column;
@@ -195,6 +204,9 @@ export class DojoTaskDialog extends HTMLElement {
         box-sizing: border-box;
         transition: border-color 0.15s;
         font-family: inherit;
+      }
+      .label-option input[type="checkbox"] {
+        width: auto;
       }
       .field input:focus,
       .field textarea:focus,
@@ -1085,6 +1097,98 @@ export class DojoTaskDialog extends HTMLElement {
     renderChips();
     dialog.appendChild(labelsField);
 
+    // ── Campo: Personas asignadas (US-29) ─────────────────────────────────
+    if (this._allPersons.length > 0) {
+      const assigneesField = document.createElement('div');
+      assigneesField.className = 'field';
+
+      const assigneesLbl = document.createElement('label');
+      assigneesLbl.textContent = 'Asignados (opcional)';
+      assigneesField.appendChild(assigneesLbl);
+
+      const assigneesChips = document.createElement('div');
+      assigneesChips.className = 'labels-chips';
+      assigneesChips.setAttribute('aria-label', 'Personas asignadas seleccionadas');
+
+      const renderAssigneeChips = (): void => {
+        assigneesChips.innerHTML = '';
+        for (const personId of this._selectedAssigneeIds) {
+          const person = this._allPersons.find(p => p.id === personId);
+          if (!person) continue;
+          const chip = document.createElement('span');
+          chip.className = 'label-chip';
+          chip.style.cssText = 'background: var(--dojo-bg); border: 1px solid var(--dojo-border); color: var(--dojo-text-primary); gap: 0.25rem;';
+          chip.textContent = `${person.avatar} ${person.name}`;
+
+          const removeBtn = document.createElement('button');
+          removeBtn.className = 'label-chip-remove';
+          removeBtn.setAttribute('aria-label', `Quitar ${person.name}`);
+          removeBtn.textContent = '×';
+          removeBtn.addEventListener('click', () => {
+            this._selectedAssigneeIds.delete(personId);
+            renderAssigneeChips();
+            updateAssigneePicker();
+          });
+          chip.appendChild(removeBtn);
+          assigneesChips.appendChild(chip);
+        }
+
+        const addBtn = document.createElement('button');
+        addBtn.className = 'add-label-btn';
+        addBtn.type = 'button';
+        addBtn.textContent = '+ Asignar';
+        addBtn.addEventListener('click', () => {
+          const picker = assigneesField.querySelector<HTMLElement>('.assignee-picker');
+          if (picker) picker.classList.toggle('open');
+        });
+        assigneesChips.appendChild(addBtn);
+      };
+
+      assigneesField.appendChild(assigneesChips);
+
+      // Picker de personas
+      const assigneePicker = document.createElement('div');
+      assigneePicker.className = 'labels-picker assignee-picker';
+      assigneePicker.setAttribute('aria-label', 'Seleccionar personas');
+
+      const updateAssigneePicker = (): void => {
+        assigneePicker.innerHTML = '';
+        for (const person of this._allPersons) {
+          const opt = document.createElement('label');
+          opt.className = 'label-option';
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = this._selectedAssigneeIds.has(person.id);
+          cb.addEventListener('change', () => {
+            if (cb.checked) this._selectedAssigneeIds.add(person.id);
+            else this._selectedAssigneeIds.delete(person.id);
+            renderAssigneeChips();
+          });
+          const avatarSpan = document.createElement('span');
+          avatarSpan.textContent = person.avatar;
+          const nameSp = document.createElement('span');
+          nameSp.textContent = person.name;
+          opt.appendChild(cb);
+          opt.appendChild(avatarSpan);
+          opt.appendChild(nameSp);
+          assigneePicker.appendChild(opt);
+        }
+      };
+
+      assigneePicker.addEventListener('keydown', (ev: KeyboardEvent) => {
+        if (ev.key === 'Escape') {
+          ev.preventDefault();
+          assigneePicker.classList.remove('open');
+          assigneesChips.querySelector<HTMLElement>('.add-label-btn')?.focus();
+        }
+      });
+
+      updateAssigneePicker();
+      renderAssigneeChips();
+      assigneesField.appendChild(assigneePicker);
+      dialog.appendChild(assigneesField);
+    }
+
     // ── Acciones ───────────────────────────────────────────────────────────
     const actions = document.createElement('div');
     actions.className = 'actions';
@@ -1117,6 +1221,7 @@ export class DojoTaskDialog extends HTMLElement {
           description: descInput.value.trim(),
           priority:    priSelect.value as Priority,
           labelIds:    [...this._selectedLabelIds],
+          assignees:   [...this._selectedAssigneeIds],
           projectId:   projSelect.value || undefined,
           dueDate:     (() => {
             if (!dueInput.value) return null;


### PR DESCRIPTION
## Descripción

Corrección completa de la US-29 (Asignación de personas a tareas). La implementación previa existía estructuralmente pero era completamente no funcional. Este PR hace operativa la feature en todos sus componentes.

## Cambios

### `dojo-person-manager.ts`
- Añadida llamada a `_setupEventListeners()` al final de `_render()` — era la causa principal de que todo el panel no respondiera a ninguna interacción
- Implementado formulario de edición inline (nombre + grid de avatar) en `_renderPersonList()`
- Reemplazadas interpolaciones `innerHTML` con datos de usuario por `createElement` + `textContent` (**OWASP A3 XSS fix**)
- Añadidos `aria-label` a botones de editar/eliminar

### `dojo-task-dialog.ts`
- Se cargan personas en `openCreate()` junto a etiquetas y proyectos
- Añadida sección de asignados (chips de seleccionados + picker con checkboxes)
- El evento `dojo:dialog-create-task` ahora incluye `assignees: string[]`
- `max-height: calc(100vh - 2rem)` + `overflow-y: auto` en `.dialog` para evitar desbordamiento con listas largas
- Eliminado `document.addEventListener('click', anonymous)` acumulativo (**memory leak fix**)

### `dojo-task-detail.ts`
- `openTask()` acepta 4.º parámetro `persons: Person[] = []`
- Nuevo método `_buildAssigneesField(task)`: chips con × para desasignar + botón "+ Asignar" que abre picker
- Corregidos nombres de clase CSS: `labels-add-btn`, `label-chip-remove` (estaban mal → componente no se mostraba)
- Añadida regla CSS `.labels-picker-opt` (faltaba → opciones sin estilo)
- Corregido toggle del picker: `display = 'block'` en lugar de `''`
- Cierre del picker mediante tecla Escape con retorno del foco
- Eliminado `_shadow.addEventListener('click', anonymous, {capture:true})` acumulativo (**memory leak fix**)

### `dojo-kanban-board.ts`
- `_handleCreateTask` ahora pasa `assignees ?? []` a `createTask()` (antes siempre `[]`)
- `ActiveFilter` incluye `assigneeId?: string`
- Selector "Asignado a:" en la barra de filtros con `_rebuildPersonFilterSelect()`
- `_filterTasks()` filtra por `assigneeId`
- `_clearAllFilters()` y `_updateClearAllVisibility()` actualizados
- `openTaskById()` y `_onTaskOpen()` pasan `persons` a `detail.openTask()`

## Causa raíz de la no-funcionalidad original

1. `_setupEventListeners()` definida pero nunca llamada → panel sin interactividad
2. Edición de persona: `console.log('TODO')` sin implementar
3. `dojo-task-dialog.ts` no cargaba personas, no tenía UI, no incluía `assignees` en el evento
4. `dojo-task-detail.ts` sin ningún código relacionado con personas
5. `dojo-kanban-board.ts` siempre creaba tareas con `assignees: []`, sin filtro por persona

## Testing

- Build TypeScript limpio (`tsc` sin errores)
- Auditoría de seguridad: sin secretos ni dependencias en los cambios

Closes #47