### PR TITLE
Feat/86 svg icon system

### DIFF
--- a/public/icons/sprite.svg
+++ b/public/icons/sprite.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <!-- Prioridad -->
+  <symbol id="icon-priority-low" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 5v14M5 12h14"/>
+  </symbol>
+
+  <symbol id="icon-priority-medium" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="12" cy="12" r="10"/>
+  </symbol>
+
+  <symbol id="icon-priority-high" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 2L20 20H4Z"/>
+  </symbol>
+
+  <symbol id="icon-priority-urgent" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+  </symbol>
+
+  <!-- Acciones -->
+  <symbol id="icon-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L21 6z"/>
+  </symbol>
+
+  <symbol id="icon-delete" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="3 6 5 6 21 6"/>
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+    <line x1="10" y1="11" x2="10" y2="17"/>
+    <line x1="14" y1="11" x2="14" y2="17"/>
+  </symbol>
+
+  <symbol id="icon-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <line x1="18" y1="6" x2="6" y2="18"/>
+    <line x1="6" y1="6" x2="18" y2="18"/>
+  </symbol>
+
+  <symbol id="icon-add" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <line x1="12" y1="5" x2="12" y2="19"/>
+    <line x1="5" y1="12" x2="19" y2="12"/>
+  </symbol>
+
+  <symbol id="icon-drag-handle" viewBox="0 0 24 24" fill="currentColor">
+    <circle cx="9" cy="5" r="1.5"/>
+    <circle cx="9" cy="12" r="1.5"/>
+    <circle cx="9" cy="19" r="1.5"/>
+    <circle cx="15" cy="5" r="1.5"/>
+    <circle cx="15" cy="12" r="1.5"/>
+    <circle cx="15" cy="19" r="1.5"/>
+  </symbol>
+
+  <!-- Estado -->
+  <symbol id="icon-calendar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+    <line x1="16" y1="2" x2="16" y2="6"/>
+    <line x1="8" y1="2" x2="8" y2="6"/>
+    <line x1="3" y1="10" x2="21" y2="10"/>
+  </symbol>
+
+  <symbol id="icon-label" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 2H2v10c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
+    <circle cx="18" cy="8" r="1" fill="currentColor"/>
+  </symbol>
+
+  <symbol id="icon-assignee" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+    <circle cx="12" cy="7" r="4"/>
+  </symbol>
+
+  <symbol id="icon-subtask" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="9 11 12 14 22 4"/>
+    <path d="M21 12a9 9 0 1 1-9-9m0 0a8.999 8.999 0 0 0-8 4"/>
+  </symbol>
+
+  <!-- Navegación -->
+  <symbol id="icon-chevron-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="6 9 12 15 18 9"/>
+  </symbol>
+
+  <symbol id="icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="11" cy="11" r="8"/>
+    <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+  </symbol>
+
+  <symbol id="icon-filter" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/>
+  </symbol>
+
+  <symbol id="icon-board-view" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <rect x="3" y="3" width="7" height="7"/>
+    <rect x="14" y="3" width="7" height="7"/>
+    <rect x="14" y="14" width="7" height="7"/>
+    <rect x="3" y="14" width="7" height="7"/>
+  </symbol>
+
+  <symbol id="icon-list-view" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <line x1="8" y1="6" x2="21" y2="6"/>
+    <line x1="8" y1="12" x2="21" y2="12"/>
+    <line x1="8" y1="18" x2="21" y2="18"/>
+    <line x1="3" y1="6" x2="3.01" y2="6"/>
+    <line x1="3" y1="12" x2="3.01" y2="12"/>
+    <line x1="3" y1="18" x2="3.01" y2="18"/>
+  </symbol>
+
+  <!-- Sistema -->
+  <symbol id="icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="20 6 9 17 4 12"/>
+  </symbol>
+
+  <symbol id="icon-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3.05h16.94a2 2 0 0 0 1.71-3.05l-8.47-14.14a2 2 0 0 0-3.42 0z"/>
+    <line x1="12" y1="9" x2="12" y2="13"/>
+    <line x1="12" y1="17" x2="12.01" y2="17"/>
+  </symbol>
+
+  <symbol id="icon-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="12" cy="12" r="10"/>
+    <line x1="12" y1="16" x2="12" y2="12"/>
+    <line x1="12" y1="8" x2="12.01" y2="8"/>
+  </symbol>
+</svg>

