### PR TITLE
feat(ui): US-35 — Larger edit dialog (modal 90vw/90vh + two-column layout)

### DIFF
--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -185,25 +185,44 @@ export class DojoTaskDetail extends HTMLElement {
         pointer-events: auto;
       }
 
-      /* ── Panel lateral ── */
+      /* ── Modal centrado (US-35) ── */
       .panel {
         position: fixed;
-        top: 0;
-        right: 0;
-        height: 100%;
-        width: 400px;
+        top: 50%;
+        left: 50%;
+        width: 90vw;
+        height: 90vh;
         max-width: 100vw;
+        max-height: 100vh;
         background: var(--dojo-surface);
-        border-left: 1px solid var(--dojo-border);
-        box-shadow: -4px 0 24px rgba(0,0,0,0.12);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius, 8px);
+        box-shadow: 0 24px 64px rgba(0,0,0,0.22);
         z-index: 201;
         display: flex;
         flex-direction: column;
-        transform: translateX(100%);
-        transition: transform 0.22s ease;
+        transform: translate(-50%, -50%) scale(0.96);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.22s ease, opacity 0.22s ease;
         overflow: hidden;
       }
-      :host([open]) .panel { transform: translateX(0); }
+      :host([open]) .panel {
+        transform: translate(-50%, -50%) scale(1);
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      /* ── Pantalla completa en móvil (< 768px) ── */
+      @media (max-width: 767px) {
+        .panel {
+          width: 100vw;
+          height: 100vh;
+          border-radius: 0;
+          top: 50%;
+          left: 50%;
+        }
+      }
 
       /* ── Encabezado fijo ── */
       .panel-header {
@@ -240,9 +259,17 @@ export class DojoTaskDetail extends HTMLElement {
         outline-offset: 2px;
       }
 
-      /* ── Cuerpo scrollable ── */
+      /* ── Cuerpo: dos columnas (US-35) ── */
       .panel-body {
         flex: 1;
+        overflow: hidden;
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 0;
+      }
+
+      .panel-main,
+      .panel-aside {
         overflow-y: auto;
         padding: 1.25rem;
         display: flex;
@@ -251,8 +278,30 @@ export class DojoTaskDetail extends HTMLElement {
         scrollbar-width: thin;
         scrollbar-color: var(--dojo-border) transparent;
       }
-      .panel-body::-webkit-scrollbar       { width: 4px; }
-      .panel-body::-webkit-scrollbar-thumb { background: var(--dojo-border); border-radius: 2px; }
+      .panel-main::-webkit-scrollbar,
+      .panel-aside::-webkit-scrollbar       { width: 4px; }
+      .panel-main::-webkit-scrollbar-thumb,
+      .panel-aside::-webkit-scrollbar-thumb { background: var(--dojo-border); border-radius: 2px; }
+
+      .panel-main {
+        border-right: 1px solid var(--dojo-border);
+      }
+
+      /* Colapso a columna única en móvil */
+      @media (max-width: 767px) {
+        .panel-body {
+          grid-template-columns: 1fr;
+          overflow-y: auto;
+        }
+        .panel-main {
+          border-right: none;
+          border-bottom: 1px solid var(--dojo-border);
+          overflow-y: visible;
+        }
+        .panel-aside {
+          overflow-y: visible;
+        }
+      }
 
       /* ── Sección genérica ── */
       .section { display: flex; flex-direction: column; gap: 0.375rem; }
@@ -881,8 +930,9 @@ export class DojoTaskDetail extends HTMLElement {
     // Panel (vacío hasta que se llame a openTask)
     const panel = document.createElement('div');
     panel.className = 'panel';
-    panel.setAttribute('role', 'complementary');
-    panel.setAttribute('aria-label', 'Detalle de tarea');
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'true');
+    panel.setAttribute('aria-labelledby', 'detail-panel-title');
     this._shadow.appendChild(panel);
   }
 
@@ -900,6 +950,7 @@ export class DojoTaskDetail extends HTMLElement {
 
     const hdrTitle = document.createElement('span');
     hdrTitle.className = 'panel-hdr-title';
+    hdrTitle.id = 'detail-panel-title';
     hdrTitle.textContent = 'Detalle de tarea';
 
     const closeBtn = document.createElement('button');
@@ -912,25 +963,36 @@ export class DojoTaskDetail extends HTMLElement {
     header.appendChild(closeBtn);
     panel.appendChild(header);
 
-    // ── Body ────────────────────────────────────────────────────────────────
+    // ── Body — layout dos columnas (US-35) ──────────────────────────────────
     const body = document.createElement('div');
     body.className = 'panel-body';
 
-    body.appendChild(this._buildTitleField(task));
-    body.appendChild(this._buildStatusPriorityRow(task));
-    body.appendChild(this._buildDueDateField(task));
-    body.appendChild(this._buildDescriptionField(task));
-    body.appendChild(this._buildLabelsField(task));
-    body.appendChild(this._buildAssigneesField(task));
-    body.appendChild(this._buildSubtasksField(task));
-    body.appendChild(this._buildMetadata(task));
+    // Columna principal: título, descripción, subtareas, actividad
+    const main = document.createElement('div');
+    main.className = 'panel-main';
+
+    main.appendChild(this._buildTitleField(task));
+    main.appendChild(this._buildDescriptionField(task));
+    main.appendChild(this._buildSubtasksField(task));
 
     // US-20: Sección de actividad (se carga de forma asíncrona)
     const activityContainer = document.createElement('div');
     activityContainer.className = 'activity-section';
-    body.appendChild(activityContainer);
+    main.appendChild(activityContainer);
     this._loadActivitySection(task.id, activityContainer);
 
+    // Columna lateral: metadatos de control
+    const aside = document.createElement('div');
+    aside.className = 'panel-aside';
+
+    aside.appendChild(this._buildStatusPriorityRow(task));
+    aside.appendChild(this._buildDueDateField(task));
+    aside.appendChild(this._buildLabelsField(task));
+    aside.appendChild(this._buildAssigneesField(task));
+    aside.appendChild(this._buildMetadata(task));
+
+    body.appendChild(main);
+    body.appendChild(aside);
     panel.appendChild(body);
 
     // ── Footer de eliminación (US-06) ──────────────────────────────────────

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -133,6 +133,7 @@ export class DojoTaskDetail extends HTMLElement {
 
   private _openPanel(): void {
     this.setAttribute('open', '');
+    this._shadow.querySelector('.panel')?.removeAttribute('aria-hidden'); // H1
     this._prevOverflow = document.body.style.overflow;  // Fix #5
     document.body.style.overflow = 'hidden';
     // Guarda de duplicados — igual que en dojo-task-dialog
@@ -146,6 +147,7 @@ export class DojoTaskDetail extends HTMLElement {
 
   private _closePanel(): void {
     this.removeAttribute('open');
+    this._shadow.querySelector('.panel')?.setAttribute('aria-hidden', 'true'); // H1
     document.body.style.overflow = this._prevOverflow;  // Fix #5
     document.removeEventListener('keydown', this._onDocKeydown);
   }
@@ -219,8 +221,6 @@ export class DojoTaskDetail extends HTMLElement {
           width: 100vw;
           height: 100vh;
           border-radius: 0;
-          top: 50%;
-          left: 50%;
         }
       }
 
@@ -933,6 +933,7 @@ export class DojoTaskDetail extends HTMLElement {
     panel.setAttribute('role', 'dialog');
     panel.setAttribute('aria-modal', 'true');
     panel.setAttribute('aria-labelledby', 'detail-panel-title');
+    panel.setAttribute('aria-hidden', 'true'); // oculto por defecto — H1
     this._shadow.appendChild(panel);
   }
 

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -143,7 +143,7 @@ export class DojoTaskDialog extends HTMLElement {
         border-radius: var(--dojo-radius);
         box-shadow: var(--dojo-shadow);
         width: 100%;
-        max-width: 560px;
+        max-width: 860px;
         max-height: calc(100vh - 2rem);
         overflow-y: auto;
         padding: 1.5rem;
@@ -151,6 +151,22 @@ export class DojoTaskDialog extends HTMLElement {
         flex-direction: column;
         gap: 1.125rem;
         animation: dlg-in 0.18s ease;
+      }
+
+      /* ── Layout dos columnas (formulario ampliado) ── */
+      .dialog-body {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        gap: 1.25rem;
+      }
+      .dialog-main,
+      .dialog-aside {
+        display: flex;
+        flex-direction: column;
+        gap: 1.125rem;
+      }
+      @media (max-width: 640px) {
+        .dialog-body { grid-template-columns: 1fr; }
       }
       @keyframes dlg-in {
         from { opacity: 0; transform: scale(0.96) translateY(-8px); }
@@ -222,7 +238,7 @@ export class DojoTaskDialog extends HTMLElement {
 
       .field textarea {
         resize: vertical;
-        min-height: 120px;
+        min-height: 180px;
         line-height: 1.5;
       }
 
@@ -534,6 +550,20 @@ export class DojoTaskDialog extends HTMLElement {
     subtitle.textContent = `En columna: ${this._columnName}`;
     dialog.appendChild(subtitle);
 
+    // ── Cuerpo: dos columnas ──────────────────────────────────────────────
+    const formBody = document.createElement('div');
+    formBody.className = 'dialog-body';
+
+    const formMain = document.createElement('div');
+    formMain.className = 'dialog-main';
+
+    const formAside = document.createElement('div');
+    formAside.className = 'dialog-aside';
+
+    formBody.appendChild(formMain);
+    formBody.appendChild(formAside);
+    dialog.appendChild(formBody);
+
     // ── Campo: Título (obligatorio, máx 120) ───────────────────────────────
     const MAX_TITLE = 120;
     const titleField = document.createElement('div');
@@ -581,7 +611,7 @@ export class DojoTaskDialog extends HTMLElement {
 
     titleField.appendChild(titleInput);
     titleField.appendChild(titleError);
-    dialog.appendChild(titleField);
+    formMain.appendChild(titleField);
 
     // ── Campo: Descripción (opcional) ─────────────────────────────────────
     const descField = document.createElement('div');
@@ -595,12 +625,12 @@ export class DojoTaskDialog extends HTMLElement {
     const descInput = document.createElement('textarea');
     descInput.id = 'task-desc-input';
     descInput.placeholder = 'Describe la tarea…';
-    descInput.rows = 5;
+    descInput.rows = 10;
     descInput.maxLength = MAX_DESC;
 
     descField.appendChild(descLabel);
     descField.appendChild(descInput);
-    dialog.appendChild(descField);
+    formMain.appendChild(descField);
 
     // ── Campo: Prioridad (default medium) ─────────────────────────────────
     const priField = document.createElement('div');
@@ -624,7 +654,7 @@ export class DojoTaskDialog extends HTMLElement {
 
     priField.appendChild(priLabel);
     priField.appendChild(priSelect);
-    dialog.appendChild(priField);
+    formAside.appendChild(priField);
 
     // ── Campo: Fecha de vencimiento (opcional, US-17) ─────────────────────
     const dueField = document.createElement('div');
@@ -641,7 +671,7 @@ export class DojoTaskDialog extends HTMLElement {
 
     dueField.appendChild(dueLabel);
     dueField.appendChild(dueInput);
-    dialog.appendChild(dueField);
+    formAside.appendChild(dueField);
 
     // ── Campo: Proyecto (US-26) ────────────────────────────────────────────
     const projField = document.createElement('div');
@@ -666,7 +696,7 @@ export class DojoTaskDialog extends HTMLElement {
 
     projField.appendChild(projLabel);
     projField.appendChild(projSelect);
-    dialog.appendChild(projField);
+    formAside.appendChild(projField);
 
     // ── Campo: Etiquetas (US-23) ──────────────────────────────────────────
     const labelsField = document.createElement('div');
@@ -1095,7 +1125,7 @@ export class DojoTaskDialog extends HTMLElement {
     };
 
     renderChips();
-    dialog.appendChild(labelsField);
+    formAside.appendChild(labelsField);
 
     // ── Campo: Personas asignadas (US-29) ─────────────────────────────────
     if (this._allPersons.length > 0) {
@@ -1186,7 +1216,7 @@ export class DojoTaskDialog extends HTMLElement {
       updateAssigneePicker();
       renderAssigneeChips();
       assigneesField.appendChild(assigneePicker);
-      dialog.appendChild(assigneesField);
+      formAside.appendChild(assigneesField);
     }
 
     // ── Acciones ───────────────────────────────────────────────────────────

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -57,7 +57,32 @@ export class DojoTaskDialog extends HTMLElement {
 
   // Referencia estable para poder eliminar el listener de teclado
   private _onDocKeydown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this._isOpen()) this._close();
+    if (!this._isOpen()) return;
+    if (e.key === 'Escape') {
+      this._close();
+      return;
+    }
+    // Focus trap: mantener Tab dentro del diálogo (H4 — WCAG 2.1 SC 2.1.2)
+    if (e.key === 'Tab') {
+      const dialog = this._shadow.querySelector<HTMLElement>('.dialog');
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(el => !el.hidden && el.offsetParent !== null);
+      if (focusable.length < 2) return;
+      const first  = focusable[0];
+      const last   = focusable[focusable.length - 1];
+      const active = this._shadow.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
   };
 
   constructor() {
@@ -165,7 +190,7 @@ export class DojoTaskDialog extends HTMLElement {
         flex-direction: column;
         gap: 1.125rem;
       }
-      @media (max-width: 640px) {
+      @media (max-width: 767px) {
         .dialog-body { grid-template-columns: 1fr; }
       }
       @keyframes dlg-in {


### PR DESCRIPTION
## Descripción

Implementación de **US-35 — Larger Edit Dialog**: transforma el panel lateral de edición de tarea y el diálogo de creación en modales ampliados con layout de dos columnas.

---

## Cambios incluidos

### `dojo-task-detail` (edición de tarea)
- Panel lateral `400px` reemplazado por modal centrado **90vw × 90vh**
- Animación `translateX` → `fade + scale(0.96→1)` en 220 ms
- Body dividido en dos columnas CSS Grid (`panel-main 2fr` / `panel-aside 1fr`)
  - **Main**: título, descripción, subtareas, historial de actividad
  - **Aside**: estado, prioridad, fecha de vencimiento, etiquetas, asignados, metadatos
- Scroll independiente por columna; header y footer siempre visibles
- Mobile `< 768px`: pantalla completa `100vw × 100vh`, columna única
- ARIA: `role="dialog"`, `aria-modal="true"`, `aria-labelledby="detail-panel-title"`

### `dojo-task-dialog` (creación de tarea)
- Ampliado de `max-width: 560px` a `max-width: 860px`
- Body dividido en `dialog-main (2fr)` / `dialog-aside (1fr)`
  - **Main**: título + textarea descripción (`rows=10`, `min-height: 180px`)
  - **Aside**: prioridad, fecha, proyecto, etiquetas, asignados
- Mobile `≤ 640px`: colapsa a columna única

---

## Archivos modificados

| Archivo | Tipo de cambio |
|---|---|
| `src/components/organisms/dojo-task-detail/dojo-task-detail.ts` | CSS modal + DOM dos columnas + ARIA |
| `src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts` | CSS 860px + DOM dos columnas |

---

## Validación

- [x] `npx tsc --noEmit` — cero errores
- [x] Sin información sensible, tokens ni dependencias en los cambios
- [x] Responsive funcional en ambos componentes

---

Closes #73