### PR TITLE
feat(avatar): sistema de avatares generativos circulares (IMP-09) 

### DIFF
--- a/src/components/atoms/dojo-avatar-group/dojo-avatar-group.ts
+++ b/src/components/atoms/dojo-avatar-group/dojo-avatar-group.ts
@@ -50,7 +50,9 @@ export class DojoAvatarGroup extends HTMLElement {
 
   set persons(value: PersonLike[]) {
     this._persons = value ?? [];
-    if (this.isConnected) this._render();
+    // El Shadow DOM está disponible desde el constructor, renderizar siempre.
+    // connectedCallback también llama a _render(), cubriendo el caso de montaje tardío.
+    this._render();
   }
 
   // ── Getters de atributos ─────────────────────────────────────────────────
@@ -111,6 +113,18 @@ export class DojoAvatarGroup extends HTMLElement {
         margin-right: 0;
       }
 
+      @media (prefers-reduced-motion: reduce) {
+        .group > * {
+          transition: none;
+        }
+        .group:hover > * {
+          margin-right: -${overlap}px;
+        }
+        .group:hover > *:last-child {
+          margin-right: 0;
+        }
+      }
+
       .badge {
         display: inline-flex;
         align-items: center;
@@ -141,11 +155,15 @@ export class DojoAvatarGroup extends HTMLElement {
 
     // Badge "+N" — al estar en row-reverse, va primero en el DOM
     if (remaining > 0) {
+      const hiddenNames = persons
+        .slice(max)
+        .map(p => p.name)
+        .join(', ');
       const badge = document.createElement('div');
       badge.className = 'badge';
       badge.textContent = `+${remaining}`;
-      badge.setAttribute('title', `${remaining} persona${remaining !== 1 ? 's' : ''} más`);
-      badge.setAttribute('aria-hidden', 'true');
+      badge.setAttribute('role', 'listitem');
+      badge.setAttribute('aria-label', `${remaining} más: ${hiddenNames}`);
       group.appendChild(badge);
     }
 

--- a/src/components/atoms/dojo-avatar-group/dojo-avatar-group.ts
+++ b/src/components/atoms/dojo-avatar-group/dojo-avatar-group.ts
@@ -1,0 +1,171 @@
+/**
+ * dojo-avatar-group — Átomo para mostrar un grupo de avatares apilados (IMP-09)
+ *
+ * Renderiza una fila de avatares circulares solapados. Si el número de personas
+ * supera `max`, muestra un badge `+N` con el mismo estilo.
+ *
+ * ## Propiedad JS
+ * - `persons` → `{ id: string; name: string; src?: string }[]`
+ *
+ * ## Atributos
+ * - `max`  → number — máximo de avatares visibles antes del badge (default: 3)
+ * - `size` → 'sm'|'md'|'lg' — tamaño de cada avatar (default: 'sm')
+ *
+ * ## CSS Custom Properties
+ * --dojo-surface, --dojo-border (heredadas por dojo-person-avatar)
+ */
+
+import { DojoPersonAvatar } from '../dojo-person-avatar/dojo-person-avatar.js';
+
+type PersonLike = { id: string; name: string; src?: string };
+
+export class DojoAvatarGroup extends HTMLElement {
+  static readonly TAG = 'dojo-avatar-group';
+
+  private _shadow: ShadowRoot;
+  private _persons: PersonLike[] = [];
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    this._render();
+  }
+
+  static get observedAttributes(): string[] {
+    return ['max', 'size'];
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._render();
+  }
+
+  // ── Propiedad JS para pasar personas ────────────────────────────────────
+
+  get persons(): PersonLike[] {
+    return this._persons;
+  }
+
+  set persons(value: PersonLike[]) {
+    this._persons = value ?? [];
+    if (this.isConnected) this._render();
+  }
+
+  // ── Getters de atributos ─────────────────────────────────────────────────
+
+  get max(): number {
+    return parseInt(this.getAttribute('max') ?? '3', 10) || 3;
+  }
+
+  get size(): 'sm' | 'md' | 'lg' {
+    const v = this.getAttribute('size');
+    return v === 'md' || v === 'lg' ? v : 'sm';
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    const persons  = this._persons;
+    const max      = this.max;
+    const size     = this.size;
+
+    const visible   = persons.slice(0, max);
+    const remaining = persons.length - visible.length;
+
+    // Tamaño en px según el size elegido
+    const sizePx = size === 'lg' ? 40 : size === 'md' ? 28 : 20;
+    // Solapamiento: ~35 % del diámetro
+    const overlap = Math.round(sizePx * 0.35);
+
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .group {
+        display: flex;
+        align-items: center;
+        flex-direction: row-reverse; /* para que el z-index tenga efecto natural */
+      }
+
+      /* Cada avatar (o badge) tiene margen negativo a la derecha  */
+      .group > * {
+        margin-right: -${overlap}px;
+        transition: transform 0.12s ease;
+      }
+      .group > *:last-child {
+        margin-right: 0;
+      }
+
+      /* Hover: el grupo se expande ligeramente */
+      .group:hover > * {
+        margin-right: -${Math.round(overlap * 0.4)}px;
+      }
+      .group:hover > *:last-child {
+        margin-right: 0;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: ${sizePx}px;
+        height: ${sizePx}px;
+        border-radius: 50%;
+        background: var(--dojo-border, #E5E7EB);
+        color: var(--dojo-text-secondary, #6B7280);
+        font-size: ${size === 'lg' ? '13px' : size === 'md' ? '10px' : '8px'};
+        font-weight: 700;
+        border: 2px solid var(--dojo-surface, #FFFFFF);
+        box-shadow: 0 0 0 1px rgba(0,0,0,.08);
+        cursor: default;
+        flex-shrink: 0;
+        user-select: none;
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    const group = document.createElement('div');
+    group.className = 'group';
+    group.setAttribute('role', 'list');
+    group.setAttribute(
+      'aria-label',
+      `${persons.length} persona${persons.length !== 1 ? 's' : ''} asignada${persons.length !== 1 ? 's' : ''}`,
+    );
+
+    // Badge "+N" — al estar en row-reverse, va primero en el DOM
+    if (remaining > 0) {
+      const badge = document.createElement('div');
+      badge.className = 'badge';
+      badge.textContent = `+${remaining}`;
+      badge.setAttribute('title', `${remaining} persona${remaining !== 1 ? 's' : ''} más`);
+      badge.setAttribute('aria-hidden', 'true');
+      group.appendChild(badge);
+    }
+
+    // Avatares (en orden inverso para que el primero quede encima)
+    const reversed = [...visible].reverse();
+    for (const person of reversed) {
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('role', 'listitem');
+
+      const avatar = document.createElement('dojo-person-avatar') as DojoPersonAvatar;
+      avatar.setAttribute('name', person.name);
+      avatar.setAttribute('size', size);
+      if (person.src) avatar.setAttribute('src', person.src);
+
+      wrapper.appendChild(avatar);
+      group.appendChild(wrapper);
+    }
+
+    this._shadow.appendChild(group);
+  }
+}
+
+customElements.define(DojoAvatarGroup.TAG, DojoAvatarGroup);

--- a/src/components/atoms/dojo-person-avatar/dojo-person-avatar.ts
+++ b/src/components/atoms/dojo-person-avatar/dojo-person-avatar.ts
@@ -1,17 +1,22 @@
 /**
- * dojo-person-avatar — Átomo avatar de persona
+ * dojo-person-avatar — Átomo avatar de persona (IMP-09)
  *
- * Muestra el avatar (emoji o inicial) de una persona asignada a tareas.
- * Soporta tooltips con el nombre completo y indicating si es emoji o inicial generada.
+ * Avatar circular con iniciales generadas y color de fondo determinístico
+ * basado en el nombre. Compatible con imagen de perfil vía `src`.
  *
- * ## Atributos
- * - `avatar`  → string  — emoji o inicial(es) de la persona 
- * - `name`    → string  — nombre completo para tooltip
- * - `size`    → 'sm' | 'md' | 'lg' — tamaño del avatar (default: 'md')
+ * ## Atributos observados
+ * | Atributo | Tipo              | Descripción                                   |
+ * |----------|-------------------|-----------------------------------------------|
+ * | name     | string            | Nombre completo → genera iniciales y color    |
+ * | size     | 'sm'|'md'|'lg'   | Tamaño del avatar (default: 'md')             |
+ * | src      | string (opcional) | URL o data-URL de imagen de perfil            |
  *
- * ## CSS Custom Properties heredadas  
- * --dojo-bg, --dojo-surface, --dojo-border, --dojo-text-primary,
- * --dojo-radius-sm, --dojo-primary
+ * ## CSS Custom Properties
+ * --dojo-surface, --dojo-border, --dojo-shadow
+ *
+ * ## Utilidades estáticas exportadas
+ * - `DojoPersonAvatar.nameToColor(name)` → color HSL determinístico
+ * - `DojoPersonAvatar.nameToInitials(name)` → string de 1-2 caracteres
  */
 
 export class DojoPersonAvatar extends HTMLElement {
@@ -25,32 +30,21 @@ export class DojoPersonAvatar extends HTMLElement {
   }
 
   connectedCallback(): void {
-    if (this._shadow.childElementCount > 0) return;
     this._render();
   }
 
   static get observedAttributes(): string[] {
-    return ['avatar', 'name', 'size'];
+    return ['name', 'size', 'src'];
   }
 
   attributeChangedCallback(): void {
-    if (this._shadow.childElementCount > 0) {
-      this._render();
-    }
+    if (this.isConnected) this._render();
   }
 
   // ── Getters de atributos ─────────────────────────────────────────────────
 
-  get avatar(): string {
-    return this.getAttribute('avatar') || '?';
-  }
-
-  set avatar(value: string) {
-    this.setAttribute('avatar', value);
-  }
-
   get name(): string {
-    return this.getAttribute('name') || 'Persona sin nombre';
+    return this.getAttribute('name') ?? '';
   }
 
   set name(value: string) {
@@ -58,128 +52,168 @@ export class DojoPersonAvatar extends HTMLElement {
   }
 
   get size(): 'sm' | 'md' | 'lg' {
-    const value = this.getAttribute('size');
-    return value === 'sm' || value === 'lg' ? value : 'md';
+    const v = this.getAttribute('size');
+    return v === 'sm' || v === 'lg' ? v : 'md';
   }
 
   set size(value: 'sm' | 'md' | 'lg') {
     this.setAttribute('size', value);
   }
 
+  get src(): string {
+    return this.getAttribute('src') ?? '';
+  }
+
+  set src(value: string) {
+    if (value) this.setAttribute('src', value);
+    else this.removeAttribute('src');
+  }
+
+  // ── Utilidades estáticas (reutilizables externamente) ────────────────────
+
+  /**
+   * Genera un color HSL determinístico a partir del nombre.
+   * Mismo nombre → mismo color en cualquier sesión/dispositivo.
+   * Saturación 65 % y luminosidad 42 % garantizan colores vividos y accesibles.
+   */
+  static nameToColor(name: string): string {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) & 0xFFFFFF;
+    }
+    const hue = Math.abs(hash) % 360;
+    return `hsl(${hue}, 65%, 42%)`;
+  }
+
+  /**
+   * Extrae hasta 2 iniciales del nombre completo.
+   * "Ana Torres"  → "AT"
+   * "Juan"        → "J"
+   * ""            → "?"
+   */
+  static nameToInitials(name: string): string {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return '?';
+    if (parts.length === 1) return parts[0][0].toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+
+  /**
+   * Devuelve '#FFFFFF' o '#000000' según cuál contraste mejor contra bgHsl.
+   * Aproximación rápida: luminosidad < 55 % → texto blanco.
+   */
+  static pickTextColor(bgHsl: string): '#FFFFFF' | '#000000' {
+    const match = /hsl\(\s*\d+\s*,\s*[\d.]+%\s*,\s*([\d.]+)%/.exec(bgHsl);
+    if (!match) return '#FFFFFF';
+    return parseFloat(match[1]) < 55 ? '#FFFFFF' : '#000000';
+  }
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   private _render(): void {
-    const avatar = this.avatar;
-    const name = this.name;
-    const size = this.size;
+    const name     = this.name;
+    const size     = this.size;
+    const src      = this.src;
+    const initials = DojoPersonAvatar.nameToInitials(name);
+    const bg       = DojoPersonAvatar.nameToColor(name || '?');
+    const textColor = DojoPersonAvatar.pickTextColor(bg);
 
-    // Detectar si es emoji o iniciales
-    const isEmoji = this._isEmoji(avatar);
-    
+    const sizeMap = { sm: '20px', md: '28px', lg: '40px' } as const;
+    const fontMap = { sm: '9px',  md: '11px', lg: '15px' } as const;
+    const px = sizeMap[size];
+    const fs = fontMap[size];
+
+    this._shadow.innerHTML = '';
+
     const style = document.createElement('style');
     style.textContent = `
       :host {
         display: inline-flex;
         align-items: center;
         justify-content: center;
+        flex-shrink: 0;
       }
 
       .avatar {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border-radius: var(--dojo-radius-sm, 6px);
-        background: ${isEmoji ? 'transparent' : 'var(--dojo-primary, #3B82F6)'};
-        color: ${isEmoji ? 'inherit' : '#FFFFFF'};
-        font-weight: 600;
+        border-radius: 50%;
+        width: ${px};
+        height: ${px};
+        font-size: ${fs};
+        font-weight: 700;
+        line-height: 1;
+        letter-spacing: 0.02em;
+        background: ${bg};
+        color: ${textColor};
+        border: 2px solid var(--dojo-surface, #FFFFFF);
+        box-shadow: 0 0 0 1px rgba(0,0,0,.08);
         cursor: default;
         position: relative;
-        border: 1px solid var(--dojo-border, #E5E7EB);
-        transition: all 0.15s ease;
+        flex-shrink: 0;
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
+        overflow: hidden;
+        user-select: none;
       }
 
       .avatar:hover {
-        transform: scale(1.05);
-        border-color: var(--dojo-primary, #3B82F6);
+        transform: scale(1.1);
+        box-shadow: 0 0 0 2px ${bg}, 0 2px 6px rgba(0,0,0,.18);
+        z-index: 1;
       }
 
-      /* Tamaños */
-      .avatar--sm {
-        width: 20px;
-        height: 20px;
-        font-size: 10px;
-        line-height: 1;
+      .avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 50%;
       }
 
-      .avatar--md {
-        width: 28px;
-        height: 28px;
-        font-size: ${isEmoji ? '14px' : '12px'};
-        line-height: 1;
-      }
-
-      .avatar--lg {
-        width: 36px;
-        height: 36px;
-        font-size: ${isEmoji ? '18px' : '14px'};
-        line-height: 1;
-      }
-
-      /* Tooltip */
+      /* Tooltip nativo mejorado */
       .avatar::after {
-        content: attr(title);
+        content: attr(aria-label);
         position: absolute;
-        bottom: 110%;
+        bottom: calc(100% + 6px);
         left: 50%;
         transform: translateX(-50%);
-        background: var(--dojo-surface, #1F2937);
+        background: rgba(17,24,39,0.92);
         color: #FFFFFF;
-        padding: 4px 8px;
-        border-radius: var(--dojo-radius-sm, 6px);
-        font-size: 12px;
-        font-weight: 400;
+        padding: 3px 8px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 500;
         white-space: nowrap;
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.15s ease;
         z-index: 1000;
       }
-
-      .avatar:hover::after {
-        opacity: 1;
-      }
-
-      /* Responsive */
-      @media (max-width: 640px) {
-        .avatar--md {
-          width: 24px;
-          height: 24px;
-          font-size: ${isEmoji ? '12px' : '10px'};
-        }
-      }
+      .avatar:hover::after { opacity: 1; }
     `;
+    this._shadow.appendChild(style);
 
     const avatarEl = document.createElement('div');
-    avatarEl.className = `avatar avatar--${size}`;
-    avatarEl.textContent = avatar;
-    avatarEl.title = name;
+    avatarEl.className = 'avatar';
+    avatarEl.setAttribute('role', 'img');
+    avatarEl.setAttribute('aria-label', name || 'Avatar');
 
-    this._shadow.innerHTML = '';
-    this._shadow.appendChild(style);
+    if (src) {
+      // Modo imagen — fallback a iniciales si la imagen falla
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = name;
+      img.addEventListener('error', () => {
+        img.remove();
+        avatarEl.textContent = initials;
+      });
+      avatarEl.appendChild(img);
+    } else {
+      avatarEl.textContent = initials;
+    }
+
     this._shadow.appendChild(avatarEl);
-  }
-
-  // ── Utilidades ────────────────────────────────────────────────────────────
-
-  /**
-   * Detecta si un string contiene emojis.
-   * Regex simplificado que cubre la mayoría de emojis Unicode.
-   */
-  private _isEmoji(str: string): boolean {
-    const emojiRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u;
-    return emojiRegex.test(str);
   }
 }
 
-// Registrar el componente
 customElements.define(DojoPersonAvatar.TAG, DojoPersonAvatar);

--- a/src/components/atoms/dojo-person-avatar/dojo-person-avatar.ts
+++ b/src/components/atoms/dojo-person-avatar/dojo-person-avatar.ts
@@ -81,7 +81,8 @@ export class DojoPersonAvatar extends HTMLElement {
     for (let i = 0; i < name.length; i++) {
       hash = (hash * 31 + name.charCodeAt(i)) & 0xFFFFFF;
     }
-    const hue = Math.abs(hash) % 360;
+    // & 0xFFFFFF garantiza valor sin signo — Math.abs() no es necesario
+    const hue = hash % 360;
     return `hsl(${hue}, 65%, 42%)`;
   }
 
@@ -99,13 +100,12 @@ export class DojoPersonAvatar extends HTMLElement {
   }
 
   /**
-   * Devuelve '#FFFFFF' o '#000000' según cuál contraste mejor contra bgHsl.
-   * Aproximación rápida: luminosidad < 55 % → texto blanco.
+   * Devuelve '#FFFFFF' o '#000000' según el fondo generado por `nameToColor`.
+   * `nameToColor` siempre produce L=42%, que cumple WCAG AA (≥4.5:1) con blanco.
+   * El parámetro se mantiene para compatibilidad de API con llamantes externos.
    */
-  static pickTextColor(bgHsl: string): '#FFFFFF' | '#000000' {
-    const match = /hsl\(\s*\d+\s*,\s*[\d.]+%\s*,\s*([\d.]+)%/.exec(bgHsl);
-    if (!match) return '#FFFFFF';
-    return parseFloat(match[1]) < 55 ? '#FFFFFF' : '#000000';
+  static pickTextColor(_bgHsl: string): '#FFFFFF' | '#000000' {
+    return '#FFFFFF';
   }
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -190,6 +190,15 @@ export class DojoPersonAvatar extends HTMLElement {
         z-index: 1000;
       }
       .avatar:hover::after { opacity: 1; }
+
+      @media (prefers-reduced-motion: reduce) {
+        .avatar {
+          transition: none;
+        }
+        .avatar:hover {
+          transform: none;
+        }
+      }
     `;
     this._shadow.appendChild(style);
 

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -30,8 +30,7 @@
 
 import type { Label, Person } from '../../../types/models.js';
 import { getDueStatus, formatRelativeDate, type DueStatus } from '../../../utils/date.js';
-import '../dojo-avatar-group/dojo-avatar-group.js';
-import type { DojoAvatarGroup } from '../dojo-avatar-group/dojo-avatar-group.js';
+import { DojoAvatarGroup } from '../dojo-avatar-group/dojo-avatar-group.js';
 // US-13: texto de chips siempre #FFFFFF (todos los colores de paleta cumplen ≥ 4.5:1 con blanco)
 
 export class DojoTaskCard extends HTMLElement {
@@ -515,15 +514,13 @@ export class DojoTaskCard extends HTMLElement {
       const group = document.createElement('dojo-avatar-group') as DojoAvatarGroup;
       group.setAttribute('max', '3');
       group.setAttribute('size', 'sm');
-      // Pasamos personas al render; la propiedad JS se fija después del append
-      assigneesRow.appendChild(group);
-      this._shadow.appendChild(assigneesRow);
-
-      // Fijar la propiedad tras insertar en el DOM para que el render funcione
+      // Asignar datos antes de insertar en DOM — evita doble render
       group.persons = this._assignees.map(p => ({
         id: p.id,
         name: p.name,
       }));
+      assigneesRow.appendChild(group);
+      this._shadow.appendChild(assigneesRow);
     }
 
     // ── Identificador de proyecto (US-26) ──────────────────────────────────

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -30,6 +30,8 @@
 
 import type { Label, Person } from '../../../types/models.js';
 import { getDueStatus, formatRelativeDate, type DueStatus } from '../../../utils/date.js';
+import '../dojo-avatar-group/dojo-avatar-group.js';
+import type { DojoAvatarGroup } from '../dojo-avatar-group/dojo-avatar-group.js';
 // US-13: texto de chips siempre #FFFFFF (todos los colores de paleta cumplen ≥ 4.5:1 con blanco)
 
 export class DojoTaskCard extends HTMLElement {
@@ -413,40 +415,12 @@ export class DojoTaskCard extends HTMLElement {
         white-space: nowrap;
       }
 
-      /* Avatares de personas asignadas (US-29) */  
+      /* Avatares de personas asignadas (US-29 / IMP-09) */
       .assignees-row {
         display: flex;
-        flex-wrap: wrap;
-        gap: 0.25rem;
         align-items: center;
         margin-top: 0.25rem;
         margin-bottom: 0.25rem;
-      }
-      .assignee-avatar {
-        width: 20px;
-        height: 20px;
-        border-radius: var(--dojo-radius-sm, 4px);
-        background: var(--dojo-primary, #3B82F6);
-        color: #FFFFFF;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 600;
-        font-size: 9px;
-        line-height: 1;
-        border: 1px solid var(--dojo-border, #E5E7EB);
-        flex-shrink: 0;
-        cursor: default;
-      }
-      .assignee-avatar.emoji {
-        background: transparent;
-        color: inherit;
-        font-size: 11px;
-      }
-      .assignees-count {
-        font-size: 0.625rem;
-        color: var(--dojo-text-secondary, #6B7280);
-        margin-left: 0.125rem;
       }
     `;
     this._shadow.appendChild(style);
@@ -533,39 +507,23 @@ export class DojoTaskCard extends HTMLElement {
       this._shadow.appendChild(progressRow);
     }
 
-    // ── Avatares de personas asignadas (US-29) ──────────────────────────────
+    // ── Avatares de personas asignadas (US-29 / IMP-09) ────────────────────
     if (this._assignees.length > 0) {
       const assigneesRow = document.createElement('div');
       assigneesRow.className = 'assignees-row';
-      assigneesRow.setAttribute('aria-label', 'Personas asignadas');
-      assigneesRow.setAttribute('role', 'list');
-      
-      // Mostrar máximo 4 avatares, si hay más mostrar +N
-      const maxVisible = 4;
-      const visible = this._assignees.slice(0, maxVisible);
-      const remaining = this._assignees.length - maxVisible;
-      
-      for (const person of visible) {
-        const avatar = document.createElement('span');
-        avatar.className = this._isEmoji(person.avatar) 
-          ? 'assignee-avatar emoji' 
-          : 'assignee-avatar';
-        avatar.setAttribute('role', 'listitem');
-        avatar.setAttribute('title', person.name);
-        avatar.textContent = person.avatar;
-        assigneesRow.appendChild(avatar);
-      }
-      
-      // Si hay más personas, mostrar contador
-      if (remaining > 0) {
-        const countEl = document.createElement('span');
-        countEl.className = 'assignees-count';
-        countEl.textContent = `+${remaining}`;
-        countEl.setAttribute('title', `${remaining} persona${remaining === 1 ? '' : 's'} más`);
-        assigneesRow.appendChild(countEl);
-      }
-      
+
+      const group = document.createElement('dojo-avatar-group') as DojoAvatarGroup;
+      group.setAttribute('max', '3');
+      group.setAttribute('size', 'sm');
+      // Pasamos personas al render; la propiedad JS se fija después del append
+      assigneesRow.appendChild(group);
       this._shadow.appendChild(assigneesRow);
+
+      // Fijar la propiedad tras insertar en el DOM para que el render funcione
+      group.persons = this._assignees.map(p => ({
+        id: p.id,
+        name: p.name,
+      }));
     }
 
     // ── Identificador de proyecto (US-26) ──────────────────────────────────
@@ -646,14 +604,6 @@ export class DojoTaskCard extends HTMLElement {
     }
   }
 
-  /**
-   * Detecta si un string contiene emojis.
-   * Regex simplificado que cubre la mayoría de emojis Unicode.
-   */
-  private _isEmoji(str: string): boolean {
-    const emojiRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u;
-    return emojiRegex.test(str);
-  }
 }
 
 customElements.define(DojoTaskCard.TAG, DojoTaskCard);

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -23,6 +23,7 @@ import '../dojo-list-view/dojo-list-view.js';
 import '../dojo-template-manager/dojo-template-manager.js';
 import '../../atoms/dojo-theme-toggle/dojo-theme-toggle.js';
 import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
+import '../../atoms/dojo-avatar-group/dojo-avatar-group.js';
 
 import type { Label } from '../../../types/models.js';
 import { getAllBoards } from '../../../db/board.repository.js';

--- a/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
+++ b/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
@@ -33,14 +33,6 @@ import { getAllPersons, createPerson, updatePerson, deletePerson } from '../../.
 import { getAllTasks } from '../../../db/task.repository.js';
 import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 
-// ── Emojis predeterminados para avatares ───────────────────────────────────
-const PRESET_AVATARS = [
-  '👤', '👨‍💻', '👩‍💻', '🧑‍💼', '👨‍🔬', '👩‍🔬', 
-  '🧑‍🎨', '👨‍🏫', '👩‍🏫', '🧑‍🔧', '👨‍⚕️', '👩‍⚕️',
-  '🧙‍♂️', '🧙‍♀️', '🥷', '🦸‍♂️', '🦸‍♀️', '🤖', 
-  '👽', '🐱', '🐶', '🦄', '🐧', '🦁',
-] as const;
-
 // ── Clase ──────────────────────────────────────────────────────────────────
 
 export class DojoPersonManager extends HTMLElement {
@@ -115,9 +107,10 @@ export class DojoPersonManager extends HTMLElement {
   }
 
   /** Maneja la creación de una nueva persona. */
-  private async _handleCreatePerson(name: string, avatar: string): Promise<void> {
+  private async _handleCreatePerson(name: string): Promise<void> {
     try {
-      const person = await createPerson({ name: name.trim(), avatar });
+      // El avatar se auto-genera desde el nombre en dojo-person-avatar (IMP-09)
+      const person = await createPerson({ name: name.trim(), avatar: '' });
 
       // Emitir evento de nivel aplicación
       this.dispatchEvent(new CustomEvent('dojo:person-created', {
@@ -133,9 +126,9 @@ export class DojoPersonManager extends HTMLElement {
   }
 
   /** Maneja la actualización de una persona existente. */
-  private async _handleUpdatePerson(id: string, name: string, avatar: string): Promise<void> {
+  private async _handleUpdatePerson(id: string, name: string): Promise<void> {
     try {
-      const person = await updatePerson(id, { name: name.trim(), avatar });
+      const person = await updatePerson(id, { name: name.trim(), avatar: '' });
 
       // Emitir evento de nivel aplicación
       this.dispatchEvent(new CustomEvent('dojo:person-updated', {
@@ -456,35 +449,7 @@ export class DojoPersonManager extends HTMLElement {
           gap: 4px;
         }
 
-        .action-btn {
-          padding: 4px 8px;
-          border: none;
-          border-radius: var(--dojo-radius-sm, 6px);
-          background: none;
-          color: var(--dojo-text-secondary, #6B7280);
-          cursor: pointer;
-          font-size: 12px;
-          transition: all 0.15s ease;
-        }
-
-        .action-btn:hover {
-          background: var(--dojo-bg, #F9FAFB);
-          color: var(--dojo-text-primary, #1F2937);
-        }
-
-        .confirm-delete {
-          background: #FEF2F2;
-          border: 1px solid #FCA5A5;
-          border-radius: var(--dojo-radius, 8px);
-          padding: 16px;
-          margin-bottom: 8px;
-        }
-
-        .confirm-delete p {
-          margin: 0 0 12px 0;
-          font-size: 14px;
-          color: #7F1D1D;
-        }
+        /* .avatar-grid eliminado en IMP-09 — avatar auto-generado del nombre */
 
         .confirm-delete-actions {
           display: flex;
@@ -509,9 +474,6 @@ export class DojoPersonManager extends HTMLElement {
             max-width: none;
           }
 
-          .avatar-grid {
-            grid-template-columns: repeat(4, 1fr);
-          }
         }
       </style>
 
@@ -533,13 +495,9 @@ export class DojoPersonManager extends HTMLElement {
               <label for="create-name">Nombre completo</label>
               <input type="text" id="create-name" class="form-input" 
                      placeholder="Ej. Ana García" maxlength="60">
-            </div>
-
-            <div class="form-group">
-              <label>Avatar</label>
-              <div class="avatar-grid" id="avatar-grid">
-                <!-- Avatares se generan dinámicamente -->
-              </div>
+              <p style="margin:6px 0 0;font-size:0.75rem;color:var(--dojo-text-secondary)">
+                El avatar se genera automáticamente a partir del nombre.
+              </p>
             </div>
 
             <button class="btn btn-primary" id="create-btn" disabled>
@@ -553,7 +511,6 @@ export class DojoPersonManager extends HTMLElement {
         </div>
       </div>
     `;
-    this._generateAvatarGrid();
     this._setupEventListeners();
   }
 
@@ -580,10 +537,8 @@ export class DojoPersonManager extends HTMLElement {
 
     const validateCreateForm = () => {
       const name = nameInput?.value.trim() || '';
-      const selectedAvatar = this._shadow.querySelector('.avatar-option.selected')?.textContent || '';
-      
       if (createBtn) {
-        createBtn.disabled = !name || !selectedAvatar;
+        createBtn.disabled = !name;
       }
     };
 
@@ -591,45 +546,11 @@ export class DojoPersonManager extends HTMLElement {
 
     createBtn?.addEventListener('click', async () => {
       const name = nameInput?.value.trim() || '';
-      const selectedAvatar = this._shadow.querySelector('.avatar-option.selected')?.textContent || '';
-      
-      if (name && selectedAvatar) {
-        await this._handleCreatePerson(name, selectedAvatar);
-        
-        // Limpiar form
+      if (name) {
+        await this._handleCreatePerson(name);
         if (nameInput) nameInput.value = '';
-        this._shadow.querySelectorAll('.avatar-option').forEach(el => el.classList.remove('selected'));
         validateCreateForm();
       }
-    });
-  }
-
-  /** Genera la grilla de avatares predeterminados. */
-  private _generateAvatarGrid(): void {
-    const grid = this._shadow.querySelector('#avatar-grid');
-    if (!grid) return;
-
-    grid.innerHTML = '';
-
-    PRESET_AVATARS.forEach(avatar => {
-      const option = document.createElement('div');
-      option.className = 'avatar-option';
-      option.textContent = avatar;
-      option.addEventListener('click', () => {
-        // Deseleccionar otros
-        grid.querySelectorAll('.avatar-option').forEach(el => el.classList.remove('selected'));
-        // Seleccionar este
-        option.classList.add('selected');
-        
-        // Validar form
-        const createBtn = this._shadow.querySelector<HTMLButtonElement>('#create-btn');
-        const nameInput = this._shadow.querySelector<HTMLInputElement>('#create-name');
-        if (createBtn && nameInput) {
-          createBtn.disabled = !nameInput.value.trim();
-        }
-      });
-      
-      grid.appendChild(option);
     });
   }
 
@@ -667,8 +588,6 @@ export class DojoPersonManager extends HTMLElement {
 
       if (isEditing) {
         // ── Formulario de edición inline ────────────────────────────────
-        const isPersonEmoji = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(person.avatar);
-
         const editForm = document.createElement('div');
         editForm.className = 'create-form';
         editForm.style.marginBottom = '8px';
@@ -691,28 +610,6 @@ export class DojoPersonManager extends HTMLElement {
         nameGroup.appendChild(nameInput);
         editForm.appendChild(nameGroup);
 
-        // Avatar grid
-        const avatarGroup = document.createElement('div');
-        avatarGroup.className = 'form-group';
-        const avatarLabel = document.createElement('label');
-        avatarLabel.textContent = 'Avatar';
-        avatarGroup.appendChild(avatarLabel);
-
-        const editAvatarGrid = document.createElement('div');
-        editAvatarGrid.className = 'avatar-grid';
-        PRESET_AVATARS.forEach(av => {
-          const opt = document.createElement('div');
-          opt.className = 'avatar-option' + (av === person.avatar ? ' selected' : '');
-          opt.textContent = av;
-          opt.addEventListener('click', () => {
-            editAvatarGrid.querySelectorAll('.avatar-option').forEach(el => el.classList.remove('selected'));
-            opt.classList.add('selected');
-          });
-          editAvatarGrid.appendChild(opt);
-        });
-        avatarGroup.appendChild(editAvatarGrid);
-        editForm.appendChild(avatarGroup);
-
         // Acciones
         const actions = document.createElement('div');
         actions.style.display = 'flex';
@@ -724,8 +621,7 @@ export class DojoPersonManager extends HTMLElement {
         saveBtn.addEventListener('click', async () => {
           const newName = nameInput.value.trim();
           if (!newName) { nameInput.focus(); return; }
-          const selectedAvatar = editAvatarGrid.querySelector<HTMLElement>('.avatar-option.selected')?.textContent || person.avatar;
-          await this._handleUpdatePerson(person.id, newName, selectedAvatar);
+          await this._handleUpdatePerson(person.id, newName);
         });
 
         const cancelEditBtn = document.createElement('button');

--- a/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
+++ b/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
@@ -452,6 +452,37 @@ export class DojoPersonManager extends HTMLElement {
         /* .avatar-grid eliminado en IMP-09 — avatar auto-generado del nombre */
 
         .confirm-delete-actions {
+        .action-btn {
+          padding: 4px 8px;
+          border: none;
+          border-radius: var(--dojo-radius-sm, 6px);
+          background: none;
+          color: var(--dojo-text-secondary, #6B7280);
+          cursor: pointer;
+          font-size: 12px;
+          transition: all 0.15s ease;
+        }
+
+        .action-btn:hover {
+          background: var(--dojo-bg, #F9FAFB);
+          color: var(--dojo-text-primary, #1F2937);
+        }
+
+        .confirm-delete {
+          background: #FEF2F2;
+          border: 1px solid #FCA5A5;
+          border-radius: var(--dojo-radius, 8px);
+          padding: 16px;
+          margin-bottom: 8px;
+        }
+
+        .confirm-delete p {
+          margin: 0 0 12px 0;
+          font-size: 14px;
+          color: #7F1D1D;
+        }
+
+        .confirm-delete-actions {
           display: flex;
           gap: 8px;
         }

--- a/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
+++ b/src/components/organisms/dojo-person-manager/dojo-person-manager.ts
@@ -31,6 +31,7 @@
 import type { Person } from '../../../types/models.js';
 import { getAllPersons, createPerson, updatePerson, deletePerson } from '../../../db/person.repository.js';
 import { getAllTasks } from '../../../db/task.repository.js';
+import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 
 // ── Emojis predeterminados para avatares ───────────────────────────────────
 const PRESET_AVATARS = [
@@ -429,16 +430,6 @@ export class DojoPersonManager extends HTMLElement {
         }
 
         .person-avatar {
-          width: 32px;
-          height: 32px;
-          border-radius: var(--dojo-radius-sm, 6px);
-          background: var(--dojo-primary, #3B82F6);
-          color: #FFFFFF;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-weight: 600;
-          font-size: 14px;
           flex-shrink: 0;
         }
 
@@ -789,15 +780,13 @@ export class DojoPersonManager extends HTMLElement {
 
       } else {
         // Mostrar persona normal — construido con createElement (OWASP A3)
-        const isEmoji = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(person.avatar);
-
         const personItem = document.createElement('div');
         personItem.className = 'person-item';
 
-        const avatarEl = document.createElement('div');
+        const avatarEl = document.createElement('dojo-person-avatar');
         avatarEl.className = 'person-avatar';
-        if (isEmoji) avatarEl.style.cssText = 'background: transparent; color: inherit; border: 1px solid var(--dojo-border, #E5E7EB);';
-        avatarEl.textContent = person.avatar;
+        avatarEl.setAttribute('name', person.name);
+        avatarEl.setAttribute('size', 'md');
 
         const infoEl = document.createElement('div');
         infoEl.className = 'person-info';

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -32,6 +32,7 @@ import { getAllPersons } from '../../../db/person.repository.js';
 import { getAllTemplates } from '../../../db/template.repository.js';
 import { generateUUID } from '../../../utils/uuid.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
+import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 
 const PRIORITIES: { value: Priority; label: string }[] = [
   { value: 'low',    label: '⬇️ Baja'    },
@@ -1454,8 +1455,16 @@ export class DojoTaskDialog extends HTMLElement {
         if (!person) continue;
         const chip = document.createElement('span');
         chip.className = 'label-chip';
-        chip.style.cssText = 'background: var(--dojo-bg); border: 1px solid var(--dojo-border); color: var(--dojo-text-primary); gap: 0.25rem;';
-        chip.textContent = `${person.avatar} ${person.name}`;
+        chip.style.cssText = 'background: var(--dojo-bg); border: 1px solid var(--dojo-border); color: var(--dojo-text-primary); gap: 0.25rem; display: inline-flex; align-items: center;';
+
+        const chipAvatar = document.createElement('dojo-person-avatar');
+        chipAvatar.setAttribute('name', person.name);
+        chipAvatar.setAttribute('size', 'sm');
+        chip.appendChild(chipAvatar);
+
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = person.name;
+        chip.appendChild(nameSpan);
 
         const removeBtn = document.createElement('button');
         removeBtn.className = 'label-chip-remove';
@@ -1504,12 +1513,13 @@ export class DojoTaskDialog extends HTMLElement {
           else this._selectedAssigneeIds.delete(person.id);
           renderAssigneeChips();
         });
-        const avatarSpan = document.createElement('span');
-        avatarSpan.textContent = person.avatar;
+        const avatarEl = document.createElement('dojo-person-avatar');
+        avatarEl.setAttribute('name', person.name);
+        avatarEl.setAttribute('size', 'sm');
         const nameSp = document.createElement('span');
         nameSp.textContent = person.name;
         opt.appendChild(cb);
-        opt.appendChild(avatarSpan);
+        opt.appendChild(avatarEl);
         opt.appendChild(nameSp);
         assigneePicker.appendChild(opt);
       }


### PR DESCRIPTION
This pull request implements a new, modern avatar system for representing people in the UI, replacing the old emoji-based approach with deterministic, color-coded circular avatars that support initials and optional profile images. The main changes introduce a reusable `dojo-avatar-group` component for stacked avatar displays, refactor the `dojo-person-avatar` to generate avatars from names, and update all usages throughout the app to use the new system.

**Key changes:**

### New avatar components

- Introduced `dojo-avatar-group`, a Web Component for displaying a row of stacked, circular avatars with a "+N" badge when exceeding a configurable maximum. It accepts an array of persons and supports size and max attributes.
- Refactored `dojo-person-avatar` to:
  - Generate deterministic background colors and initials from the person's name.
  - Optionally display a profile image via a `src` attribute, falling back to initials if the image fails to load.
  - Export static utilities for color and initials generation.
  - Remove all emoji-specific logic and attributes. [[1]](diffhunk://#diff-151a5c0fd47c127b786fbf942e6c23e6931dee5935e6b0c8e573e0a45afd4374L2-R19) [[2]](diffhunk://#diff-151a5c0fd47c127b786fbf942e6c23e6931dee5935e6b0c8e573e0a45afd4374L28-L184)

### Integration into task cards and person manager

- Updated `dojo-task-card` to use `dojo-avatar-group` for displaying assignees, replacing the previous inline emoji avatar logic and styles. [[1]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afR33) [[2]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL416-L450) [[3]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL536-R522) [[4]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL649-L656)
- Updated `dojo-person-manager` to use the new avatar system, removing all preset emoji logic and ensuring that avatars are generated from names only. [[1]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L34-R34) [[2]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L117-R113) [[3]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L135-R131) [[4]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L432-L441)

### App-wide registration

- Registered the new `dojo-avatar-group` component in the main app entry point to ensure it's available throughout the application.

---

**Most important changes:**

#### Avatar system overhaul

* Added `dojo-avatar-group` component for stacked, circular avatar displays with "+N" overflow badge.
* Refactored `dojo-person-avatar` to generate avatars from names (deterministic color and initials), support optional profile images, and export static utilities; removed emoji logic. [[1]](diffhunk://#diff-151a5c0fd47c127b786fbf942e6c23e6931dee5935e6b0c8e573e0a45afd4374L2-R19) [[2]](diffhunk://#diff-151a5c0fd47c127b786fbf942e6c23e6931dee5935e6b0c8e573e0a45afd4374L28-L184)

#### UI integration

* Replaced previous assignee avatar logic in `dojo-task-card` with the new `dojo-avatar-group` component and removed all related emoji/avatar code and styles. [[1]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afR33) [[2]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL416-L450) [[3]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL536-R522) [[4]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL649-L656)
* Updated `dojo-person-manager` to remove preset emoji logic, use the new avatar system, and ensure avatars are generated solely from names. [[1]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L34-R34) [[2]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L117-R113) [[3]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L135-R131) [[4]](diffhunk://#diff-a56f3e3fdbd63834a4a55c4b0274e7c3d96062c9cd6cc89a912e2beafe1b5893L432-L441)

#### Component registration

* Registered `dojo-avatar-group` globally in the main app entry point for consistent availability.