--- a/src/components/atoms/dojo-icon/dojo-icon.ts
+++ b/src/components/atoms/dojo-icon/dojo-icon.ts
@@ -1,0 +1,143 @@
+/**
+ * dojo-icon — Átomo de Iconografía SVG
+ * 
+ * Componente para renderizar iconos SVG desde un sprite centralizado.
+ * Soporta personalización de tamaño y color mediante atributos.
+ * 
+ * @example
+ * <dojo-icon name="edit" size="lg" color="var(--dojo-primary)"></dojo-icon>
+ */
+
+export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type IconName = 
+  // Prioridad
+  | 'priority-low' | 'priority-medium' | 'priority-high' | 'priority-urgent'
+  // Acciones
+  | 'edit' | 'delete' | 'close' | 'add' | 'drag-handle'
+  // Estado
+  | 'calendar' | 'label' | 'assignee' | 'subtask'
+  // Navegación
+  | 'chevron-down' | 'search' | 'filter' | 'board-view' | 'list-view'
+  // Sistema
+  | 'check' | 'warning' | 'info';
+
+export class DojoIcon extends HTMLElement {
+  static readonly TAG = 'dojo-icon';
+
+  static get observedAttributes(): string[] {
+    return ['name', 'size', 'color'];
+  }
+
+  private _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback(): void {
+    if (this._shadow.childElementCount === 0) {
+      this._render();
+    }
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._render();
+  }
+
+  // ── Getters ────────────────────────────────────────────────────────────
+
+  get name(): IconName {
+    const n = this.getAttribute('name');
+    return this._isValidIconName(n) ? (n as IconName) : 'info';
+  }
+
+  get size(): IconSize {
+    const s = this.getAttribute('size');
+    return (s === 'xs' || s === 'sm' || s === 'md' || s === 'lg' || s === 'xl' || s === '2xl')
+      ? s
+      : 'md';
+  }
+
+  get color(): string {
+    return this.getAttribute('color') ?? 'currentColor';
+  }
+
+  // ── Validación ──────────────────────────────────────────────────────────
+
+  private _isValidIconName(name: string | null): boolean {
+    const validNames: IconName[] = [
+      'priority-low', 'priority-medium', 'priority-high', 'priority-urgent',
+      'edit', 'delete', 'close', 'add', 'drag-handle',
+      'calendar', 'label', 'assignee', 'subtask',
+      'chevron-down', 'search', 'filter', 'board-view', 'list-view',
+      'check', 'warning', 'info'
+    ];
+    return validNames.includes(name as IconName);
+  }
+
+  private _getSizeClasses(): Record<IconSize, { width: string; height: string }> {
+    return {
+      xs: { width: '12px', height: '12px' },
+      sm: { width: '16px', height: '16px' },
+      md: { width: '20px', height: '20px' },
+      lg: { width: '24px', height: '24px' },
+      xl: { width: '32px', height: '32px' },
+      '2xl': { width: '40px', height: '40px' }
+    };
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  private _render(): void {
+    this._shadow.innerHTML = '';
+
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+        color: ${this.color};
+        stroke: ${this.color};
+        fill: ${this.color};
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        svg {
+          animation: none !important;
+        }
+      }
+    `;
+    this._shadow.appendChild(style);
+
+    // Obtener dimensiones según tamaño
+    const sizeConfig = this._getSizeClasses()[this.size];
+
+    // Crear SVG que referencia el sprite
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('width', sizeConfig.width);
+    svg.setAttribute('height', sizeConfig.height);
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.style.color = this.color;
+    svg.style.stroke = this.color;
+    svg.style.fill = this.color;
+
+    // Crear elemento use que referencia el símbolo del sprite
+    const use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+    use.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', `/icons/sprite.svg#icon-${this.name}`);
+    
+    svg.appendChild(use);
+    this._shadow.appendChild(svg);
+  }
+}
+
+customElements.define(DojoIcon.TAG, DojoIcon);

