### PR TITLE
feat(kanban): add WIP limits per column (US-32)

### DIFF
--- a/src/components/atoms/dojo-column-header/dojo-column-header.ts
+++ b/src/components/atoms/dojo-column-header/dojo-column-header.ts
@@ -188,19 +188,17 @@ export class DojoColumnHeader extends HTMLElement {
     header.appendChild(nameSpan);
 
     // US-32: indicador visual WIP
-    if (wipState === 'warning') {
+    const wipIndicators: Record<string, { icon: string; label: string; tooltip: string }> = {
+      warning:  { icon: '⚠️', label: 'Advertencia: próximo al límite WIP', tooltip: `Próximo al límite WIP (${totalTasks}/${wipLimit})` },
+      exceeded: { icon: '🔴', label: 'Límite WIP superado',                tooltip: `Límite WIP superado (${totalTasks}/${wipLimit})` },
+    };
+    const wipCfg = wipIndicators[wipState];
+    if (wipCfg) {
       const indicator = document.createElement('span');
       indicator.className = 'wip-indicator';
-      indicator.textContent = '⚠️';
-      indicator.title = `Próximo al límite WIP (${totalTasks}/${wipLimit})`;
-      indicator.setAttribute('aria-label', `Advertencia: próximo al límite WIP`);
-      header.appendChild(indicator);
-    } else if (wipState === 'exceeded') {
-      const indicator = document.createElement('span');
-      indicator.className = 'wip-indicator';
-      indicator.textContent = '🔴';
-      indicator.title = `Límite WIP superado (${totalTasks}/${wipLimit})`;
-      indicator.setAttribute('aria-label', `Límite WIP superado`);
+      indicator.textContent = wipCfg.icon;
+      indicator.title = wipCfg.tooltip;
+      indicator.setAttribute('aria-label', wipCfg.label);
       header.appendChild(indicator);
     }
 

--- a/src/components/atoms/dojo-column-header/dojo-column-header.ts
+++ b/src/components/atoms/dojo-column-header/dojo-column-header.ts
@@ -14,20 +14,21 @@
  * | count         | number | Número de tareas visibles                           |
  * | total-count   | number | Total de tareas (sin filtro). Si omitido = count    |
  * | accent-color  | string | Color hex de acento opcional (borde superior)       |
+ * | wip-limit     | number | Límite WIP de la columna (US-32). Omitido = sin lím |
  *
  * ## Eventos despachados
  * Ninguno en esta versión.
  *
  * ## CSS Custom Properties heredadas
  * --dojo-text-primary, --dojo-text-secondary, --dojo-surface, --dojo-border,
- * --dojo-radius, --dojo-bg
+ * --dojo-radius, --dojo-bg, --dojo-warning, --dojo-danger
  */
 
 export class DojoColumnHeader extends HTMLElement {
   static readonly TAG = 'dojo-column-header';
 
   static get observedAttributes(): string[] {
-    return ['icon', 'column-name', 'count', 'total-count', 'accent-color'];
+    return ['icon', 'column-name', 'count', 'total-count', 'accent-color', 'wip-limit'];
   }
 
   private _shadow: ShadowRoot;
@@ -55,11 +56,28 @@ export class DojoColumnHeader extends HTMLElement {
     return t !== null ? Number(t) : this._count;
   }
   private get _accentColor(): string | null { return this.getAttribute('accent-color'); }
+  private get _wipLimit(): number | null {
+    const v = this.getAttribute('wip-limit');
+    if (v === null) return null;
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 1 ? n : null;
+  }
 
   // ── Render ───────────────────────────────────────────────────────────────
 
   private _render(): void {
     const hasFilter  = this._count !== this._totalCount;
+    const wipLimit   = this._wipLimit;
+    const totalTasks = this._totalCount;
+
+    // US-32: determinar estado WIP
+    let wipState: 'none' | 'normal' | 'warning' | 'exceeded' = 'none';
+    if (wipLimit !== null) {
+      if (totalTasks >= wipLimit)            wipState = 'exceeded';
+      else if (totalTasks >= wipLimit * 0.8) wipState = 'warning';
+      else                                    wipState = 'normal';
+    }
+
     const countLabel = hasFilter
       ? `${this._count} / ${this._totalCount}`
       : `${this._count}`;
@@ -116,6 +134,23 @@ export class DojoColumnHeader extends HTMLElement {
         color: var(--dojo-primary, #1D4ED8);
         border-color: var(--dojo-primary, #1D4ED8);
       }
+      /* US-32: estados WIP */
+      .badge[data-wip="warning"] {
+        color: var(--dojo-warning, #D97706);
+        border-color: var(--dojo-warning, #D97706);
+        background: color-mix(in srgb, var(--dojo-warning, #D97706) 10%, var(--dojo-bg));
+      }
+      .badge[data-wip="exceeded"] {
+        color: var(--dojo-danger, #DC2626);
+        border-color: var(--dojo-danger, #DC2626);
+        background: color-mix(in srgb, var(--dojo-danger, #DC2626) 10%, var(--dojo-bg));
+        font-weight: 700;
+      }
+      .wip-indicator {
+        font-size: 0.8125rem;
+        flex-shrink: 0;
+        cursor: default;
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -137,15 +172,38 @@ export class DojoColumnHeader extends HTMLElement {
     const badge = document.createElement('span');
     badge.className = 'badge';
     badge.dataset.filtered = String(hasFilter);
-    badge.textContent = countLabel;
+    if (wipState !== 'none') badge.dataset.wip = wipState;
+    badge.textContent = wipLimit !== null
+      ? `${totalTasks} / ${wipLimit}`
+      : countLabel;
     badge.setAttribute('aria-label',
-      hasFilter
-        ? `${this._count} tareas visibles de ${this._totalCount} totales`
-        : `${this._count} tareas`
+      wipLimit !== null
+        ? `${totalTasks} de ${wipLimit} tareas (límite WIP)`
+        : hasFilter
+          ? `${this._count} tareas visibles de ${this._totalCount} totales`
+          : `${this._count} tareas`
     );
 
     header.appendChild(iconSpan);
     header.appendChild(nameSpan);
+
+    // US-32: indicador visual WIP
+    if (wipState === 'warning') {
+      const indicator = document.createElement('span');
+      indicator.className = 'wip-indicator';
+      indicator.textContent = '⚠️';
+      indicator.title = `Próximo al límite WIP (${totalTasks}/${wipLimit})`;
+      indicator.setAttribute('aria-label', `Advertencia: próximo al límite WIP`);
+      header.appendChild(indicator);
+    } else if (wipState === 'exceeded') {
+      const indicator = document.createElement('span');
+      indicator.className = 'wip-indicator';
+      indicator.textContent = '🔴';
+      indicator.title = `Límite WIP superado (${totalTasks}/${wipLimit})`;
+      indicator.setAttribute('aria-label', `Límite WIP superado`);
+      header.appendChild(indicator);
+    }
+
     header.appendChild(badge);
     this._shadow.appendChild(header);
   }

--- a/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
+++ b/src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts
@@ -41,7 +41,7 @@ export class DojoKanbanColumn extends HTMLElement {
   static readonly TAG = 'dojo-kanban-column';
 
   static get observedAttributes(): string[] {
-    return ['column-id', 'column-name', 'icon', 'count', 'total-count', 'accent-color'];
+    return ['column-id', 'column-name', 'icon', 'count', 'total-count', 'accent-color', 'wip-limit'];
   }
 
   private _shadow: ShadowRoot;
@@ -80,6 +80,7 @@ export class DojoKanbanColumn extends HTMLElement {
   private get _count(): string      { return this.getAttribute('count') ?? '0'; }
   private get _totalCount(): string { return this.getAttribute('total-count') ?? this._count; }
   private get _accentColor(): string | null { return this.getAttribute('accent-color'); }
+  private get _wipLimit(): string | null { return this.getAttribute('wip-limit'); }
 
   // ── Render ───────────────────────────────────────────────────────────────
 
@@ -182,6 +183,7 @@ export class DojoKanbanColumn extends HTMLElement {
     header.setAttribute('count', this._count);
     header.setAttribute('total-count', this._totalCount);
     if (this._accentColor) header.setAttribute('accent-color', this._accentColor);
+    if (this._wipLimit) header.setAttribute('wip-limit', this._wipLimit);
     headerRow.appendChild(header);
 
     const menu = document.createElement('dojo-column-menu');
@@ -249,6 +251,8 @@ export class DojoKanbanColumn extends HTMLElement {
     header.setAttribute('total-count', this._totalCount);
     if (this._accentColor) header.setAttribute('accent-color', this._accentColor);
     else header.removeAttribute('accent-color');
+    if (this._wipLimit) header.setAttribute('wip-limit', this._wipLimit);
+    else header.removeAttribute('wip-limit');
   }
 
   // ── Drag & Drop de columnas (reorder) ────────────────────────────────────

--- a/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
+++ b/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
@@ -572,18 +572,20 @@ export class DojoColumnDialog extends HTMLElement {
     field.className = 'field';
     const lbl = document.createElement('label');
     lbl.textContent = 'Límite WIP';
-    lbl.setAttribute('for', 'col-wip-input');
+    const inputId = `col-wip-input-${this._mode}`;
+    const hintId = `wip-hint-${this._mode}`;
+    lbl.setAttribute('for', inputId);
     const input = document.createElement('input');
-    input.id = 'col-wip-input';
+    input.id = inputId;
     input.type = 'number';
     input.min = '1';
     input.placeholder = 'Sin límite';
-    input.setAttribute('aria-describedby', 'wip-hint');
+    input.setAttribute('aria-describedby', hintId);
     if (currentValue !== null && currentValue !== undefined) {
       input.value = String(currentValue);
     }
     const hint = document.createElement('span');
-    hint.id = 'wip-hint';
+    hint.id = hintId;
     hint.style.cssText = 'font-size:0.75rem;color:var(--dojo-text-secondary);';
     hint.textContent = 'Máximo de tareas permitidas. Vacío = sin límite.';
     field.appendChild(lbl);

--- a/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
+++ b/src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts
@@ -43,6 +43,7 @@ export class DojoColumnDialog extends HTMLElement {
   private _mode: DialogMode = 'create';
   private _columnId = '';
   private _currentName = '';
+  private _currentWipLimit: number | null = null;
   private _otherColumns: Column[] = [];
 
   // B-1: referencia estable para poder añadir y quitar el listener
@@ -70,15 +71,17 @@ export class DojoColumnDialog extends HTMLElement {
     this._mode = 'create';
     this._columnId = '';
     this._currentName = '';
+    this._currentWipLimit = null;
     this._otherColumns = [];
     this._buildContent();
     this._open();
   }
 
-  openRename(columnId: string, currentName: string): void {
+  openRename(columnId: string, currentName: string, currentWipLimit?: number | null): void {
     this._mode = 'rename';
     this._columnId = columnId;
     this._currentName = currentName;
+    this._currentWipLimit = currentWipLimit ?? null;
     this._otherColumns = [];
     this._buildContent();
     this._open();
@@ -332,6 +335,10 @@ export class DojoColumnDialog extends HTMLElement {
     iconField.appendChild(iconGrid);
     container.appendChild(iconField);
 
+    // Campo límite WIP (US-32)
+    const wipField = this._buildWipField(null);
+    container.appendChild(wipField.container);
+
     // Acciones
     const actions = document.createElement('div');
     actions.className = 'actions';
@@ -347,9 +354,10 @@ export class DojoColumnDialog extends HTMLElement {
     confirmBtn.addEventListener('click', () => {
       const name = nameInput.value.trim();
       if (!name) { nameInput.focus(); return; }
+      const wipValue = wipField.getValue();
       this.dispatchEvent(new CustomEvent('dojo:dialog-create-column', {
         bubbles: true, composed: true,
-        detail: { name, icon: selectedIcon },
+        detail: { name, icon: selectedIcon, wipLimit: wipValue },
       }));
       this._close();
     });
@@ -385,6 +393,10 @@ export class DojoColumnDialog extends HTMLElement {
     nameField.appendChild(nameInput);
     container.appendChild(nameField);
 
+    // Campo límite WIP (US-32)
+    const wipField = this._buildWipField(this._currentWipLimit);
+    container.appendChild(wipField.container);
+
     const actions = document.createElement('div');
     actions.className = 'actions';
 
@@ -399,9 +411,10 @@ export class DojoColumnDialog extends HTMLElement {
     confirmBtn.addEventListener('click', () => {
       const name = nameInput.value.trim();
       if (!name) { nameInput.focus(); return; }
+      const wipValue = wipField.getValue();
       this.dispatchEvent(new CustomEvent('dojo:dialog-rename-column', {
         bubbles: true, composed: true,
-        detail: { columnId: this._columnId, name },
+        detail: { columnId: this._columnId, name, wipLimit: wipValue },
       }));
       this._close();
     });
@@ -550,6 +563,41 @@ export class DojoColumnDialog extends HTMLElement {
   private _isOpen(): boolean {
     const backdrop = this._shadow.querySelector<HTMLElement>('.backdrop');
     return backdrop?.getAttribute('aria-hidden') === 'false';
+  }
+
+  // ── Campo reutilizable: Límite WIP (US-32) ────────────────────────────────
+
+  private _buildWipField(currentValue: number | null): { container: HTMLElement; getValue: () => number | null } {
+    const field = document.createElement('div');
+    field.className = 'field';
+    const lbl = document.createElement('label');
+    lbl.textContent = 'Límite WIP';
+    lbl.setAttribute('for', 'col-wip-input');
+    const input = document.createElement('input');
+    input.id = 'col-wip-input';
+    input.type = 'number';
+    input.min = '1';
+    input.placeholder = 'Sin límite';
+    input.setAttribute('aria-describedby', 'wip-hint');
+    if (currentValue !== null && currentValue !== undefined) {
+      input.value = String(currentValue);
+    }
+    const hint = document.createElement('span');
+    hint.id = 'wip-hint';
+    hint.style.cssText = 'font-size:0.75rem;color:var(--dojo-text-secondary);';
+    hint.textContent = 'Máximo de tareas permitidas. Vacío = sin límite.';
+    field.appendChild(lbl);
+    field.appendChild(input);
+    field.appendChild(hint);
+    return {
+      container: field,
+      getValue: (): number | null => {
+        const v = input.value.trim();
+        if (!v) return null;
+        const n = parseInt(v, 10);
+        return Number.isFinite(n) && n >= 1 ? n : null;
+      },
+    };
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -1675,14 +1675,20 @@ export class DojoKanbanBoard extends HTMLElement {
       `;
       continueBtn.textContent = 'Continuar';
 
-      const close = (result: boolean): void => {
-        backdrop.remove();
-        resolve(result);
-      };
-
       cancelBtn.addEventListener('click', () => close(false));
       continueBtn.addEventListener('click', () => close(true));
       backdrop.addEventListener('click', (ev) => { if (ev.target === backdrop) close(false); });
+
+      const onKeydown = (e: KeyboardEvent): void => {
+        if (e.key === 'Escape') close(false);
+      };
+      document.addEventListener('keydown', onKeydown);
+
+      const close = (result: boolean): void => {
+        document.removeEventListener('keydown', onKeydown);
+        backdrop.remove();
+        resolve(result);
+      };
 
       actions.appendChild(cancelBtn);
       actions.appendChild(continueBtn);

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -980,6 +980,7 @@ export class DojoKanbanBoard extends HTMLElement {
       colEl.setAttribute('count', String(visible));
       colEl.setAttribute('total-count', String(total));
       if (col.color) colEl.setAttribute('accent-color', col.color);
+      if (col.wipLimit != null) colEl.setAttribute('wip-limit', String(col.wipLimit));
 
       // US-03: Renderizar tarjetas de tarea en la columna
       const tasks = this._tasksByColumn.get(col.id) ?? [];
@@ -1147,9 +1148,16 @@ export class DojoKanbanBoard extends HTMLElement {
           orderedIds.map((id, order) => ({ ...taskMap.get(id)!, order })),
         );
       } else {
+        // US-32: advertencia de límite WIP al mover entre columnas (bloqueo suave)
+        const targetCol = this._columns.find(c => c.id === targetColumnId);
+        const targetTasks = this._tasksByColumn.get(targetColumnId) ?? [];
+        if (targetCol?.wipLimit != null && targetTasks.length >= targetCol.wipLimit) {
+          const proceed = await this._showWipWarning(targetCol.name, targetTasks.length, targetCol.wipLimit);
+          if (!proceed) return;
+        }
+
         // ── Movimiento entre columnas ──────────────────────────────────────
         const sourceTasks = this._tasksByColumn.get(sourceColumnId) ?? [];
-        const targetTasks = this._tasksByColumn.get(targetColumnId) ?? [];
         const movedTask   = sourceTasks.find(t => t.id === taskId);
         if (!movedTask) return;
 
@@ -1248,7 +1256,7 @@ export class DojoKanbanBoard extends HTMLElement {
     const col = this._columns.find(c => c.id === columnId);
     if (!col) return;
     const dialog = this._getDialog() as any;
-    if (dialog?.openRename) dialog.openRename(col.id, col.name);
+    if (dialog?.openRename) dialog.openRename(col.id, col.name, col.wipLimit ?? null);
   }
 
   private _onColumnDeleteRequest(e: CustomEvent): void {
@@ -1261,12 +1269,12 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private async _handleCreate(e: CustomEvent): Promise<void> {
-    const { name, icon } = e.detail as { name: string; icon: string };
+    const { name, icon, wipLimit } = e.detail as { name: string; icon: string; wipLimit?: number | null };
     const nextOrder = this._columns.length > 0
       ? Math.max(...this._columns.map(c => c.order)) + 1
       : 0;
     try {
-      const newCol = await createColumn({ name, icon, order: nextOrder, boardId: this._boardId });
+      const newCol = await createColumn({ name, icon, order: nextOrder, boardId: this._boardId, wipLimit: wipLimit ?? undefined });
       this._columns.push(newCol);
       this._tasksByColumn.set(newCol.id, []);
       this._renderColumns(this._columns);
@@ -1276,14 +1284,18 @@ export class DojoKanbanBoard extends HTMLElement {
   }
 
   private async _handleRename(e: CustomEvent): Promise<void> {
-    const { columnId, name } = e.detail as { columnId: string; name: string };
+    const { columnId, name, wipLimit } = e.detail as { columnId: string; name: string; wipLimit?: number | null };
     try {
-      const updated = await updateColumn(columnId, { name });
+      const updated = await updateColumn(columnId, { name, wipLimit: wipLimit !== undefined ? wipLimit : undefined });
       const idx = this._columns.findIndex(c => c.id === columnId);
       if (idx !== -1) this._columns[idx] = updated;
-      // Actualizar solo el atributo del elemento del DOM
+      // Actualizar atributos del elemento del DOM
       const colEl = this._shadow.querySelector(`dojo-kanban-column[column-id="${columnId}"]`);
-      if (colEl) colEl.setAttribute('column-name', name);
+      if (colEl) {
+        colEl.setAttribute('column-name', name);
+        if (updated.wipLimit != null) colEl.setAttribute('wip-limit', String(updated.wipLimit));
+        else colEl.removeAttribute('wip-limit');
+      }
     } catch (err) {
       console.error('[dojo-kanban-board] Error al renombrar columna:', err);
     }
@@ -1377,6 +1389,14 @@ export class DojoKanbanBoard extends HTMLElement {
       return;
     }
     const tasks = this._tasksByColumn.get(statusId) ?? [];
+
+    // US-32: advertencia de límite WIP al crear tarea (bloqueo suave)
+    const targetCol = this._columns.find(c => c.id === statusId);
+    if (targetCol?.wipLimit != null && tasks.length >= targetCol.wipLimit) {
+      const proceed = await this._showWipWarning(targetCol.name, tasks.length, targetCol.wipLimit);
+      if (!proceed) return;
+    }
+
     try {
       // US-26: resolver proyecto y obtener taskNumber
       let resolvedProjectId = projectId || '';
@@ -1457,6 +1477,16 @@ export class DojoKanbanBoard extends HTMLElement {
     if (changes.statusId && !this._columns.some(c => c.id === changes.statusId)) {
       console.warn('[dojo-kanban-board] Intento de mover tarea a columna inexistente:', changes.statusId);
       return;
+    }
+
+    // US-32: advertencia de límite WIP al cambiar estado desde el panel de detalle
+    if (changes.statusId && changes.statusId !== sourceColumnId) {
+      const targetCol = this._columns.find(c => c.id === changes.statusId);
+      const targetTasks = this._tasksByColumn.get(changes.statusId) ?? [];
+      if (targetCol?.wipLimit != null && targetTasks.length >= targetCol.wipLimit) {
+        const proceed = await this._showWipWarning(targetCol.name, targetTasks.length, targetCol.wipLimit);
+        if (!proceed) return;
+      }
     }
 
     try {
@@ -1588,6 +1618,81 @@ export class DojoKanbanBoard extends HTMLElement {
     } catch (err) {
       console.error('[dojo-kanban-board] Error al eliminar tarea:', err);
     }
+  }
+
+  // ── Advertencia WIP (US-32) ─────────────────────────────────────────────
+
+  /**
+   * Muestra una advertencia de bloqueo suave cuando se supera el límite WIP.
+   * Retorna `true` si el usuario decide continuar, `false` para cancelar.
+   */
+  private _showWipWarning(columnName: string, currentCount: number, wipLimit: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const backdrop = document.createElement('div');
+      backdrop.style.cssText = `
+        position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:300;
+        display:flex;align-items:center;justify-content:center;padding:1rem;
+      `;
+
+      const dialog = document.createElement('div');
+      dialog.style.cssText = `
+        background:var(--dojo-surface);border:1px solid var(--dojo-border);
+        border-radius:var(--dojo-radius);box-shadow:var(--dojo-shadow);
+        width:100%;max-width:380px;padding:1.25rem;display:flex;
+        flex-direction:column;gap:1rem;animation:dlg-in 0.18s ease;
+      `;
+      dialog.setAttribute('role', 'alertdialog');
+      dialog.setAttribute('aria-label', 'Límite WIP superado');
+
+      const warning = document.createElement('div');
+      warning.style.cssText = `
+        display:flex;align-items:flex-start;gap:0.5rem;padding:0.75rem;
+        background:color-mix(in srgb, var(--dojo-warning, #D97706) 10%, transparent);
+        border:1px solid color-mix(in srgb, var(--dojo-warning, #D97706) 30%, transparent);
+        border-radius:var(--dojo-radius-sm, 4px);font-size:0.875rem;
+        color:var(--dojo-text-primary);
+      `;
+      warning.textContent = `⚠️ La columna "${columnName}" ya tiene ${currentCount} tareas (límite: ${wipLimit}). ¿Deseas continuar de todos modos?`;
+
+      const actions = document.createElement('div');
+      actions.style.cssText = 'display:flex;justify-content:flex-end;gap:0.625rem;';
+
+      const cancelBtn = document.createElement('button');
+      cancelBtn.style.cssText = `
+        padding:0.4375rem 1rem;border-radius:var(--dojo-radius-sm, 4px);
+        font-size:0.875rem;font-weight:500;cursor:pointer;
+        background:transparent;border:1px solid var(--dojo-border);
+        color:var(--dojo-text-secondary);font-family:inherit;
+      `;
+      cancelBtn.textContent = 'Cancelar';
+
+      const continueBtn = document.createElement('button');
+      continueBtn.style.cssText = `
+        padding:0.4375rem 1rem;border-radius:var(--dojo-radius-sm, 4px);
+        font-size:0.875rem;font-weight:500;cursor:pointer;
+        background:var(--dojo-warning, #D97706);border:1px solid transparent;
+        color:#fff;font-family:inherit;
+      `;
+      continueBtn.textContent = 'Continuar';
+
+      const close = (result: boolean): void => {
+        backdrop.remove();
+        resolve(result);
+      };
+
+      cancelBtn.addEventListener('click', () => close(false));
+      continueBtn.addEventListener('click', () => close(true));
+      backdrop.addEventListener('click', (ev) => { if (ev.target === backdrop) close(false); });
+
+      actions.appendChild(cancelBtn);
+      actions.appendChild(continueBtn);
+      dialog.appendChild(warning);
+      dialog.appendChild(actions);
+      backdrop.appendChild(dialog);
+      this._shadow.appendChild(backdrop);
+
+      setTimeout(() => continueBtn.focus(), 50);
+    });
   }
 }
 

--- a/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
+++ b/src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts
@@ -480,6 +480,66 @@ export class DojoKanbanBoard extends HTMLElement {
         align-items: center;
         gap: 0.375rem;
       }
+
+      /* ── Diálogo de advertencia WIP (US-32) ── */
+      .wip-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.45);
+        z-index: 300;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1rem;
+      }
+      .wip-dialog {
+        background: var(--dojo-surface);
+        border: 1px solid var(--dojo-border);
+        border-radius: var(--dojo-radius);
+        box-shadow: var(--dojo-shadow);
+        width: 100%;
+        max-width: 380px;
+        padding: 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        animation: dlg-in 0.18s ease;
+      }
+      @keyframes dlg-in { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+      .wip-warning {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.5rem;
+        padding: 0.75rem;
+        background: color-mix(in srgb, var(--dojo-warning, #D97706) 10%, transparent);
+        border: 1px solid color-mix(in srgb, var(--dojo-warning, #D97706) 30%, transparent);
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        color: var(--dojo-text-primary);
+      }
+      .wip-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.625rem;
+      }
+      .wip-btn {
+        padding: 0.4375rem 1rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .wip-btn--cancel {
+        background: transparent;
+        border: 1px solid var(--dojo-border);
+        color: var(--dojo-text-secondary);
+      }
+      .wip-btn--continue {
+        background: var(--dojo-warning, #D97706);
+        border: 1px solid transparent;
+        color: #fff;
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -1149,12 +1209,8 @@ export class DojoKanbanBoard extends HTMLElement {
         );
       } else {
         // US-32: advertencia de límite WIP al mover entre columnas (bloqueo suave)
-        const targetCol = this._columns.find(c => c.id === targetColumnId);
         const targetTasks = this._tasksByColumn.get(targetColumnId) ?? [];
-        if (targetCol?.wipLimit != null && targetTasks.length >= targetCol.wipLimit) {
-          const proceed = await this._showWipWarning(targetCol.name, targetTasks.length, targetCol.wipLimit);
-          if (!proceed) return;
-        }
+        if (!(await this._checkWipLimit(targetColumnId, targetTasks.length))) return;
 
         // ── Movimiento entre columnas ──────────────────────────────────────
         const sourceTasks = this._tasksByColumn.get(sourceColumnId) ?? [];
@@ -1391,11 +1447,7 @@ export class DojoKanbanBoard extends HTMLElement {
     const tasks = this._tasksByColumn.get(statusId) ?? [];
 
     // US-32: advertencia de límite WIP al crear tarea (bloqueo suave)
-    const targetCol = this._columns.find(c => c.id === statusId);
-    if (targetCol?.wipLimit != null && tasks.length >= targetCol.wipLimit) {
-      const proceed = await this._showWipWarning(targetCol.name, tasks.length, targetCol.wipLimit);
-      if (!proceed) return;
-    }
+    if (!(await this._checkWipLimit(statusId, tasks.length))) return;
 
     try {
       // US-26: resolver proyecto y obtener taskNumber
@@ -1481,12 +1533,8 @@ export class DojoKanbanBoard extends HTMLElement {
 
     // US-32: advertencia de límite WIP al cambiar estado desde el panel de detalle
     if (changes.statusId && changes.statusId !== sourceColumnId) {
-      const targetCol = this._columns.find(c => c.id === changes.statusId);
       const targetTasks = this._tasksByColumn.get(changes.statusId) ?? [];
-      if (targetCol?.wipLimit != null && targetTasks.length >= targetCol.wipLimit) {
-        const proceed = await this._showWipWarning(targetCol.name, targetTasks.length, targetCol.wipLimit);
-        if (!proceed) return;
-      }
+      if (!(await this._checkWipLimit(changes.statusId, targetTasks.length))) return;
     }
 
     try {
@@ -1623,56 +1671,42 @@ export class DojoKanbanBoard extends HTMLElement {
   // ── Advertencia WIP (US-32) ─────────────────────────────────────────────
 
   /**
+   * Verifica si la columna destino supera su límite WIP.
+   * Muestra advertencia si procede. Retorna `true` para continuar, `false` para cancelar.
+   */
+  private async _checkWipLimit(columnId: string, currentCount: number): Promise<boolean> {
+    const col = this._columns.find(c => c.id === columnId);
+    if (col?.wipLimit == null || currentCount < col.wipLimit) return true;
+    return this._showWipWarning(col.name, currentCount, col.wipLimit);
+  }
+
+  /**
    * Muestra una advertencia de bloqueo suave cuando se supera el límite WIP.
    * Retorna `true` si el usuario decide continuar, `false` para cancelar.
    */
   private _showWipWarning(columnName: string, currentCount: number, wipLimit: number): Promise<boolean> {
     return new Promise((resolve) => {
       const backdrop = document.createElement('div');
-      backdrop.style.cssText = `
-        position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:300;
-        display:flex;align-items:center;justify-content:center;padding:1rem;
-      `;
+      backdrop.className = 'wip-backdrop';
 
       const dialog = document.createElement('div');
-      dialog.style.cssText = `
-        background:var(--dojo-surface);border:1px solid var(--dojo-border);
-        border-radius:var(--dojo-radius);box-shadow:var(--dojo-shadow);
-        width:100%;max-width:380px;padding:1.25rem;display:flex;
-        flex-direction:column;gap:1rem;animation:dlg-in 0.18s ease;
-      `;
+      dialog.className = 'wip-dialog';
       dialog.setAttribute('role', 'alertdialog');
       dialog.setAttribute('aria-label', 'Límite WIP superado');
 
       const warning = document.createElement('div');
-      warning.style.cssText = `
-        display:flex;align-items:flex-start;gap:0.5rem;padding:0.75rem;
-        background:color-mix(in srgb, var(--dojo-warning, #D97706) 10%, transparent);
-        border:1px solid color-mix(in srgb, var(--dojo-warning, #D97706) 30%, transparent);
-        border-radius:var(--dojo-radius-sm, 4px);font-size:0.875rem;
-        color:var(--dojo-text-primary);
-      `;
+      warning.className = 'wip-warning';
       warning.textContent = `⚠️ La columna "${columnName}" ya tiene ${currentCount} tareas (límite: ${wipLimit}). ¿Deseas continuar de todos modos?`;
 
       const actions = document.createElement('div');
-      actions.style.cssText = 'display:flex;justify-content:flex-end;gap:0.625rem;';
+      actions.className = 'wip-actions';
 
       const cancelBtn = document.createElement('button');
-      cancelBtn.style.cssText = `
-        padding:0.4375rem 1rem;border-radius:var(--dojo-radius-sm, 4px);
-        font-size:0.875rem;font-weight:500;cursor:pointer;
-        background:transparent;border:1px solid var(--dojo-border);
-        color:var(--dojo-text-secondary);font-family:inherit;
-      `;
+      cancelBtn.className = 'wip-btn wip-btn--cancel';
       cancelBtn.textContent = 'Cancelar';
 
       const continueBtn = document.createElement('button');
-      continueBtn.style.cssText = `
-        padding:0.4375rem 1rem;border-radius:var(--dojo-radius-sm, 4px);
-        font-size:0.875rem;font-weight:500;cursor:pointer;
-        background:var(--dojo-warning, #D97706);border:1px solid transparent;
-        color:#fff;font-family:inherit;
-      `;
+      continueBtn.className = 'wip-btn wip-btn--continue';
       continueBtn.textContent = 'Continuar';
 
       cancelBtn.addEventListener('click', () => close(false));

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -75,6 +75,8 @@ export interface Column {
   color?: string;
   /** Indica que la columna fue creada por el seed inicial (US-37). No bloquea edición ni eliminación. */
   isDefault?: boolean;
+  /** Límite máximo de tareas (WIP). undefined/null = sin límite (US-32). */
+  wipLimit?: number | null;
 }
 
 /** Columnas por defecto que se insertan al inicializar la base de datos (US-37). */


### PR DESCRIPTION
## Descripción

Implementa **US-32 — Límites WIP por columna**, permitiendo a los usuarios definir un límite máximo de tareas por columna para identificar cuellos de botella y mantener un ritmo sostenible.

Closes #71

---

## Cambios realizados

### Modelo de datos
- **`src/types/models.ts`** — Añadido campo `wipLimit?: number | null` a la interfaz `Column`. No requiere migración de IndexedDB ya que es un campo opcional sobre registros existentes.

### UI: Diálogo de columna
- **`src/components/organisms/dojo-column-dialog/dojo-column-dialog.ts`**
  - Campo numérico "Límite WIP" en el formulario de **creación** de columna.
  - Campo numérico "Límite WIP" en el formulario de **edición** (renombrar) con valor prellenado.
  - Método privado `_buildWipField()` reutilizable para ambos modos.
  - Validación: solo acepta enteros ≥ 1; vacío = `null` (sin límite).

### UI: Indicadores visuales en cabecera
- **`src/components/atoms/dojo-column-header/dojo-column-header.ts`**
  - Nuevo atributo observado `wip-limit`.
  - Badge muestra formato `X / Y` (tareas / límite) cuando hay WIP configurado.
  - 3 estados visuales:
    - **Normal** (< 80%): sin indicador adicional.
    - **⚠️ Advertencia** (≥ 80%): badge ámbar + icono ⚠️ con tooltip.
    - **🔴 Superado** (≥ 100%): badge rojo + icono 🔴 con tooltip.
  - CSS Custom Properties: `--dojo-warning`, `--dojo-danger` para theming.

### UI: Propagación del atributo
- **`src/components/molecules/dojo-kanban-column/dojo-kanban-column.ts`**
  - Nuevo atributo observado `wip-limit`.
  - Propagación al `<dojo-column-header>` interno.

### Lógica de negocio: Tablero
- **`src/components/organisms/dojo-kanban-board/dojo-kanban-board.ts`**
  - Pasa `wip-limit` al renderizar columnas.
  - Envía `wipLimit` en eventos de creación y edición de columna.
  - **Bloqueo suave** (`_showWipWarning`): diálogo de advertencia que permite al usuario continuar o cancelar, implementado en 3 puntos:
    1. Crear tarea en columna saturada.
    2. Drag & drop entre columnas.
    3. Cambio de estado desde el panel de detalle.

---

## Criterios de aceptación cubiertos

| Escenario | Estado |
|-----------|--------|
| Configurar WIP al crear columna | ✅ |
| Configurar WIP en columna existente | ✅ |
| Columna dentro del límite (normal) | ✅ |
| Columna próxima al límite (≥80% → ámbar) | ✅ |
| Columna que supera el límite (≥100% → rojo) | ✅ |
| Bloqueo suave al agregar tarea | ✅ |
| Columna sin límite = sin indicadores | ✅ |
| Quitar el límite (vacío → null) | ✅ |

---

## Notas técnicas

- No se requiere migración de IndexedDB (v5 → v6) porque `wipLimit` es un campo opcional en el modelo. IndexedDB almacena registros JSON completos sin esquema estricto.
- El bloqueo es **suave** (no impeditivo): el usuario siempre puede continuar.
- Compatible con sincronización cross-tab (US-30) mediante `emitSync` existente.