### PR TITLE
feat(db): columnas por defecto estandarizadas en tableros nuevos (US-37)

### DIFF
--- a/src/db/column.repository.ts
+++ b/src/db/column.repository.ts
@@ -91,18 +91,37 @@ export async function deleteColumn(id: string): Promise<void> {
 
 /**
  * Inserta las columnas por defecto para un tablero dado (US-37).
- * Es idempotente: no inserta nada si el tablero ya tiene columnas.
+ * Es idempotente: la comprobación y la escritura ocurren en la misma
+ * transacción `readwrite` para evitar race conditions entre pestañas.
+ * Emite `column:created` por cada columna insertada (US-30).
  * @param boardId - ID del tablero al que pertenecerán las columnas.
  */
 export async function seedDefaultColumns(boardId: string): Promise<void> {
-  const existing = await getColumnsByBoard(boardId);
-  if (existing.length > 0) return;
-
   const { store, tx } = await getStore('columns', 'readwrite');
-  for (const col of DEFAULT_COLUMNS) {
-    store.add({ ...col, id: generateUUID(), boardId });
+
+  // Comprobar existencia dentro de la misma transacción para evitar TOCTOU
+  const index    = store.index('by-board');
+  const existing = await idbRequest<Column[]>(index.getAll(boardId));
+  if (existing.length > 0) {
+    tx.abort();
+    return;
+  }
+
+  const newColumns: Column[] = DEFAULT_COLUMNS.map(col => ({
+    ...col,
+    id: generateUUID(),
+    boardId,
+  }));
+
+  for (const col of newColumns) {
+    store.add(col);
   }
   await idbTransaction(tx);
+
+  // Notificar a otras pestañas (US-30)
+  for (const col of newColumns) {
+    emitSync('column:created', col.id, col);
+  }
 }
 
 /**

--- a/src/db/column.repository.ts
+++ b/src/db/column.repository.ts
@@ -90,10 +90,14 @@ export async function deleteColumn(id: string): Promise<void> {
 }
 
 /**
- * Inserta las columnas por defecto para un tablero dado.
+ * Inserta las columnas por defecto para un tablero dado (US-37).
+ * Es idempotente: no inserta nada si el tablero ya tiene columnas.
  * @param boardId - ID del tablero al que pertenecerán las columnas.
  */
 export async function seedDefaultColumns(boardId: string): Promise<void> {
+  const existing = await getColumnsByBoard(boardId);
+  if (existing.length > 0) return;
+
   const { store, tx } = await getStore('columns', 'readwrite');
   for (const col of DEFAULT_COLUMNS) {
     store.add({ ...col, id: generateUUID(), boardId });

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@
 import { openDatabase } from './db/database.js';
 import { seedDefaultLabels } from './db/label.repository.js';
 import { seedDefaultProject } from './db/project.repository.js';
+import { getAllBoards } from './db/board.repository.js';
+import { seedDefaultColumns } from './db/column.repository.js';
 import { initTheme } from './utils/theme.js';
 import { initializeUISync } from './utils/ui-sync.js';
 
@@ -34,7 +36,12 @@ async function bootstrap(): Promise<void> {
     // 3b. Seed de proyecto por defecto "General" (US-26)
     await seedDefaultProject();
 
-    // 3c. Inicializar sincronización entre pestañas (US-30)
+    // 3c. Seed de columnas por defecto para tableros sin columnas (US-37)
+    //     Cubre: primer arranque y usuarios migrados que aún no tienen columnas.
+    const boards = await getAllBoards();
+    await Promise.all(boards.map(b => seedDefaultColumns(b.id)));
+
+    // 3d. Inicializar sincronización entre pestañas (US-30)
     initializeUISync();
 
     // 4. Registrar Web Components — US-01 Visualización del tablero Kanban

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,12 @@
  * main.ts — Entry point de la aplicación Dojo Kanban.
  *
  * Responsabilidades:
- *   1. Inicializar la base de datos IndexedDB.
- *   2. Insertar columnas por defecto si es la primera ejecución.
- *   3. Insertar etiquetas por defecto si es la primera ejecución.
- *   4. Registrar todos los Web Components (Custom Elements).
- *   5. Montar el componente raíz <dojo-app> en el DOM.
+ *   1. Aplicar el tema (light/dark/system).
+ *   2. Abrir (o crear) la base de datos IndexedDB.
+ *   3. Seeds iniciales: etiquetas, proyecto y columnas por defecto (US-37).
+ *   4. Inicializar sincronización multi-pestaña (US-30).
+ *   5. Registrar todos los Web Components (Custom Elements).
+ *   6. Montar el componente raíz <dojo-app> en el DOM.
  *
  * Este archivo es el único módulo referenciado desde public/index.html:
  *   <script type="module" src="./main.js"></script>

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -80,9 +80,9 @@ export interface Column {
 /** Columnas por defecto que se insertan al inicializar la base de datos (US-37). */
 export const DEFAULT_COLUMNS: Omit<Column, 'id' | 'boardId'>[] = [
   { name: 'Backlog',      icon: '📋', order: 0, isDefault: true },
-  { name: 'Por hacer',    icon: '🔲', order: 1, isDefault: true },
-  { name: 'En progreso',  icon: '🔄', order: 2, isDefault: true },
-  { name: 'En revisión',  icon: '🔍', order: 3, isDefault: true },
+  { name: 'Por Hacer',    icon: '🔲', order: 1, isDefault: true },
+  { name: 'En Progreso',  icon: '🔄', order: 2, isDefault: true },
+  { name: 'En Revisión',  icon: '🔍', order: 3, isDefault: true },
   { name: 'Hecho',        icon: '✅', order: 4, isDefault: true },
   { name: 'Bloqueado',    icon: '🚫', order: 5, isDefault: true },
 ];

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -73,16 +73,18 @@ export interface Column {
   order: number;
   /** Color de acento opcional en formato hexadecimal (ej. "#1D4ED8"). */
   color?: string;
+  /** Indica que la columna fue creada por el seed inicial (US-37). No bloquea edición ni eliminación. */
+  isDefault?: boolean;
 }
 
-/** Columnas por defecto que se insertan al inicializar la base de datos. */
+/** Columnas por defecto que se insertan al inicializar la base de datos (US-37). */
 export const DEFAULT_COLUMNS: Omit<Column, 'id' | 'boardId'>[] = [
-  { name: 'Backlog',      icon: '📋', order: 0 },
-  { name: 'Por hacer',    icon: '🔲', order: 1 },
-  { name: 'En progreso',  icon: '🔄', order: 2 },
-  { name: 'En revisión',  icon: '🔍', order: 3 },
-  { name: 'Hecho',        icon: '✅', order: 4 },
-  { name: 'Bloqueado',    icon: '🚫', order: 5 },
+  { name: 'Backlog',      icon: '📋', order: 0, isDefault: true },
+  { name: 'Por hacer',    icon: '🔲', order: 1, isDefault: true },
+  { name: 'En progreso',  icon: '🔄', order: 2, isDefault: true },
+  { name: 'En revisión',  icon: '🔍', order: 3, isDefault: true },
+  { name: 'Hecho',        icon: '✅', order: 4, isDefault: true },
+  { name: 'Bloqueado',    icon: '🚫', order: 5, isDefault: true },
 ];
 
 // ── Board (US-22) ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Descripción

Implementa la US-37 — Columnas por defecto estandarizadas en tableros nuevos.

Al crear un tablero nuevo (o en el primer arranque sin datos) la aplicación inicializa automáticamente 6 columnas Kanban estándar, sin requerir configuración manual por parte del usuario.

---

## Cambios

### `src/types/models.ts`
- Añadido campo `isDefault?: boolean` a la interfaz `Column`.
- Constante `DEFAULT_COLUMNS` actualizada: todas las entradas incluyen `isDefault: true`.

### `src/db/column.repository.ts`
- `seedDefaultColumns(boardId)` es ahora **idempotente**: comprueba si el tablero ya tiene columnas antes de insertar; si existen, retorna sin hacer nada.

### `src/main.ts`
- Imports añadidos: `getAllBoards`, `seedDefaultColumns`.
- Paso 3c en `bootstrap()`: obtiene todos los tableros y ejecuta `seedDefaultColumns` para cada uno, cubriendo tanto el primer arranque (base de datos vacía) como usuarios migrados sin columnas previas.

---

## Columnas inicializadas

| Orden | Icono | Nombre       |
|-------|-------|--------------|
| 0     | 📋    | Backlog      |
| 1     | 🔲    | Por hacer    |
| 2     | 🔄    | En progreso  |
| 3     | 🔍    | En revisión  |
| 4     | ✅    | Hecho        |
| 5     | 🚫    | Bloqueado    |

---

## Criterios de aceptación cubiertos

- ✅ Primer arranque sin datos → 6 columnas creadas automáticamente.
- ✅ Recarga con columnas existentes → sin duplicados (idempotencia en `seedDefaultColumns`).
- ✅ Nuevo tablero desde UI → `dojo-board-selector` ya llamaba a `seedDefaultColumns`; ahora la guarda idempotente lo protege también contra doble invocación.
- ✅ Columnas editables y eliminables (`isDefault` no bloquea ninguna operación).
- ✅ Sin errores de compilación TypeScript (`tsc --noEmit` limpio).

---

Closes #68