--- a/src/components/atoms/dojo-task-card/dojo-task-card.ts
+++ b/src/components/atoms/dojo-task-card/dojo-task-card.ts
@@ -146,10 +146,10 @@ export class DojoTaskCard extends HTMLElement {
   // ── Prioridades ───────────────────────────────────────────────────────────
 
   private static readonly PRIORITY_CONFIG = {
-    low:    { icon: '⬇️', label: 'Baja',    color: 'var(--dojo-priority-low,    #3B82F6)' },
-    medium: { icon: '➡️', label: 'Media',   color: 'var(--dojo-priority-medium, #F59E0B)' },
-    high:   { icon: '⬆️', label: 'Alta',    color: 'var(--dojo-priority-high,   #F97316)' },
-    urgent: { icon: '🔥', label: 'Urgente', color: 'var(--dojo-priority-urgent, #EF4444)' },
+    low:    { iconName: 'priority-low',    label: 'Baja',    color: 'var(--dojo-priority-low,    #3B82F6)' },
+    medium: { iconName: 'priority-medium', label: 'Media',   color: 'var(--dojo-priority-medium, #F59E0B)' },
+    high:   { iconName: 'priority-high',   label: 'Alta',    color: 'var(--dojo-priority-high,   #F97316)' },
+    urgent: { iconName: 'priority-urgent', label: 'Urgente', color: 'var(--dojo-priority-urgent, #EF4444)' },
   } as const;
 
   /** Colores dinámicos para barra de progreso de subtareas.
@@ -646,10 +646,12 @@ export class DojoTaskCard extends HTMLElement {
     const footerPriority = document.createElement('div');
     footerPriority.className = 'footer-priority';
 
-    const iconEl = document.createElement('span');
+    // Usar dojo-icon en lugar de emoji (IMP-07)
+    const iconEl = document.createElement('dojo-icon');
+    (iconEl as any).setAttribute('name', pConfig.iconName);
+    (iconEl as any).setAttribute('size', 'sm');
+    (iconEl as any).setAttribute('color', pConfig.color);
     iconEl.className = 'priority-icon';
-    iconEl.setAttribute('aria-hidden', 'true');
-    iconEl.textContent = pConfig.icon;
 
     const label = document.createElement('span');
     label.className = 'priority-label';
@@ -681,7 +683,17 @@ export class DojoTaskCard extends HTMLElement {
         ? `Venció ${dueRelative}`
         : `Vence ${dueRelative}`;
       dueEl.setAttribute('aria-label', ariaLabel);
-      dueEl.textContent = `📅 ${dueRelative}`;
+      
+      // Usar dojo-icon en lugar de emoji (IMP-07)
+      const iconEl = document.createElement('dojo-icon');
+      (iconEl as any).setAttribute('name', 'calendar');
+      (iconEl as any).setAttribute('size', 'xs');
+      dueEl.appendChild(iconEl);
+      
+      const textNode = document.createElement('span');
+      textNode.textContent = dueRelative;
+      dueEl.appendChild(textNode);
+      
       footer.appendChild(dueEl);
     }
 

--- a/src/components/organisms/dojo-app/dojo-app.ts
+++ b/src/components/organisms/dojo-app/dojo-app.ts
@@ -24,6 +24,8 @@ import '../dojo-template-manager/dojo-template-manager.js';
 import '../../atoms/dojo-theme-toggle/dojo-theme-toggle.js';
 import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 import '../../atoms/dojo-avatar-group/dojo-avatar-group.js';
+import '../../atoms/dojo-icon/dojo-icon.js';
+import '../../atoms/dojo-toast/dojo-toast.js';
 
 import type { Label } from '../../../types/models.js';
 import { getAllBoards } from '../../../db/board.repository.js';

--- a/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
+++ b/src/components/organisms/dojo-task-detail/dojo-task-detail.ts
@@ -35,11 +35,12 @@ import { generateUUID } from '../../../utils/uuid.js';
 
 // ── Constantes ─────────────────────────────────────────────────────────────
 
-const PRIORITIES: { value: Priority; label: string; icon: string }[] = [
-  { value: 'low',    label: 'Baja',    icon: '⬇️' },
-  { value: 'medium', label: 'Media',   icon: '➡️' },
-  { value: 'high',   label: 'Alta',    icon: '⬆️' },
-  { value: 'urgent', label: 'Urgente', icon: '🔥' },
+// Prioridades con nombres de iconos SVG en lugar de emojis (IMP-07)
+const PRIORITIES: { value: Priority; label: string; iconName: string }[] = [
+  { value: 'low',    label: 'Baja',    iconName: 'priority-low' },
+  { value: 'medium', label: 'Media',   iconName: 'priority-medium' },
+  { value: 'high',   label: 'Alta',    iconName: 'priority-high' },
+  { value: 'urgent', label: 'Urgente', iconName: 'priority-urgent' },
 ];
 
 /** Instancia cacheada de Intl.RelativeTimeFormat para fechas de actividad (US-20). */
@@ -1098,10 +1099,10 @@ export class DojoTaskDetail extends HTMLElement {
     priSelect.id        = 'detail-priority';
     priSelect.className = 'field-select';
     priSelect.setAttribute('aria-label', 'Prioridad de la tarea');
-    PRIORITIES.forEach(({ value, label, icon }) => {
+    PRIORITIES.forEach(({ value, label }) => {
       const opt = document.createElement('option');
       opt.value       = value;
-      opt.textContent = `${icon} ${label}`;
+      opt.textContent = label;  // Sin iconos en select nativo para mejor accesibilidad
       if (value === task.priority) opt.selected = true;
       priSelect.appendChild(opt);
     });

--- a/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
+++ b/src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts
@@ -34,11 +34,12 @@ import { generateUUID } from '../../../utils/uuid.js';
 import { pickTextColor, meetsWcagAA, suggestAccessibleColor } from '../../../utils/contrast.js';
 import '../../atoms/dojo-person-avatar/dojo-person-avatar.js';
 
+// Prioridades sin emojis para mejor compatibilidad en select nativo (IMP-07)
 const PRIORITIES: { value: Priority; label: string }[] = [
-  { value: 'low',    label: '⬇️ Baja'    },
-  { value: 'medium', label: '➡️ Media'   },
-  { value: 'high',   label: '⬆️ Alta'    },
-  { value: 'urgent', label: '🔥 Urgente' },
+  { value: 'low',    label: 'Baja'    },
+  { value: 'medium', label: 'Media'   },
+  { value: 'high',   label: 'Alta'    },
+  { value: 'urgent', label: 'Urgente' },
 ];
 
 export class DojoTaskDialog extends HTMLElement {


### PR DESCRIPTION
This pull request introduces a new reusable SVG icon component (`dojo-icon`) and refactors the UI to use consistent SVG icons instead of emojis for task priorities and dates. It also improves accessibility by removing emojis from native select options. The most important changes are grouped below:

**New SVG Icon System:**

* Added the `dojo-icon` web component in `dojo-icon.ts`, which renders SVG icons from a central sprite and supports customizable size and color via attributes. (`src/components/atoms/dojo-icon/dojo-icon.ts`)
* Registered the new `dojo-icon` component in the main app and other relevant modules. (`src/components/organisms/dojo-app/dojo-app.ts`)

**Refactor: Replace Emojis with SVG Icons:**

* Updated `DojoTaskCard` to use `dojo-icon` for rendering priority and due date icons instead of emojis, and changed the priority config to use `iconName` instead of emoji characters. (`src/components/atoms/dojo-task-card/dojo-task-card.ts`) [[1]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL149-R152) [[2]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL649-L652) [[3]](diffhunk://#diff-ee7b7eb1da73a9fcd823732ce17f6132629d6aa92a020cc3493f502f519de2afL684-R696)
* Changed the priorities definition in `DojoTaskDetail` to use SVG icon names, and updated the select dropdown to display only the label (no icons) for better accessibility. (`src/components/organisms/dojo-task-detail/dojo-task-detail.ts`) [[1]](diffhunk://#diff-59bb3ec1b3326afff3cb5584a5f143a9ab451052ea07c454446f630d2e7b5773L38-R43) [[2]](diffhunk://#diff-59bb3ec1b3326afff3cb5584a5f143a9ab451052ea07c454446f630d2e7b5773L1101-R1105)
* Modified the priorities in `DojoTaskDialog` to remove emojis from the select options, improving compatibility and accessibility. (`src/components/organisms/dojo-task-dialog/dojo-task-dialog.ts`)