### PR TITLE
feat(notifications): browser due-date reminders via Service Worker (US-34)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -62,7 +62,8 @@ async function getStoredNotificationState() {
 }
 
 function getNotificationStageKeys(task) {
-  return [`${task.id}:24h`, `${task.id}:due`];
+  const duePart = task.dueDate ? `:${task.dueDate}` : '';
+  return [`${task.id}${duePart}:24h`, `${task.id}${duePart}:due`];
 }
 
 function pruneNotificationState(tasks, state) {
@@ -84,8 +85,7 @@ function getPendingNotificationTriggers(tasks, state, now) {
     if (Number.isNaN(dueAt)) continue;
 
     const reminderAt = dueAt - (24 * 60 * 60 * 1000);
-    const reminderKey = `${task.id}:24h`;
-    const dueKey = `${task.id}:due`;
+    const [reminderKey, dueKey] = getNotificationStageKeys(task);
 
     if (!state.sent[reminderKey] && reminderAt > now) {
       pending.push(reminderAt);
@@ -113,7 +113,8 @@ async function scheduleNotificationCheck() {
   if (pendingTriggers.length === 0) return;
 
   const nextTrigger = Math.min(...pendingTriggers);
-  const delay = Math.max(nextTrigger - Date.now(), 0);
+  const MAX_TIMEOUT_MS = 60 * 60 * 1000; // 1 hora máx para evitar overflow en setTimeout
+  const delay = Math.min(Math.max(nextTrigger - Date.now(), 0), MAX_TIMEOUT_MS);
 
   notificationTimer = setTimeout(() => {
     notificationTimer = null;
@@ -150,6 +151,8 @@ function buildNotificationPayload(task, stage) {
 }
 
 async function checkDueNotifications() {
+  if (Notification.permission !== 'granted') return;
+
   const [tasks, rawState] = await Promise.all([
     getStoredNotificationTasks(),
     getStoredNotificationState(),
@@ -163,8 +166,7 @@ async function checkDueNotifications() {
     if (Number.isNaN(dueAt)) continue;
 
     const reminderAt = dueAt - (24 * 60 * 60 * 1000);
-    const reminderKey = `${task.id}:24h`;
-    const dueKey = `${task.id}:due`;
+    const [reminderKey, dueKey] = getNotificationStageKeys(task);
 
     if (now < dueAt && now >= reminderAt && !state.sent[reminderKey]) {
       const payload = buildNotificationPayload(task, '24h');

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,6 +4,11 @@
 
 const CACHE_VERSION = 'v1';
 const CACHE_NAME = `dojo-kanban-${CACHE_VERSION}`;
+const NOTIFICATION_CACHE_NAME = 'dojo-task-notifications-v1';
+const NOTIFICATION_TASKS_URL = new URL('./__dojo_notification_tasks__', self.location.origin).toString();
+const NOTIFICATION_STATE_URL = new URL('./__dojo_notification_state__', self.location.origin).toString();
+
+let notificationTimer = null;
 
 // Assets esenciales a pre-cachear durante la instalación.
 // Garantizan que la app cargue completamente sin conexión.
@@ -15,6 +20,186 @@ const PRECACHE_URLS = [
   './icons/icon-192.svg',
   './icons/icon-512.svg',
 ];
+
+function isNotifiableTask(task) {
+  return task && typeof task.id === 'string'
+    && typeof task.boardId === 'string'
+    && typeof task.title === 'string'
+    && typeof task.dueDate === 'string'
+    && typeof task.statusName === 'string';
+}
+
+async function readNotificationJson(url, fallback) {
+  const cache = await caches.open(NOTIFICATION_CACHE_NAME);
+  const response = await cache.match(url);
+  if (!response) return fallback;
+
+  try {
+    return await response.json();
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeNotificationJson(url, payload) {
+  const cache = await caches.open(NOTIFICATION_CACHE_NAME);
+  await cache.put(url, new Response(JSON.stringify(payload), {
+    headers: { 'Content-Type': 'application/json' },
+  }));
+}
+
+async function getStoredNotificationTasks() {
+  const tasks = await readNotificationJson(NOTIFICATION_TASKS_URL, []);
+  return Array.isArray(tasks) ? tasks.filter(isNotifiableTask) : [];
+}
+
+async function getStoredNotificationState() {
+  const state = await readNotificationJson(NOTIFICATION_STATE_URL, { sent: {} });
+  if (!state || typeof state !== 'object' || typeof state.sent !== 'object' || !state.sent) {
+    return { sent: {} };
+  }
+  return state;
+}
+
+function getNotificationStageKeys(task) {
+  return [`${task.id}:24h`, `${task.id}:due`];
+}
+
+function pruneNotificationState(tasks, state) {
+  const validKeys = new Set(tasks.flatMap(getNotificationStageKeys));
+  const nextSent = {};
+
+  for (const [key, value] of Object.entries(state.sent || {})) {
+    if (validKeys.has(key)) nextSent[key] = value;
+  }
+
+  return { sent: nextSent };
+}
+
+function getPendingNotificationTriggers(tasks, state, now) {
+  const pending = [];
+
+  for (const task of tasks) {
+    const dueAt = new Date(task.dueDate).getTime();
+    if (Number.isNaN(dueAt)) continue;
+
+    const reminderAt = dueAt - (24 * 60 * 60 * 1000);
+    const reminderKey = `${task.id}:24h`;
+    const dueKey = `${task.id}:due`;
+
+    if (!state.sent[reminderKey] && reminderAt > now) {
+      pending.push(reminderAt);
+    }
+
+    if (!state.sent[dueKey] && dueAt > now) {
+      pending.push(dueAt);
+    }
+  }
+
+  return pending;
+}
+
+async function scheduleNotificationCheck() {
+  if (notificationTimer) {
+    clearTimeout(notificationTimer);
+    notificationTimer = null;
+  }
+
+  const [tasks, state] = await Promise.all([
+    getStoredNotificationTasks(),
+    getStoredNotificationState(),
+  ]);
+  const pendingTriggers = getPendingNotificationTriggers(tasks, state, Date.now());
+  if (pendingTriggers.length === 0) return;
+
+  const nextTrigger = Math.min(...pendingTriggers);
+  const delay = Math.max(nextTrigger - Date.now(), 0);
+
+  notificationTimer = setTimeout(() => {
+    notificationTimer = null;
+    checkDueNotifications().catch((error) => {
+      console.error('[SW] Error al comprobar notificaciones:', error);
+    });
+  }, delay);
+}
+
+function buildNotificationPayload(task, stage) {
+  const isDue = stage === 'due';
+  const title = isDue
+    ? `Venció: ${task.title}`
+    : `Vence pronto: ${task.title}`;
+  const body = isDue
+    ? `La tarea ya venció en ${task.statusName}.`
+    : `La tarea vence en menos de 24 horas en ${task.statusName}.`;
+
+  return {
+    title,
+    options: {
+      body,
+      tag: `dojo-task-${task.id}-${stage}`,
+      renotify: false,
+      data: {
+        taskId: task.id,
+        boardId: task.boardId,
+      },
+      actions: [
+        { action: 'open-task', title: 'Abrir tarea' },
+      ],
+    },
+  };
+}
+
+async function checkDueNotifications() {
+  const [tasks, rawState] = await Promise.all([
+    getStoredNotificationTasks(),
+    getStoredNotificationState(),
+  ]);
+  const state = pruneNotificationState(tasks, rawState);
+  const now = Date.now();
+  let stateChanged = false;
+
+  for (const task of tasks) {
+    const dueAt = new Date(task.dueDate).getTime();
+    if (Number.isNaN(dueAt)) continue;
+
+    const reminderAt = dueAt - (24 * 60 * 60 * 1000);
+    const reminderKey = `${task.id}:24h`;
+    const dueKey = `${task.id}:due`;
+
+    if (now < dueAt && now >= reminderAt && !state.sent[reminderKey]) {
+      const payload = buildNotificationPayload(task, '24h');
+      await self.registration.showNotification(payload.title, payload.options);
+      state.sent[reminderKey] = now;
+      stateChanged = true;
+    }
+
+    if (now >= dueAt && !state.sent[dueKey]) {
+      const payload = buildNotificationPayload(task, 'due');
+      await self.registration.showNotification(payload.title, payload.options);
+      state.sent[dueKey] = now;
+      stateChanged = true;
+    }
+  }
+
+  if (stateChanged) {
+    await writeNotificationJson(NOTIFICATION_STATE_URL, state);
+  }
+
+  await scheduleNotificationCheck();
+}
+
+async function syncNotificationTasks(tasks) {
+  const normalizedTasks = Array.isArray(tasks) ? tasks.filter(isNotifiableTask) : [];
+  const previousState = await getStoredNotificationState();
+  const nextState = pruneNotificationState(normalizedTasks, previousState);
+
+  await Promise.all([
+    writeNotificationJson(NOTIFICATION_TASKS_URL, normalizedTasks),
+    writeNotificationJson(NOTIFICATION_STATE_URL, nextState),
+  ]);
+
+  await checkDueNotifications();
+}
 
 // ── Install: pre-cachear assets esenciales ─────────────────────────────────
 // Se ejecuta una sola vez al registrar el SW por primera vez.
@@ -44,7 +229,49 @@ self.addEventListener('activate', (event) => {
         )
       )
       .then(() => self.clients.claim())
+      .then(() => scheduleNotificationCheck())
   );
+});
+
+self.addEventListener('message', (event) => {
+  const { data } = event;
+  if (!data || typeof data !== 'object') return;
+
+  if (data.type === 'dojo:notifications-sync') {
+    event.waitUntil(syncNotificationTasks(data.tasks));
+  }
+});
+
+self.addEventListener('periodicsync', (event) => {
+  if (event.tag === 'dojo-task-notifications') {
+    event.waitUntil(checkDueNotifications());
+  }
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const { taskId, boardId } = event.notification.data || {};
+  if (!taskId || !boardId) return;
+
+  const targetUrl = new URL('./', self.location.origin);
+  targetUrl.searchParams.set('boardId', boardId);
+  targetUrl.searchParams.set('taskId', taskId);
+
+  event.waitUntil((async () => {
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clients) {
+      if ('focus' in client) {
+        await client.navigate(targetUrl.toString());
+        await client.focus();
+        return;
+      }
+    }
+
+    if (self.clients.openWindow) {
+      await self.clients.openWindow(targetUrl.toString());
+    }
+  })());
 });
 
 // ── Fetch: Cache First con Network Fallback ───────────────────────────────

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -25,6 +25,12 @@ import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 
 import type { Label } from '../../../types/models.js';
 import { getAllBoards } from '../../../db/board.repository.js';
+import { onMultipleSync } from '../../../utils/broadcast-sync.js';
+import {
+  dismissTaskNotificationPromptForSession,
+  requestTaskNotificationPermission,
+  shouldPromptForTaskNotifications,
+} from '../../../utils/task-notifications.js';
 import {
   exportBoardData,
   downloadBoardExport,
@@ -40,10 +46,12 @@ export class DojoApp extends HTMLElement {
   /** Datos pendientes de importación (tras validación, previo a confirmación). */
   private _pendingImport: import('../../../db/export-import.js').BoardExport | null = null;
   private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+  private _notificationPromptCleanup: (() => void) | null = null;
   /** ID del tablero activo. Si es vacío, se muestra el selector de tableros (US-22). */
   private _activeBoardId = '';
   /** Modo de vista activo para el tablero: 'kanban' o 'list'. Persiste en localStorage (US-33). */
   private _boardViewMode: 'kanban' | 'list' = 'kanban';
+  private _pendingTaskLink: { boardId: string; taskId: string } | null = null;
 
   /** Referencia estable para poder eliminar el listener de teclado del diálogo de importación. */
   private _onImportKeydown = (e: KeyboardEvent): void => {
@@ -81,12 +89,23 @@ export class DojoApp extends HTMLElement {
     // Guarda de idempotencia: evita re-render al mover el elemento en el DOM
     if (this._shadow.childElementCount > 0) return;
     this._boardViewMode = this._loadBoardViewPreference();
+    this._pendingTaskLink = this._readPendingTaskLink();
+    if (this._pendingTaskLink) this._boardViewMode = 'kanban';
     this._render();
     this._autoSelectSingleBoard();
+    void this._refreshNotificationPrompt();
+    this._notificationPromptCleanup = onMultipleSync({
+      'task:created': () => void this._refreshNotificationPrompt(),
+      'task:updated': () => void this._refreshNotificationPrompt(),
+      'task:deleted': () => void this._refreshNotificationPrompt(),
+      'board:deleted': () => void this._refreshNotificationPrompt(),
+    });
   }
 
   disconnectedCallback(): void {
     document.removeEventListener('keydown', this._onImportKeydown);
+    this._notificationPromptCleanup?.();
+    this._notificationPromptCleanup = null;
   }
 
   private _render(): void {
@@ -168,6 +187,58 @@ export class DojoApp extends HTMLElement {
         margin-left: auto;
       }
       .import-input { display: none; }
+
+      .notification-banner {
+        display: none;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.75rem 1.25rem;
+        background: color-mix(in srgb, var(--dojo-warning, #D97706) 14%, var(--dojo-surface));
+        border-bottom: 1px solid color-mix(in srgb, var(--dojo-warning, #D97706) 35%, var(--dojo-border));
+      }
+      .notification-banner.visible {
+        display: flex;
+      }
+      .notification-banner-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+      .notification-banner-title {
+        font-size: 0.875rem;
+        font-weight: 700;
+        color: var(--dojo-text-primary);
+      }
+      .notification-banner-text {
+        font-size: 0.8125rem;
+        color: var(--dojo-text-secondary);
+      }
+      .notification-banner-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-shrink: 0;
+      }
+      .notification-banner-btn {
+        padding: 0.4375rem 0.8rem;
+        border-radius: var(--dojo-radius-sm, 4px);
+        border: 1px solid var(--dojo-border);
+        background: transparent;
+        color: var(--dojo-text-primary);
+        font: inherit;
+        cursor: pointer;
+      }
+      .notification-banner-btn.primary {
+        background: var(--dojo-warning, #D97706);
+        border-color: transparent;
+        color: #fff;
+        font-weight: 700;
+      }
+      .notification-banner-btn:focus-visible {
+        outline: 2px solid var(--dojo-primary, #1D4ED8);
+        outline-offset: 2px;
+      }
 
       /* ── Diálogo de confirmación de importación ───────────────── */
       .import-backdrop {
@@ -394,6 +465,17 @@ export class DojoApp extends HTMLElement {
         outline: 2px solid var(--dojo-primary, #1D4ED8);
         outline-offset: 2px;
       }
+
+      @media (max-width: 767px) {
+        .notification-banner {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        .notification-banner-actions {
+          width: 100%;
+          justify-content: flex-end;
+        }
+      }
     `;
     this._shadow.appendChild(style);
 
@@ -574,6 +656,46 @@ export class DojoApp extends HTMLElement {
     appHeader.appendChild(themeToggle);
     this._shadow.appendChild(appHeader);
 
+    const notificationBanner = document.createElement('section');
+    notificationBanner.className = 'notification-banner';
+    notificationBanner.setAttribute('aria-label', 'Permiso de notificaciones');
+
+    const notificationCopy = document.createElement('div');
+    notificationCopy.className = 'notification-banner-copy';
+    const notificationTitle = document.createElement('strong');
+    notificationTitle.className = 'notification-banner-title';
+    notificationTitle.textContent = 'Activa recordatorios de vencimiento';
+    const notificationText = document.createElement('span');
+    notificationText.className = 'notification-banner-text';
+    notificationText.textContent = 'La app puede avisarte 24 horas antes y al vencer una tarea, incluso si no tienes el tablero en primer plano.';
+    notificationCopy.appendChild(notificationTitle);
+    notificationCopy.appendChild(notificationText);
+
+    const notificationActions = document.createElement('div');
+    notificationActions.className = 'notification-banner-actions';
+    const dismissNotificationsBtn = document.createElement('button');
+    dismissNotificationsBtn.type = 'button';
+    dismissNotificationsBtn.className = 'notification-banner-btn';
+    dismissNotificationsBtn.textContent = 'Ahora no';
+    dismissNotificationsBtn.addEventListener('click', () => {
+      dismissTaskNotificationPromptForSession();
+      void this._refreshNotificationPrompt();
+    });
+
+    const allowNotificationsBtn = document.createElement('button');
+    allowNotificationsBtn.type = 'button';
+    allowNotificationsBtn.className = 'notification-banner-btn primary';
+    allowNotificationsBtn.textContent = 'Permitir';
+    allowNotificationsBtn.addEventListener('click', () => {
+      void this._handleNotificationPermissionRequest();
+    });
+
+    notificationActions.appendChild(dismissNotificationsBtn);
+    notificationActions.appendChild(allowNotificationsBtn);
+    notificationBanner.appendChild(notificationCopy);
+    notificationBanner.appendChild(notificationActions);
+    this._shadow.appendChild(notificationBanner);
+
     // ── Área del tablero ────────────────────────────────────────────────────────────────────
     const boardArea = document.createElement('main');
     boardArea.className = 'board-area';
@@ -638,7 +760,10 @@ export class DojoApp extends HTMLElement {
     };
     this._shadow.addEventListener('dojo:task-field-updated',   invalidatePalette);
     this._shadow.addEventListener('dojo:task-delete-confirm',  invalidatePalette);
-    this._shadow.addEventListener('dojo:board-ready',          invalidatePalette);
+    this._shadow.addEventListener('dojo:board-ready', () => {
+      invalidatePalette();
+      void this._openPendingTaskLink();
+    });
 
     // Cuando se crea/actualiza/elimina un proyecto, refrescar el tablero
     this._shadow.addEventListener('dojo:project-created', () => {
@@ -709,6 +834,11 @@ export class DojoApp extends HTMLElement {
    */
   private async _autoSelectSingleBoard(): Promise<void> {
     try {
+      if (this._pendingTaskLink?.boardId) {
+        this._navigateToBoard(this._pendingTaskLink.boardId);
+        return;
+      }
+
       const boards = await getAllBoards();
       if (boards.length === 1) {
         this._navigateToBoard(boards[0].id);
@@ -888,6 +1018,60 @@ export class DojoApp extends HTMLElement {
     const board    = this._shadow.querySelector('dojo-kanban-board') as HTMLElement | null;
     const listView = this._shadow.querySelector('dojo-list-view') as HTMLElement | null;
     this._applyBoardViewMode(this._activeBoardId, board, listView);
+  }
+
+  private _readPendingTaskLink(): { boardId: string; taskId: string } | null {
+    try {
+      const url = new URL(window.location.href);
+      const boardId = url.searchParams.get('boardId');
+      const taskId = url.searchParams.get('taskId');
+      if (!boardId || !taskId) return null;
+      return { boardId, taskId };
+    } catch {
+      return null;
+    }
+  }
+
+  private _clearPendingTaskLink(): void {
+    this._pendingTaskLink = null;
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('boardId');
+      url.searchParams.delete('taskId');
+      window.history.replaceState({}, '', url);
+    } catch {
+      // Ignorar si el navegador no soporta URL/history como se espera.
+    }
+  }
+
+  private async _openPendingTaskLink(): Promise<void> {
+    if (!this._pendingTaskLink || this._activeBoardId !== this._pendingTaskLink.boardId) return;
+
+    const board = this._shadow.querySelector('dojo-kanban-board') as any;
+    if (!board?.openTaskById) return;
+
+    await board.openTaskById(this._pendingTaskLink.taskId);
+    this._clearPendingTaskLink();
+  }
+
+  private async _refreshNotificationPrompt(): Promise<void> {
+    const banner = this._shadow.querySelector<HTMLElement>('.notification-banner');
+    if (!banner) return;
+
+    const shouldPrompt = await shouldPromptForTaskNotifications();
+    banner.classList.toggle('visible', shouldPrompt);
+  }
+
+  private async _handleNotificationPermissionRequest(): Promise<void> {
+    const permission = await requestTaskNotificationPermission();
+
+    if (permission === 'granted') {
+      this._showToast('Notificaciones activadas para vencimientos.');
+    } else if (permission === 'denied') {
+      this._showToast('El navegador bloqueó las notificaciones para esta sesión.', true);
+    }
+
+    await this._refreshNotificationPrompt();
   }
 
   private _showToast(message: string, isError = false): void {

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -1726,6 +1726,25 @@ export class DojoTaskDetail extends HTMLElement {
       } catch { /* ignorar fecha inválida */ }
     }
 
+    const notificationsRow = document.createElement('label');
+    notificationsRow.className = 'check-item';
+    notificationsRow.style.marginTop = '0.75rem';
+
+    const notificationsToggle = document.createElement('input');
+    notificationsToggle.type = 'checkbox';
+    notificationsToggle.checked = Boolean(task.dueDate && task.notifications !== false);
+    notificationsToggle.disabled = !task.dueDate;
+    notificationsToggle.setAttribute('aria-label', 'Activar recordatorios de vencimiento');
+    notificationsToggle.addEventListener('change', () => {
+      this._save({ notifications: notificationsToggle.checked });
+    });
+
+    const notificationsText = document.createElement('span');
+    notificationsText.textContent = 'Notificaciones de vencimiento';
+
+    notificationsRow.appendChild(notificationsToggle);
+    notificationsRow.appendChild(notificationsText);
+
     input.addEventListener('change', () => {
       let isoValue: string | null = null;
       if (input.value) {
@@ -1743,7 +1762,20 @@ export class DojoTaskDetail extends HTMLElement {
           }
         }
       }
-      this._save({ dueDate: isoValue });
+
+      if (isoValue) {
+        const shouldEnableNotifications = this._task?.dueDate
+          ? this._task.notifications !== false
+          : true;
+        notificationsToggle.disabled = false;
+        notificationsToggle.checked = shouldEnableNotifications;
+        this._save({ dueDate: isoValue, notifications: shouldEnableNotifications });
+        return;
+      }
+
+      notificationsToggle.checked = false;
+      notificationsToggle.disabled = true;
+      this._save({ dueDate: null, notifications: false });
     });
 
     const clearBtn = document.createElement('button');
@@ -1754,13 +1786,16 @@ export class DojoTaskDetail extends HTMLElement {
     clearBtn.style.flexShrink = '0';
     clearBtn.addEventListener('click', () => {
       input.value = '';
-      this._save({ dueDate: null });
+      notificationsToggle.checked = false;
+      notificationsToggle.disabled = true;
+      this._save({ dueDate: null, notifications: false });
     });
 
     row.appendChild(input);
     row.appendChild(clearBtn);
     section.appendChild(lbl);
     section.appendChild(row);
+    section.appendChild(notificationsRow);
     return section;
   }
 

--- a/src/db/task.repository.ts
+++ b/src/db/task.repository.ts
@@ -15,6 +15,18 @@ import type { Task, Priority } from '../types/models.js';
 type CreateTaskInput = Omit<Task, 'id' | 'createdAt' | 'updatedAt'>;
 type UpdateTaskInput = Partial<Omit<Task, 'id' | 'createdAt'>>;
 
+function normalizeTaskNotifications<T extends Pick<Task, 'dueDate' | 'notifications'>>(task: T): T {
+  if (!task.dueDate) {
+    return { ...task, notifications: false };
+  }
+
+  if (task.notifications === undefined) {
+    return { ...task, notifications: true };
+  }
+
+  return task;
+}
+
 // ── Implementación ─────────────────────────────────────────────────────────
 
 /** Devuelve todas las tareas almacenadas. */
@@ -55,7 +67,7 @@ export async function getTasksByPriority(priority: Priority): Promise<Task[]> {
 export async function createTask(input: CreateTaskInput): Promise<Task> {
   const now  = new Date().toISOString();
   const task: Task = {
-    ...input,
+    ...normalizeTaskNotifications(input),
     id:        generateUUID(),
     createdAt: now,
     updatedAt: now,
@@ -79,13 +91,13 @@ export async function updateTask(id: string, changes: UpdateTaskInput): Promise<
   const existing = await getTaskById(id);
   if (!existing) throw new Error(`Task not found: ${id}`);
 
-  const updated: Task = {
+  const updated: Task = normalizeTaskNotifications({
     ...existing,
     ...changes,
     id,                              // id nunca puede cambiar
     createdAt: existing.createdAt,   // createdAt nunca puede cambiar
     updatedAt: new Date().toISOString(),
-  };
+  });
 
   const { store, tx } = await getStore('tasks', 'readwrite');
   store.put(updated);

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,10 @@ async function bootstrap(): Promise<void> {
     initializeUISync();
 
     // 3e. Sincronizar recordatorios de vencimiento con el Service Worker (US-34)
-    await initializeTaskNotifications();
+    //     No debe bloquear el arranque: el Service Worker puede registrarse más tarde.
+    void initializeTaskNotifications().catch((error) => {
+      console.error('[Dojo Kanban] Error al inicializar notificaciones de tareas:', error);
+    });
 
     // 4. Registrar Web Components — US-01 Visualización del tablero Kanban
     await import('./components/organisms/dojo-app/dojo-app.js');

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { getAllBoards } from './db/board.repository.js';
 import { seedDefaultColumns } from './db/column.repository.js';
 import { initTheme } from './utils/theme.js';
 import { initializeUISync } from './utils/ui-sync.js';
+import { initializeTaskNotifications } from './utils/task-notifications.js';
 
 // ── Inicialización ─────────────────────────────────────────────────────────
 
@@ -44,6 +45,9 @@ async function bootstrap(): Promise<void> {
 
     // 3d. Inicializar sincronización entre pestañas (US-30)
     initializeUISync();
+
+    // 3e. Sincronizar recordatorios de vencimiento con el Service Worker (US-34)
+    await initializeTaskNotifications();
 
     // 4. Registrar Web Components — US-01 Visualización del tablero Kanban
     await import('./components/organisms/dojo-app/dojo-app.js');

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -49,6 +49,8 @@ export interface Task {
   updatedAt: string;
   /** Fecha de vencimiento en formato ISO 8601. Null/undefined = sin vencimiento (US-17). */
   dueDate?: string | null;
+  /** Indica si la tarea puede generar recordatorios de vencimiento (US-34). */
+  notifications?: boolean;
   /** Lista de subtareas (checklist). Puede estar vacía (US-21). */
   subtasks?: Subtask[];
   /** Lista de FK → Person.id asignadas a la tarea (US-29). */

--- a/src/utils/task-notifications.ts
+++ b/src/utils/task-notifications.ts
@@ -17,7 +17,17 @@ export interface NotificationTaskSummary {
 let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 function canUseSessionStorage(): boolean {
-  return typeof sessionStorage !== 'undefined';
+  if (typeof window === 'undefined') return false;
+
+  try {
+    const storage = window.sessionStorage;
+    const testKey = `${SESSION_PROMPT_DISMISSED_KEY}:probe`;
+    storage.setItem(testKey, '1');
+    storage.removeItem(testKey);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isNotifiableTask(task: Task): task is Task & { dueDate: string } {

--- a/src/utils/task-notifications.ts
+++ b/src/utils/task-notifications.ts
@@ -1,0 +1,161 @@
+import { getColumnsByBoard } from '../db/column.repository.js';
+import { getAllTasks } from '../db/task.repository.js';
+import type { Task } from '../types/models.js';
+import { onMultipleSync } from './broadcast-sync.js';
+
+const SESSION_PROMPT_DISMISSED_KEY = 'dojo:notifications-prompt-dismissed';
+const PERIODIC_SYNC_TAG = 'dojo-task-notifications';
+
+export interface NotificationTaskSummary {
+  id: string;
+  boardId: string;
+  title: string;
+  dueDate: string;
+  statusName: string;
+}
+
+let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function canUseSessionStorage(): boolean {
+  return typeof sessionStorage !== 'undefined';
+}
+
+function isNotifiableTask(task: Task): task is Task & { dueDate: string } {
+  return Boolean(task.dueDate && task.notifications !== false);
+}
+
+async function postToServiceWorker(message: unknown): Promise<void> {
+  if (!('serviceWorker' in navigator)) return;
+
+  const registration = await navigator.serviceWorker.ready;
+  const target = registration.active ?? registration.waiting ?? registration.installing ?? navigator.serviceWorker.controller;
+  target?.postMessage(message);
+}
+
+async function registerPeriodicTaskNotificationSync(): Promise<void> {
+  if (!('serviceWorker' in navigator) || Notification.permission !== 'granted') return;
+
+  const registration = await navigator.serviceWorker.ready;
+  const periodicSync = (registration as ServiceWorkerRegistration & {
+    periodicSync?: { register(tag: string, options?: { minInterval: number }): Promise<void> };
+  }).periodicSync;
+
+  if (!periodicSync) return;
+
+  try {
+    await periodicSync.register(PERIODIC_SYNC_TAG, { minInterval: 60 * 60 * 1000 });
+  } catch {
+    // Silencio: algunos navegadores requieren permisos/flags adicionales.
+  }
+}
+
+export function canUseTaskNotifications(): boolean {
+  return typeof window !== 'undefined'
+    && 'Notification' in window
+    && 'serviceWorker' in navigator;
+}
+
+export async function collectNotificationTaskSummaries(): Promise<NotificationTaskSummary[]> {
+  const eligibleTasks = (await getAllTasks()).filter(isNotifiableTask);
+  if (eligibleTasks.length === 0) return [];
+
+  const boardIds = [...new Set(eligibleTasks.map(task => task.boardId))];
+  const boardColumns = await Promise.all(boardIds.map(async (boardId) => [boardId, await getColumnsByBoard(boardId)] as const));
+  const columnNameById = new Map<string, string>();
+
+  for (const [, columns] of boardColumns) {
+    columns.forEach(column => columnNameById.set(column.id, column.name));
+  }
+
+  return eligibleTasks
+    .map(task => ({
+      id: task.id,
+      boardId: task.boardId,
+      title: task.title,
+      dueDate: task.dueDate,
+      statusName: columnNameById.get(task.statusId) ?? 'Sin estado',
+    }))
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
+}
+
+export async function syncTaskNotifications(): Promise<void> {
+  if (!canUseTaskNotifications()) return;
+
+  const tasks = await collectNotificationTaskSummaries();
+  await postToServiceWorker({ type: 'dojo:notifications-sync', tasks });
+
+  if (Notification.permission === 'granted') {
+    await registerPeriodicTaskNotificationSync();
+  }
+}
+
+export async function initializeTaskNotifications(): Promise<() => void> {
+  if (!canUseTaskNotifications()) return () => {};
+
+  const scheduleSync = (): void => {
+    if (syncDebounceTimer) clearTimeout(syncDebounceTimer);
+    syncDebounceTimer = setTimeout(() => {
+      syncDebounceTimer = null;
+      void syncTaskNotifications();
+    }, 120);
+  };
+
+  const unsubscribe = onMultipleSync({
+    'task:created': scheduleSync,
+    'task:updated': scheduleSync,
+    'task:deleted': scheduleSync,
+    'column:created': scheduleSync,
+    'column:updated': scheduleSync,
+    'column:deleted': scheduleSync,
+    'board:created': scheduleSync,
+    'board:updated': scheduleSync,
+    'board:deleted': scheduleSync,
+  });
+
+  await syncTaskNotifications();
+  return () => {
+    if (syncDebounceTimer) {
+      clearTimeout(syncDebounceTimer);
+      syncDebounceTimer = null;
+    }
+    unsubscribe();
+  };
+}
+
+export function dismissTaskNotificationPromptForSession(): void {
+  if (!canUseSessionStorage()) return;
+  sessionStorage.setItem(SESSION_PROMPT_DISMISSED_KEY, '1');
+}
+
+export function clearTaskNotificationPromptDismissal(): void {
+  if (!canUseSessionStorage()) return;
+  sessionStorage.removeItem(SESSION_PROMPT_DISMISSED_KEY);
+}
+
+export function hasDismissedTaskNotificationPromptForSession(): boolean {
+  return canUseSessionStorage() && sessionStorage.getItem(SESSION_PROMPT_DISMISSED_KEY) === '1';
+}
+
+export async function shouldPromptForTaskNotifications(): Promise<boolean> {
+  if (!canUseTaskNotifications()) return false;
+  if (Notification.permission !== 'default') return false;
+  if (hasDismissedTaskNotificationPromptForSession()) return false;
+
+  const tasks = await collectNotificationTaskSummaries();
+  return tasks.length > 0;
+}
+
+export async function requestTaskNotificationPermission(): Promise<NotificationPermission> {
+  if (!canUseTaskNotifications()) return 'denied';
+
+  const permission = await Notification.requestPermission();
+
+  if (permission === 'granted') {
+    clearTaskNotificationPromptDismissal();
+    await syncTaskNotifications();
+    return permission;
+  }
+
+  dismissTaskNotificationPromptForSession();
+  return permission;
+}


### PR DESCRIPTION
## Descripción

Implementa **US-34 — Notificaciones del navegador para fechas de vencimiento** (IMP-03).

Integra la Notification API con el Service Worker existente para enviar recordatorios automáticos de tareas próximas a vencer, con soporte para segundo plano y deduplicación entre pestañas.

---

## Cambios incluidos

### Modelo de datos
- `src/types/models.ts` — Añade campo opcional `notifications?: boolean` a `Task`.

### Persistencia
- `src/db/task.repository.ts` — Función `normalizeTaskNotifications` aplicada en `createTask` y `updateTask`: activa `notifications: true` por defecto cuando hay `dueDate`, lo pone a `false` cuando se elimina la fecha.

### Infraestructura de notificaciones
- `src/utils/task-notifications.ts` *(nuevo)* — Gestor central:
  - `collectNotificationTaskSummaries()` — Lee tareas elegibles de IndexedDB y resuelve nombres de columna.
  - `syncTaskNotifications()` — Envía el resumen al Service Worker via `postMessage`.
  - `initializeTaskNotifications()` — Inicializa el ciclo y se suscribe a eventos de sincronización entre pestañas (US-30) para re-sincronizar ante cambios.
  - `shouldPromptForTaskNotifications()` / `requestTaskNotificationPermission()` — Lógica de permiso con guard de sesión (no repite en la misma sesión si el usuario deniega).

### Arranque de la app
- `src/main.ts` — Llama a `initializeTaskNotifications()` en el bootstrap.

### UI — Banner de permiso y deep link
- `src/components/organisms/dojo-app/dojo-app.ts`:
  - Banner no intrusivo (debajo del header) que aparece solo cuando hay tareas con `dueDate` y el permiso está en estado `default`. Botones "Ahora no" y "Permitir".
  - `_readPendingTaskLink()` — Lee `?boardId=&taskId=` de la URL al arrancar.
  - `_openPendingTaskLink()` — Abre el panel de detalle de la tarea indicada cuando el tablero esté listo (`dojo:board-ready`).

### UI — Toggle por tarea
- `src/components/organisms/dojo-task-detail/dojo-task-detail.ts`:
  - Checkbox "Notificaciones de vencimiento" bajo el campo de fecha, deshabilitado si no hay fecha, activo por defecto al asignar una fecha.
  - Al borrar la fecha el toggle se desactiva automáticamente y guarda `notifications: false`.

### Service Worker
- `public/sw.js`:
  - `syncNotificationTasks(tasks)` — Almacena las tareas en Cache API y llama a `checkDueNotifications()`.
  - `checkDueNotifications()` — Dispara notificaciones para el recordatorio de 24 h y el vencimiento exacto, sin duplicar (estado persistido en Cache API).
  - `scheduleNotificationCheck()` — Programa el siguiente setTimeout al momento del próximo trigger pendiente.
  - Listener `message` — Procesa `dojo:notifications-sync` desde la app.
  - Listener `periodicsync` — Comprueba notificaciones cuando el navegador lo activa en segundo plano.
  - Listener `notificationclick` — Navega a `?boardId=&taskId=` y enfoca/abre la ventana de la app. Deduplicación mediante el campo `tag` de la notificación.

---

## Criterios de aceptación cubiertos

- [x] La solicitud de permiso se muestra solo una vez y de forma no bloqueante.
- [x] Si el permiso es denegado, no hay errores y no se vuelve a solicitar en la misma sesión.
- [x] Notificaciones 24 h antes y en el momento exacto del vencimiento.
- [x] Funcionan aunque la pestaña esté cerrada (via Service Worker).
- [x] Toggle de notificaciones por tarea visible y funcional en el panel de edición.
- [x] Notificaciones incluyen acción que abre la tarea directamente.
- [x] Sin notificaciones duplicadas entre pestañas (tag único + estado persistido en Cache API).

---

Closes #70